### PR TITLE
feat: expand analytics dashboard with interactive insights

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -64,6 +64,23 @@
     .timeline-bar .bar-label { font-weight: 500; }
     .timeline-bar .bar-progress { opacity: 0.7; }
     .analytics-cat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+    .analytics-filter-card{margin-top:12px;padding:16px;border-radius:16px;border:1px solid var(--line);background:var(--card);box-shadow:0 1px 2px rgba(15,23,42,0.08)}
+    .analytics-filter-grid{margin-top:12px;display:grid;gap:8px;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));max-height:260px;overflow-y:auto;padding-right:4px}
+    .analytics-filter-grid label{display:flex;align-items:center;gap:8px;padding:6px 10px;border:1px solid var(--line);border-radius:10px;background:#fff;font-size:13px;cursor:pointer;transition:all .2s ease}
+    .analytics-filter-grid label.active{border-color:var(--blue);background:#eff6ff}
+    .analytics-filter-grid label span{flex:1;display:flex;align-items:center;gap:6px}
+    .analytics-filter-grid input{width:auto}
+    .analytics-filter-actions{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+    .analytics-filter-actions .btn{padding:6px 10px;font-size:13px}
+    .analytics-summary{font-size:12px;color:var(--muted);margin-top:4px}
+    .table-sortable th{cursor:pointer;position:relative;white-space:nowrap}
+    .table-sortable th .sort-indicator{font-size:10px;margin-left:4px}
+    .delta-up{color:var(--green);font-weight:600}
+    .delta-down{color:var(--red);font-weight:600}
+    .delta-neutral{color:var(--muted);font-weight:500}
+    .chart-box.tall{height:320px}
+    .chart-box.wide{height:280px}
+    .insight-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;border:1px solid var(--line);font-size:12px;background:#f8fafc;margin-right:6px;margin-top:4px}
   </style>
 </head>
 <body>
@@ -440,57 +457,119 @@
     <section id="tab-analytics" class="card" style="margin-top:12px;display:none">
       <div class="row">
         <h3 class="title">Centrum Analityczne</h3>
-        <div class="row" style="gap:8px">
-           <label for="analytics-period" class="tiny">Okres:</label>
-           <select id="analytics-period" style="width:auto">
-              <option value="1" selected>Bieżący miesiąc</option>
-              <option value="3">Ostatnie 3 miesiące</option>
-              <option value="6">Ostatnie 6 miesięcy</option>
-              <option value="12">Ostatnie 12 miesięcy</option>
-              <option value="all">Wszystkie dane</option>
-           </select>
+        <div class="row" style="gap:8px;align-items:center">
+          <label for="analytics-period" class="tiny">Okres:</label>
+          <select id="analytics-period" style="width:auto">
+            <option value="1" selected>Bieżący miesiąc</option>
+            <option value="3">Ostatnie 3 miesiące</option>
+            <option value="6">Ostatnie 6 miesięcy</option>
+            <option value="12">Ostatnie 12 miesięcy</option>
+            <option value="all">Wszystkie dane</option>
+          </select>
         </div>
       </div>
-      
+
+      <div class="analytics-filter-card">
+        <div class="row" style="align-items:flex-start;gap:12px">
+          <div style="flex:1">
+            <div class="title" style="margin:0;font-size:18px">Filtry kategorii</div>
+            <div id="analytics-filter-summary" class="analytics-summary">Zaznacz kategorie, aby analizować je w szczegółach.</div>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:6px;align-items:flex-end">
+            <input id="analytics-category-search" placeholder="Szukaj kategorii" style="min-width:220px" />
+            <div class="analytics-filter-actions">
+              <button class="btn soft" id="analytics-select-all">Wszystkie</button>
+              <button class="btn soft" id="analytics-select-none">Wyczyść</button>
+              <button class="btn soft" id="analytics-select-expense">Tylko wydatki</button>
+              <button class="btn soft" id="analytics-select-savings">Tylko oszczędności</button>
+              <button class="btn soft" id="analytics-select-top5">Top 5 wg sumy</button>
+            </div>
+          </div>
+        </div>
+        <div id="analytics-category-filter-list" class="analytics-filter-grid"></div>
+      </div>
+
       <div id="analytics-kpis" class="grid g-4" style="margin-top:12px"></div>
 
       <div class="grid g-2" style="margin-top:12px">
         <div class="card">
           <div class="title">Przychody vs Wydatki</div>
+          <div class="hint">Porównanie całkowitych wpływów, wydatków oraz wydatków z wybranych kategorii.</div>
           <div class="chart-box"><canvas id="analytics-income-expense-chart"></canvas></div>
         </div>
         <div class="card">
-          <div class="title">Struktura Wydatków (bez stałych)</div>
+          <div class="title">Struktura wybranych kategorii</div>
+          <div class="hint">Wizualizacja udziałów kategorii w sumie wydatków objętych filtrem.</div>
           <div class="chart-box"><canvas id="analytics-category-chart"></canvas></div>
         </div>
       </div>
-      
+
+      <div class="grid g-2" style="margin-top:12px">
+        <div class="card">
+          <div class="title">Aktywność miesięczna (wybrane kategorie)</div>
+          <div class="hint">Sprawdź, czy zmiany wynikają z większej liczby transakcji czy z wyższych kwot.</div>
+          <div class="chart-box"><canvas id="analytics-monthly-activity-chart"></canvas></div>
+        </div>
+        <div class="card">
+          <div class="title">Średnia i mediana transakcji</div>
+          <div class="hint">Porównanie trendu średniej i mediany dla wybranych kategorii.</div>
+          <div class="chart-box"><canvas id="analytics-avg-trend-chart"></canvas></div>
+        </div>
+      </div>
+
       <div class="card" style="margin-top:12px">
-        <h4 class="title">Trendy w Kategoriach</h4>
-        <p class="tiny">Zobacz, jak zmieniały się Twoje wydatki w poszczególnych kategoriach na przestrzeni wybranego okresu.</p>
+        <div class="title">Top kategorie — suma, częstotliwość i średnia</div>
+        <div class="hint">Łatwo ocenisz, które kategorie rosną przez większą liczbę transakcji, a które przez wyższe rachunki.</div>
+        <div class="chart-box tall"><canvas id="analytics-category-leader-chart"></canvas></div>
+      </div>
+
+      <div class="card" style="margin-top:12px">
+        <div class="title">Trendy najważniejszych kategorii</div>
+        <div class="hint">Miesięczne wydatki w kluczowych kategoriach objętych filtrem.</div>
+        <div class="chart-box tall"><canvas id="analytics-category-trend-chart"></canvas></div>
+      </div>
+
+      <div class="card" style="margin-top:12px">
+        <h4 class="title">Macierz kategorii × miesiąc</h4>
+        <p class="tiny">W każdej komórce znajdziesz sumę, liczbę transakcji oraz średnią wartość. Kolor wskazuje odchylenie od średniej dla danej kategorii.</p>
         <div style="overflow-x:auto;">
           <table id="analytics-category-trends"></table>
         </div>
       </div>
 
+      <div class="card" style="margin-top:12px">
+        <div class="row" style="align-items:flex-end">
+          <h4 class="title">Ranking kategorii (wybrane)</h4>
+          <span class="tiny muted">Kliknij nagłówek, aby sortować po dowolnym KPI.</span>
+        </div>
+        <div style="overflow-x:auto;">
+          <table id="analytics-category-summary" class="table-sortable"></table>
+        </div>
+      </div>
+
+      <div class="card" style="margin-top:12px">
+        <h4 class="title">Zmiany miesiąc do miesiąca</h4>
+        <p class="tiny">Analiza czy wzrost wynika z liczby transakcji czy z ich wartości.</p>
+        <div style="overflow-x:auto;">
+          <table id="analytics-category-momentum" class="table-sortable"></table>
+        </div>
+      </div>
+
+      <div class="card" style="margin-top:12px">
+        <h4 class="title">Przegląd miesięczny (wybrane kategorie)</h4>
+        <div style="overflow-x:auto;">
+          <table id="analytics-monthly-breakdown"></table>
+        </div>
+      </div>
+
       <div class="card" style="margin-top:12px; position: relative;">
         <div class="row">
-         <h4 class="title">Największe Pojedyncze Wydatki</h4>
-         <div id="analytics-cat-filter-container" style="position: relative;">
-           <button class="btn ghost" id="analytics-cat-filter-btn">Wszystkie kategorie</button>
-            <div id="analytics-cat-filter-dropdown" style="display:none; position: absolute; right:0; top: 100%; background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 12px; z-index: 20; box-shadow: 0 4px 6px rgba(0,0,0,.1); min-width: 500px;">
-             <div id="analytics-cat-filter-options" class="analytics-cat-grid" style="max-height: 250px; overflow-y: auto;"></div>
-             <div class="row" style="margin-top: 8px; border-top: 1px solid var(--line); padding-top: 8px;">
-               <button class="btn soft" id="analytics-cat-filter-all">Wszystkie</button>
-               <button class="btn soft" id="analytics-cat-filter-none">Żadne</button>
-               <button class="btn soft" id="analytics-cat-filter-invert">Odwróć</button>
-             </div>
-           </div>
-         </div>
-       </div>
-       <p class="tiny">Twoje 10 największych transakcji w wybranym okresie. To dobre miejsce do szukania oszczędności.</p>
-       <table id="analytics-top-transactions"></table>
-     </div>
+          <h4 class="title">Największe Pojedyncze Wydatki</h4>
+          <span class="tiny muted">Lista respektuje aktualne filtry kategorii.</span>
+        </div>
+        <p class="tiny">Twoje 10 największych transakcji w wybranym okresie. To dobre miejsce do szukania oszczędności.</p>
+        <table id="analytics-top-transactions"></table>
+      </div>
     </section>
   </div>
 
@@ -1754,6 +1833,89 @@
   }
 
   // --- Analytics Helpers ---
+  const ANALYTICS_STATE_KEY='lifeos_budget_filters_v1';
+  let analyticsUiState = loadAnalyticsUiState();
+  const analyticsCharts={};
+  const ANALYTICS_COLORS=['#0ea5e9','#ef4444','#16a34a','#f97316','#8b5cf6','#14b8a6','#facc15','#6366f1','#0f172a'];
+
+  function loadAnalyticsUiState(){
+    try{
+      const raw=localStorage.getItem(ANALYTICS_STATE_KEY);
+      if(!raw) return {selectedCategoryIds:[],sortField:'total',sortDir:'desc',searchTerm:''};
+      const parsed=JSON.parse(raw);
+      return {
+        selectedCategoryIds:Array.isArray(parsed?.selectedCategoryIds)?parsed.selectedCategoryIds:[],
+        sortField:typeof parsed?.sortField==='string'?parsed.sortField:'total',
+        sortDir:parsed?.sortDir==='asc'?'asc':'desc',
+        searchTerm:typeof parsed?.searchTerm==='string'?parsed.searchTerm:''
+      };
+    }catch(err){
+      console.warn('Nie można odczytać ustawień analityki',err);
+      return {selectedCategoryIds:[],sortField:'total',sortDir:'desc',searchTerm:''};
+    }
+  }
+  function saveAnalyticsUiState(){
+    try{localStorage.setItem(ANALYTICS_STATE_KEY,JSON.stringify(analyticsUiState));}catch(err){console.warn('Nie można zapisać ustawień analityki',err);}
+  }
+  function analyticsExpenseCategories(){
+    return (b().categories||[]).filter(c=>c.type==='expense'||c.type==='saving');
+  }
+  function getActiveAnalyticsCategoryIds(expenseCats=analyticsExpenseCategories()){
+    const valid=(analyticsUiState?.selectedCategoryIds||[]).filter(id=>expenseCats.some(c=>c.id===id));
+    return valid.length?valid:expenseCats.map(c=>c.id);
+  }
+  function setAnalyticsSelectedCategories(ids){
+    analyticsUiState.selectedCategoryIds=Array.from(new Set(ids));
+    saveAnalyticsUiState();
+  }
+  function ensureAnalyticsSortDefaults(){
+    if(!analyticsUiState.sortField) analyticsUiState.sortField='total';
+    if(!['asc','desc'].includes(analyticsUiState.sortDir)) analyticsUiState.sortDir='desc';
+  }
+  function destroyAnalyticsChart(key){
+    if(analyticsCharts[key]){analyticsCharts[key].destroy(); delete analyticsCharts[key];}
+  }
+  function calcMedian(values){
+    if(!values||!values.length) return 0;
+    const sorted=[...values].sort((a,b)=>a-b);
+    const mid=Math.floor(sorted.length/2);
+    return sorted.length%2?sorted[mid]:(sorted[mid-1]+sorted[mid])/2;
+  }
+  function formatTrend(amount, percent, type){
+    if(!amount && !percent) return '<span class="delta-neutral">—</span>';
+    const isPositive=amount>0;
+    const good=type==='saving';
+    const cls=isPositive?(good?'delta-up':'delta-down'):(good?'delta-down':'delta-up');
+    const arrow=isPositive?'▲':'▼';
+    const pctText=percent?` (${percent>0?'+':''}${percent.toFixed(1)}%)`:'';
+    return `<span class="${cls}">${arrow} ${fmt(amount, state.currency)}${pctText}</span>`;
+  }
+  function formatCountTrend(delta, prevCount, type){
+    if(!delta) return '<span class="delta-neutral">—</span>';
+    const isPositive=delta>0;
+    const good=type==='saving';
+    const cls=isPositive?(good?'delta-up':'delta-down'):(good?'delta-down':'delta-up');
+    const arrow=isPositive?'▲':'▼';
+    const pct=prevCount?Math.abs(delta/prevCount)*100:0;
+    const pctText=pct?` (${delta>0?'+':''}${pct.toFixed(0)}%)`:'';
+    return `<span class="${cls}">${arrow} ${delta>0?'+':''}${delta}${pctText}</span>`;
+  }
+  function heatColor(ratio){
+    if(!Number.isFinite(ratio)||ratio===0) return 'transparent';
+    if(ratio>=1.5) return '#fee2e2';
+    if(ratio>=1.15) return '#ffedd5';
+    if(ratio>=0.9) return '#f8fafc';
+    if(ratio>=0.65) return '#dcfce7';
+    return '#dbeafe';
+  }
+  function withAlpha(hex,alpha){
+    const raw=(hex||'').replace('#','');
+    if(raw.length!==6){return hex;}
+    const r=parseInt(raw.slice(0,2),16);
+    const g=parseInt(raw.slice(2,4),16);
+    const b=parseInt(raw.slice(4,6),16);
+    return `rgba(${r},${g},${b},${alpha})`;
+  }
   function getVisibleTotal(chart) {
     if (!chart || !chart.getDatasetMeta) return 0;
     const meta = chart.getDatasetMeta(0);
@@ -1768,73 +1930,141 @@
   }
 
   // --- Analytics --------------------------------------------------------------
-  function setupAnalyticsCategoryFilter(allEntriesInPeriod) {
-    const container = document.getElementById('analytics-cat-filter-container');
-    const btn = document.getElementById('analytics-cat-filter-btn');
-    const dropdown = document.getElementById('analytics-cat-filter-dropdown');
-    const optionsDiv = document.getElementById('analytics-cat-filter-options');
-    const selectAllBtn = document.getElementById('analytics-cat-filter-all');
-    const selectNoneBtn = document.getElementById('analytics-cat-filter-none');
-    const selectInvertBtn = document.getElementById('analytics-cat-filter-invert');
+  function renderAnalyticsFilterPanel(expenseCats, categoryStats, totalExpense) {
+    const list = document.getElementById('analytics-category-filter-list');
+    const searchInput = document.getElementById('analytics-category-search');
+    const summary = document.getElementById('analytics-filter-summary');
+    if(!list || !searchInput || !summary) return;
 
-    btn.onclick = () => {
-      dropdown.style.display = dropdown.style.display === 'none' ? 'block' : 'none';
+    const selectedIds = getActiveAnalyticsCategoryIds(expenseCats);
+    const searchTerm = (analyticsUiState.searchTerm||'').toLowerCase();
+    searchInput.value = analyticsUiState.searchTerm || '';
+
+    const buttons = {
+      all: document.getElementById('analytics-select-all'),
+      none: document.getElementById('analytics-select-none'),
+      expense: document.getElementById('analytics-select-expense'),
+      savings: document.getElementById('analytics-select-savings'),
+      top5: document.getElementById('analytics-select-top5')
     };
 
-    document.addEventListener('click', (e) => {
-      if (!container.contains(e.target)) {
-        dropdown.style.display = 'none';
-      }
-    });
-    
-    optionsDiv.innerHTML = '';
-    const expenseCats = b().categories.filter(c => c.type === 'expense' || c.type === 'saving');
-    expenseCats.forEach(c => {
-      const label = document.createElement('label');
-      label.className = 'tiny';
-      label.style = "display:flex; align-items:center; gap:6px; padding: 4px; border-radius: 4px; cursor:pointer; hover:background: var(--bg);"
-      label.innerHTML = `<input type="checkbox" class="analytics-cat-filter-cb" value="${c.id}" checked> ${c.emoji || ''} ${c.name}`;
-      optionsDiv.appendChild(label);
-    });
-
-    const checkboxes = optionsDiv.querySelectorAll('.analytics-cat-filter-cb');
-    
-    function updateAndRender() {
-        renderAnalyticsTopTransactions(allEntriesInPeriod);
-        updateFilterButtonText();
+    if(buttons.all){
+      buttons.all.onclick=()=>{setAnalyticsSelectedCategories(expenseCats.map(c=>c.id)); renderAnalytics();};
+    }
+    if(buttons.none){
+      buttons.none.onclick=()=>{setAnalyticsSelectedCategories([]); renderAnalytics();};
+    }
+    if(buttons.expense){
+      buttons.expense.onclick=()=>{setAnalyticsSelectedCategories(expenseCats.filter(c=>c.type==='expense').map(c=>c.id)); renderAnalytics();};
+    }
+    if(buttons.savings){
+      buttons.savings.onclick=()=>{setAnalyticsSelectedCategories(expenseCats.filter(c=>c.type==='saving').map(c=>c.id)); renderAnalytics();};
+    }
+    if(buttons.top5){
+      buttons.top5.onclick=()=>{
+        const sorted=[...expenseCats].sort((a,b)=>{
+          const at=categoryStats[a.id]?.total||0;
+          const bt=categoryStats[b.id]?.total||0;
+          return bt-at;
+        });
+        setAnalyticsSelectedCategories(sorted.slice(0,5).map(c=>c.id));
+        renderAnalytics();
+      };
     }
 
-    checkboxes.forEach(cb => cb.onchange = updateAndRender);
-    selectAllBtn.onclick = () => {
-      checkboxes.forEach(cb => cb.checked = true);
-      updateAndRender();
-    };
-    selectNoneBtn.onclick = () => {
-      checkboxes.forEach(cb => cb.checked = false);
-      updateAndRender();
-    };
-    selectInvertBtn.onclick = () => {
-      checkboxes.forEach(cb => cb.checked = !cb.checked);
-      updateAndRender();
+    searchInput.oninput = (e)=>{
+      analyticsUiState.searchTerm = e.target.value;
+      saveAnalyticsUiState();
+      renderAnalyticsFilterPanel(expenseCats, categoryStats, totalExpense);
     };
 
+    const sortedCats=[...expenseCats].sort((a,b)=>{
+      const at=categoryStats[a.id]?.total||0;
+      const bt=categoryStats[b.id]?.total||0;
+      return bt-at;
+    });
 
-    function updateFilterButtonText() {
-        const selectedCount = Array.from(checkboxes).filter(cb => cb.checked).length;
-        if (selectedCount === checkboxes.length) {
-            btn.textContent = 'Wszystkie kategorie';
-        } else if (selectedCount === 0) {
-            btn.textContent = 'Żadne kategorie';
-        } else {
-            btn.textContent = `Wybrano: ${selectedCount}`;
-        }
+    list.innerHTML='';
+    for(const cat of sortedCats){
+      const label=`${cat.emoji||''} ${cat.name}`.trim();
+      if(searchTerm && !label.toLowerCase().includes(searchTerm)) continue;
+      const wrapper=document.createElement('label');
+      wrapper.className='analytics-filter-grid-label'+(selectedIds.includes(cat.id)?' active':'');
+      wrapper.classList.add('tiny');
+      wrapper.innerHTML=`<input type="checkbox" class="analytics-cat-filter-cb" value="${cat.id}" ${selectedIds.includes(cat.id)?'checked':''}> <span>${cat.emoji||''} ${cat.name}</span><span class="tiny muted" style="justify-content:flex-end;">${fmt(categoryStats[cat.id]?.total||0, state.currency)}</span>`;
+      const checkbox=wrapper.querySelector('input');
+      checkbox.onchange=()=>{
+        const next=new Set(selectedIds);
+        if(checkbox.checked) next.add(cat.id); else next.delete(cat.id);
+        setAnalyticsSelectedCategories(Array.from(next));
+        renderAnalytics();
+      };
+      list.appendChild(wrapper);
     }
-    updateFilterButtonText();
+
+    const selectedTotalAmount = selectedIds.reduce((s,id)=>s+(categoryStats[id]?.total||0),0);
+    const share = totalExpense>0 ? (selectedTotalAmount/totalExpense)*100 : 0;
+    const other = totalExpense - selectedTotalAmount;
+    summary.textContent = `Wybrane ${selectedIds.length} z ${expenseCats.length} kategorii • ${fmt(selectedTotalAmount, state.currency)} (${share.toFixed(1)}% wydatków) • Pozostałe: ${fmt(other, state.currency)}`;
+  }
+
+  function renderAnalyticsKpis(ctx) {
+    const container = document.getElementById('analytics-kpis');
+    if(!container) return;
+    const {
+      totalIncome,
+      totalExpenseAll,
+      netChange,
+      avgSavingsRate,
+      totalSelectedExpense,
+      totalSelectedCount,
+      selectedAvg,
+      selectedMedian,
+      selectedShare,
+      monthsCount,
+      lastMonthSummary,
+      prevMonthSummary,
+      lastVsPrevAmount,
+      lastVsPrevPercent,
+      lastCountDelta,
+      avgDelta,
+      avgDeltaPct,
+      selectedMood,
+      largestCategory,
+      selectedTypeTotals
+    } = ctx;
+
+    const avgPerMonth = monthsCount ? totalSelectedExpense / monthsCount : 0;
+    const countPerMonth = monthsCount ? totalSelectedCount / monthsCount : 0;
+    const largestName = largestCategory ? `${largestCategory.category?.emoji||''} ${largestCategory.category?.name||'—'}`.trim() : '—';
+    const largestShare = largestCategory && totalSelectedExpense > 0 ? (largestCategory.total / totalSelectedExpense) * 100 : 0;
+    const largestAvg = largestCategory && largestCategory.count ? largestCategory.total / largestCategory.count : 0;
+    const totalSelectedStructure = (selectedTypeTotals?.expense || 0) + (selectedTypeTotals?.saving || 0);
+    const savingsShare = totalSelectedStructure > 0 ? (selectedTypeTotals.saving / totalSelectedStructure) * 100 : 0;
+    const expenseShare = totalSelectedStructure > 0 ? (selectedTypeTotals.expense / totalSelectedStructure) * 100 : 0;
+
+    let html = `
+      <div class="stat-card"><div class="muted">Całkowity przychód</div><div class="big-number ok">${fmt(totalIncome, state.currency)}</div><div class="trend">Śr. ${fmt(totalIncome / (monthsCount || 1), state.currency)} / miesiąc</div></div>
+      <div class="stat-card"><div class="muted">Całkowite wydatki</div><div class="big-number bad">${fmt(totalExpenseAll, state.currency)}</div><div class="trend">Śr. ${fmt(totalExpenseAll / (monthsCount || 1), state.currency)} / miesiąc</div></div>
+      <div class="stat-card"><div class="muted">Bilans (Netto)</div><div class="big-number ${netChange >= 0 ? 'ok' : 'bad'}">${fmt(netChange, state.currency)}</div><div class="trend">Stopa oszczędności: ${avgSavingsRate.toFixed(1)}%</div></div>
+      <div class="stat-card"><div class="muted">Wydatki (wybrane)</div><div class="big-number ${selectedMood === 'saving' ? 'ok' : 'bad'}">${fmt(totalSelectedExpense, state.currency)}</div><div class="trend">Śr. ${fmt(avgPerMonth, state.currency)} / mies.</div></div>
+      <div class="stat-card"><div class="muted">Transakcji (wybrane)</div><div class="big-number">${totalSelectedCount}</div><div class="trend">~${countPerMonth.toFixed(1)} / miesiąc</div></div>
+      <div class="stat-card"><div class="muted">Średnia vs mediana</div><div class="big-number">${fmt(selectedAvg, state.currency)}</div><div class="trend">Mediana: ${fmt(selectedMedian, state.currency)}</div></div>
+      <div class="stat-card"><div class="muted">Udział wybranych</div><div class="big-number">${selectedShare.toFixed(1)}%</div><div class="trend">Pozostałe: ${fmt(totalExpenseAll - totalSelectedExpense, state.currency)}</div></div>
+      <div class="stat-card"><div class="muted">Dynamika ${lastMonthSummary?.ym || ''}</div><div class="big-number">${fmt(lastMonthSummary?.selectedTotal || 0, state.currency)}</div><div class="trend">Suma: ${formatTrend(lastVsPrevAmount, lastVsPrevPercent, selectedMood)}<br>Liczba: ${formatCountTrend(lastCountDelta, prevMonthSummary?.selectedCount || 0, selectedMood)}<br>Średnia: ${formatTrend(avgDelta, avgDeltaPct, selectedMood)}</div></div>
+      <div class="stat-card"><div class="muted">Top kategoria</div><div class="big-number">${largestName}</div><div class="trend">${largestCategory ? `${fmt(largestCategory.total, state.currency)} (${largestShare.toFixed(1)}%) • ${largestCategory.count} × ${fmt(largestAvg, state.currency)}` : 'Brak danych'}</div></div>
+    `;
+
+    if(totalSelectedStructure > 0){
+      html += `<div class="stat-card"><div class="muted">Struktura wybranych</div><div class="big-number">${fmt(totalSelectedExpense, state.currency)}</div><div class="trend"><span class="insight-pill">Wydatki: ${expenseShare.toFixed(1)}%</span><span class="insight-pill">Oszczędności: ${savingsShare.toFixed(1)}%</span></div></div>`;
+    }
+
+    container.innerHTML = html;
   }
 
   function renderAnalytics(){
     document.getElementById('analytics-period').onchange = renderAnalytics;
-    
+
     const period = document.getElementById('analytics-period').value;
     const allMonthsRaw = [...new Set(b().transactions.map(t => t.date.slice(0, 7)))];
     if (b().monthly) {
@@ -1843,14 +2073,13 @@
         });
     }
     const allMonths = [...new Set(allMonthsRaw)].sort();
-    
+
     let monthsToAnalyze;
     if (period === 'all') {
         monthsToAnalyze = allMonths;
     } else if (period === '1') {
         monthsToAnalyze = [b().workingMonth];
-    }
-    else {
+    } else {
         const monthCount = parseInt(period, 10);
         const endIndex = allMonths.indexOf(b().workingMonth);
         if (endIndex > -1) {
@@ -1866,6 +2095,12 @@
       return;
     }
 
+    ensureAnalyticsSortDefaults();
+    const expenseCats = analyticsExpenseCategories();
+    const selectedCatIds = getActiveAnalyticsCategoryIds(expenseCats);
+    const selectedCatSet = new Set(selectedCatIds);
+    const catsMap = catsById();
+
     const firstMonth = monthsToAnalyze[0];
     const lastMonth = monthsToAnalyze[monthsToAnalyze.length - 1];
 
@@ -1873,11 +2108,15 @@
         const ym = t.date.slice(0, 7);
         return ym >= firstMonth && ym <= lastMonth;
     });
-    
+
+    const categoryStats = {};
+    const monthlySummaries = [];
     let totalIncome = 0;
-    let totalExpense = 0;
-    const expenseByCategory = {};
-    const expenseByCategoryByMonth = {};
+    let totalExpenseAll = 0;
+    let totalSelectedExpense = 0;
+    let totalSelectedCount = 0;
+    let totalEntriesAll = 0;
+    const selectedAmounts = [];
 
     monthsToAnalyze.forEach(ym => {
         ensureMonth(ym);
@@ -1885,126 +2124,251 @@
         totalIncome += monthIncome;
 
         const monthEntries = entriesForMonth(ym);
+        let monthExpense = 0;
+        let monthSelectedTotal = 0;
+        let monthSelectedCount = 0;
+        const monthSelectedValues = [];
+        const byCategory = {};
+
         monthEntries.forEach(e => {
-            const cat = catsById()[e.categoryId];
-            if(cat && (cat.type === 'expense' || cat.type === 'saving')) {
-                const amount = Math.abs(e.amount);
-                totalExpense += amount;
-                expenseByCategory[cat.id] = (expenseByCategory[cat.id] || 0) + amount;
-                
-                if (!expenseByCategoryByMonth[cat.id]) expenseByCategoryByMonth[cat.id] = {};
-                 if (!expenseByCategoryByMonth[cat.id][ym]) {
-                    expenseByCategoryByMonth[cat.id][ym] = { total: 0, count: 0 };
-                }
-                expenseByCategoryByMonth[cat.id][ym].total += amount;
-                expenseByCategoryByMonth[cat.id][ym].count += 1;
+            const cat = catsMap[e.categoryId];
+            if(!cat || (cat.type !== 'expense' && cat.type !== 'saving')) return;
+            const amount = Math.abs(e.amount);
+            monthExpense += amount;
+            totalExpenseAll += amount;
+            totalEntriesAll += 1;
+
+            let stat = categoryStats[cat.id];
+            if(!stat){
+                stat = categoryStats[cat.id] = {
+                    category: cat,
+                    total: 0,
+                    count: 0,
+                    values: [],
+                    months: {},
+                    max: { amount: 0, date: '' },
+                    min: { amount: Infinity, date: '' }
+                };
             }
+            stat.total += amount;
+            stat.count += 1;
+            stat.values.push(amount);
+            if(!stat.months[ym]) stat.months[ym] = { total: 0, count: 0, values: [] };
+            stat.months[ym].total += amount;
+            stat.months[ym].count += 1;
+            stat.months[ym].values.push(amount);
+            if(amount > stat.max.amount) stat.max = { amount, date: e.date };
+            if(amount < stat.min.amount) stat.min = { amount, date: e.date };
+
+            if(!byCategory[cat.id]) byCategory[cat.id] = { total: 0, count: 0, values: [] };
+            byCategory[cat.id].total += amount;
+            byCategory[cat.id].count += 1;
+            byCategory[cat.id].values.push(amount);
+
+            if(selectedCatSet.has(cat.id)){
+                monthSelectedTotal += amount;
+                monthSelectedCount += 1;
+                totalSelectedExpense += amount;
+                totalSelectedCount += 1;
+                selectedAmounts.push(amount);
+                monthSelectedValues.push(amount);
+            }
+        });
+
+        monthlySummaries.push({
+            ym,
+            incomes: monthIncome,
+            expenses: monthExpense,
+            selectedTotal: monthSelectedTotal,
+            selectedCount: monthSelectedCount,
+            selectedAvg: monthSelectedCount ? monthSelectedTotal / monthSelectedCount : 0,
+            selectedMedian: calcMedian(monthSelectedValues),
+            byCategory
         });
     });
 
-    const netChange = totalIncome - totalExpense;
-    const avgSavingsRate = totalIncome > 0 ? (netChange / totalIncome) * 100 : 0;
-
-    const kpisContainer = document.getElementById('analytics-kpis');
-    kpisContainer.innerHTML = `
-        <div class="stat-card"><div class="muted">Całkowity przychód</div><div class="big-number ok">${fmt(totalIncome, state.currency)}</div></div>
-        <div class="stat-card"><div class="muted">Całkowite wydatki</div><div class="big-number bad">${fmt(totalExpense, state.currency)}</div></div>
-        <div class="stat-card"><div class="muted">Bilans (Netto)</div><div class="big-number ${netChange >= 0 ? 'ok' : 'bad'}">${fmt(netChange, state.currency)}</div></div>
-        <div class="stat-card"><div class="muted">Śr. stopa oszczędności</div><div class="big-number">${avgSavingsRate.toFixed(0)}%</div></div>
-    `;
-
-    renderAnalyticsIncomeExpenseChart(monthsToAnalyze);
-    renderAnalyticsCategoryChart(expenseByCategory);
-    renderAnalyticsCategoryTrends(monthsToAnalyze, expenseByCategoryByMonth);
-    setupAnalyticsCategoryFilter(allEntriesInPeriod);
-    renderAnalyticsTopTransactions(allEntriesInPeriod);
-  }
-
-  function renderAnalyticsIncomeExpenseChart(months) {
-    const ctx = document.getElementById('analytics-income-expense-chart').getContext('2d');
-    if(window.analyticsIncomeExpense) window.analyticsIncomeExpense.destroy();
-
-    const incomes = [];
-    const expenses = [];
-    months.forEach(ym => {
-        ensureMonth(ym);
-        incomes.push(b().monthly[ym].incomes.reduce((s, x) => s + num(x.amount), 0));
-        const monthExpenses = entriesForMonth(ym).reduce((s, e) => {
-            const cat = catsById()[e.categoryId];
-            return (cat && (cat.type === 'expense' || cat.type === 'saving')) ? s + Math.abs(e.amount) : s;
-        }, 0);
-        expenses.push(monthExpenses);
+    expenseCats.forEach(cat => {
+        if(!categoryStats[cat.id]){
+            categoryStats[cat.id] = {
+                category: cat,
+                total: 0,
+                count: 0,
+                values: [],
+                months: {},
+                max: { amount: 0, date: '' },
+                min: { amount: 0, date: '' }
+            };
+        } else if(categoryStats[cat.id].min.amount === Infinity){
+            categoryStats[cat.id].min = { amount: 0, date: '' };
+        }
     });
 
-    window.analyticsIncomeExpense = new Chart(ctx, {
+    const monthsCount = monthsToAnalyze.length;
+    const netChange = totalIncome - totalExpenseAll;
+    const avgSavingsRate = totalIncome > 0 ? (netChange / totalIncome) * 100 : 0;
+    const selectedAvg = totalSelectedCount ? totalSelectedExpense / totalSelectedCount : 0;
+    const selectedMedian = calcMedian(selectedAmounts);
+    const selectedShare = totalExpenseAll > 0 ? (totalSelectedExpense / totalExpenseAll) * 100 : 0;
+    const lastMonthSummary = monthlySummaries[monthlySummaries.length - 1];
+    const prevMonthSummary = monthlySummaries.length >= 2 ? monthlySummaries[monthlySummaries.length - 2] : null;
+    const lastVsPrevAmount = prevMonthSummary ? lastMonthSummary.selectedTotal - prevMonthSummary.selectedTotal : 0;
+    const lastVsPrevPercent = (prevMonthSummary && prevMonthSummary.selectedTotal > 0)
+        ? (lastVsPrevAmount / prevMonthSummary.selectedTotal) * 100
+        : 0;
+    const lastCountDelta = prevMonthSummary ? lastMonthSummary.selectedCount - prevMonthSummary.selectedCount : 0;
+    const lastAvg = lastMonthSummary.selectedCount ? lastMonthSummary.selectedTotal / lastMonthSummary.selectedCount : 0;
+    const prevAvg = prevMonthSummary && prevMonthSummary.selectedCount ? prevMonthSummary.selectedTotal / prevMonthSummary.selectedCount : 0;
+    const avgDelta = lastAvg - prevAvg;
+    const avgDeltaPct = prevAvg ? (avgDelta / prevAvg) * 100 : 0;
+
+    const selectedTypeTotals = selectedCatIds.reduce((acc, id) => {
+        const cat = catsMap[id];
+        if(!cat) return acc;
+        if(cat.type === 'saving') acc.saving += categoryStats[id]?.total || 0;
+        else acc.expense += categoryStats[id]?.total || 0;
+        return acc;
+    }, {expense:0, saving:0});
+    const selectedMood = selectedTypeTotals.saving > selectedTypeTotals.expense ? 'saving' : 'expense';
+
+    const largestCategory = selectedCatIds.map(id => categoryStats[id]).filter(Boolean).sort((a,b) => (b?.total||0) - (a?.total||0))[0] || null;
+
+    const analyticsContext = {
+        months: monthsToAnalyze,
+        monthlySummaries,
+        categoryStats,
+        selectedCatIds,
+        totalSelectedExpense,
+        totalSelectedCount,
+        selectedAvg,
+        selectedMedian,
+        selectedShare,
+        totalExpenseAll,
+        totalIncome,
+        netChange,
+        avgSavingsRate,
+        monthsCount,
+        lastMonthSummary,
+        prevMonthSummary,
+        lastVsPrevAmount,
+        lastVsPrevPercent,
+        lastCountDelta,
+        avgDelta,
+        avgDeltaPct,
+        selectedMood,
+        largestCategory,
+        allEntriesInPeriod,
+        totalEntriesAll,
+        selectedTypeTotals
+    };
+
+    renderAnalyticsFilterPanel(expenseCats, categoryStats, totalExpenseAll);
+
+    renderAnalyticsKpis(analyticsContext);
+    renderAnalyticsIncomeExpenseChart(monthlySummaries);
+    renderAnalyticsCategoryChart(categoryStats, selectedCatIds);
+    renderAnalyticsMonthlyActivityChart(monthlySummaries, analyticsContext);
+    renderAnalyticsAverageTrendChart(monthlySummaries);
+    renderAnalyticsCategoryLeaderChart(categoryStats, selectedCatIds);
+    renderAnalyticsCategoryTrendChart(monthsToAnalyze, categoryStats, selectedCatIds);
+    renderAnalyticsCategoryTrends(monthsToAnalyze, categoryStats, selectedCatIds);
+    renderAnalyticsCategorySummary(analyticsContext);
+    renderAnalyticsMomentumTable(analyticsContext);
+    renderAnalyticsMonthlyBreakdown(analyticsContext);
+    renderAnalyticsTopTransactions(analyticsContext);
+  }
+
+  function renderAnalyticsIncomeExpenseChart(monthlySummaries) {
+    const canvas = document.getElementById('analytics-income-expense-chart');
+    if(!canvas) return;
+    const ctx = canvas.getContext('2d');
+    destroyAnalyticsChart('incomeExpense');
+
+    const labels = monthlySummaries.map(m => m.ym);
+    const incomes = monthlySummaries.map(m => m.incomes);
+    const expenses = monthlySummaries.map(m => m.expenses);
+    const selected = monthlySummaries.map(m => m.selectedTotal);
+
+    analyticsCharts.incomeExpense = new Chart(ctx, {
         type: 'bar',
         data: {
-            labels: months,
+            labels,
             datasets: [
-                { label: 'Przychody', data: incomes, backgroundColor: 'rgba(5, 150, 105, 0.7)' },
-                { label: 'Wydatki', data: expenses, backgroundColor: 'rgba(190, 18, 60, 0.7)' }
+                { label: 'Przychody', data: incomes, backgroundColor: 'rgba(5,150,105,0.7)', order: 2 },
+                { label: 'Wydatki (wszystkie)', data: expenses, backgroundColor: 'rgba(190,18,60,0.6)', order: 1 },
+                { type: 'line', label: 'Wydatki (wybrane)', data: selected, borderColor: '#0f172a', backgroundColor: 'rgba(15,23,42,0.12)', borderWidth: 2, tension: 0.3, fill: false, order: 0 }
             ]
         },
-        options:{responsive:true,maintainAspectRatio:false, scales:{y:{beginAtZero:true,ticks:{callback:currencyTicks}}}}
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: { beginAtZero: true, ticks: { callback: currencyTicks } }
+            },
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: context => `${context.dataset.label}: ${fmt(context.parsed.y, state.currency)}`
+                    }
+                }
+            }
+        }
     });
   }
 
-  function renderAnalyticsCategoryChart(expenseByCategory) {
-      const ctx = document.getElementById('analytics-category-chart').getContext('2d');
-      if(window.analyticsCategory) window.analyticsCategory.destroy();
+  function renderAnalyticsCategoryChart(categoryStats, selectedCatIds) {
+      const canvas = document.getElementById('analytics-category-chart');
+      if(!canvas) return;
+      const ctx = canvas.getContext('2d');
+      destroyAnalyticsChart('categoryShare');
 
-      const expenseForChart = { ...expenseByCategory };
-      delete expenseForChart['c_fixed'];
+      const stats = selectedCatIds.map(id => categoryStats[id]).filter(Boolean).sort((a,b) => (b?.total||0) - (a?.total||0));
+      const labels = stats.map(stat => `${stat.category?.emoji||''} ${stat.category?.name||'—'}`.trim());
+      const data = stats.map(stat => stat.total);
 
-      const sortedCategories = Object.entries(expenseForChart).sort(([,a],[,b]) => b-a);
-      const labels = sortedCategories.map(([id]) => catsById()[id]?.name || 'Brak kategorii');
-      const data = sortedCategories.map(([,amount]) => amount);
-      
-      window.analyticsCategory=new Chart(ctx,{
+      analyticsCharts.categoryShare = new Chart(ctx,{
           type:'doughnut',
-          data:{labels, datasets:[{data, backgroundColor:['#0ea5e9','#ef4444','#f59e0b','#10b981','#8b5cf6','#06b6d4','#f97316', '#64748b']}]},
+          data:{
+              labels,
+              datasets:[{
+                  data,
+                  backgroundColor: labels.map((_,i)=>ANALYTICS_COLORS[i % ANALYTICS_COLORS.length])
+              }]
+          },
           options:{
               responsive:true,
               maintainAspectRatio:false,
-              plugins: {
-                  tooltip: {
-                      callbacks: {
-                          label: function(context) {
-                              const chart = context.chart;
-                              const visibleTotal = getVisibleTotal(chart);
-                              const value = context.raw;
-                              const percentage = visibleTotal > 0 ? ((value / visibleTotal) * 100).toFixed(1) + '%' : '0%';
+              plugins:{
+                  tooltip:{
+                      callbacks:{
+                          label:function(context){
+                              const chart=context.chart;
+                              const visibleTotal=getVisibleTotal(chart);
+                              const value=context.raw;
+                              const percentage=visibleTotal>0?((value/visibleTotal)*100).toFixed(1)+'%':'0%';
                               return `${context.label}: ${fmt(value, state.currency)} (${percentage})`;
                           }
                       }
                   },
-                  legend: {
-                      position: 'top',
-                      onClick: (e, legendItem, legend) => {
-                          const ci = legend.chart;
-                          Chart.defaults.plugins.legend.onClick(e, legendItem, legend);
-                          ci.update();
-                      },
-                      labels: {
-                          generateLabels: function(chart) {
-                              const data = chart.data;
-                              if (data.labels.length && data.datasets.length) {
-                                  const {labels: {pointStyle}} = chart.legend.options;
-                                  const visibleTotal = getVisibleTotal(chart);
-                                  return data.labels.map((label, i) => {
-                                      const meta = chart.getDatasetMeta(0);
-                                      const style = meta.controller.getStyle(i);
-                                      const value = chart.data.datasets[0].data[i];
-                                      const hidden = !chart.getDataVisibility(i);
-                                      const percentage = !hidden && visibleTotal > 0 ? ((value / visibleTotal) * 100).toFixed(1) + '%' : '0%';
+                  legend:{
+                      position:'top',
+                      labels:{
+                          generateLabels:function(chart){
+                              const data=chart.data;
+                              if(data.labels.length && data.datasets.length){
+                                  const visibleTotal=getVisibleTotal(chart);
+                                  return data.labels.map((label,i)=>{
+                                      const meta=chart.getDatasetMeta(0);
+                                      const style=meta.controller.getStyle(i);
+                                      const value=data.datasets[0].data[i];
+                                      const hidden=!chart.getDataVisibility(i);
+                                      const percentage=!hidden && visibleTotal>0?((value/visibleTotal)*100).toFixed(1)+'%':'0%';
                                       return {
-                                          text: `${label} (${!hidden ? percentage : 'ukryte'})`,
-                                          fillStyle: style.backgroundColor,
-                                          strokeStyle: style.borderColor,
-                                          lineWidth: style.borderWidth,
-                                          pointStyle: pointStyle,
-                                          hidden: hidden,
-                                          index: i
+                                          text:`${label} (${!hidden ? percentage : 'ukryte'})`,
+                                          fillStyle:style.backgroundColor,
+                                          strokeStyle:style.borderColor,
+                                          lineWidth:style.borderWidth,
+                                          hidden:hidden,
+                                          index:i
                                       };
                                   });
                               }
@@ -2017,78 +2381,444 @@
       });
   }
   
-  function renderAnalyticsCategoryTrends(months, data) {
-    const table = document.getElementById('analytics-category-trends');
-    const categories = Object.keys(data).map(id => catsById()[id]).filter(Boolean);
+  function renderAnalyticsMonthlyActivityChart(monthlySummaries, ctx) {
+    const canvas = document.getElementById('analytics-monthly-activity-chart');
+    if(!canvas) return;
+    const chartCtx = canvas.getContext('2d');
+    destroyAnalyticsChart('monthlyActivity');
 
-    let header = `<thead><tr><th>Kategoria</th>`;
+    const labels = monthlySummaries.map(m => m.ym);
+    const totals = monthlySummaries.map(m => m.selectedTotal);
+    const counts = monthlySummaries.map(m => m.selectedCount);
+    const averages = monthlySummaries.map(m => m.selectedAvg);
+    const barColor = ctx?.selectedMood === 'saving' ? 'rgba(5,150,105,0.65)' : 'rgba(190,18,60,0.65)';
+
+    analyticsCharts.monthlyActivity = new Chart(chartCtx, {
+        data: {
+            labels,
+            datasets: [
+                { type:'bar', label:'Suma wydatków (wybrane)', data: totals, backgroundColor: barColor, borderRadius:6, yAxisID:'y' },
+                { type:'line', label:'Liczba transakcji', data: counts, borderColor:'#0ea5e9', backgroundColor:'rgba(14,165,233,0.15)', borderWidth:2, tension:0.3, yAxisID:'y1', fill:false },
+                { type:'line', label:'Średnia kwota', data: averages, borderColor:'#0f172a', backgroundColor:'rgba(15,23,42,0.1)', borderDash:[6,4], tension:0.3, yAxisID:'y' }
+            ]
+        },
+        options: {
+            responsive:true,
+            maintainAspectRatio:false,
+            scales: {
+                y: { beginAtZero:true, ticks:{ callback: currencyTicks } },
+                y1: { beginAtZero:true, position:'right', grid:{ drawOnChartArea:false }, ticks:{ precision:0 } }
+            },
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: context => {
+                            if(context.dataset.label === 'Liczba transakcji'){
+                                return `${context.dataset.label}: ${context.parsed.y}`;
+                            }
+                            return `${context.dataset.label}: ${fmt(context.parsed.y, state.currency)}`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+  }
+
+  function renderAnalyticsAverageTrendChart(monthlySummaries) {
+    const canvas = document.getElementById('analytics-avg-trend-chart');
+    if(!canvas) return;
+    const ctx = canvas.getContext('2d');
+    destroyAnalyticsChart('avgTrend');
+
+    const labels = monthlySummaries.map(m => m.ym);
+    const averages = monthlySummaries.map(m => m.selectedAvg);
+    const medians = monthlySummaries.map(m => m.selectedMedian);
+
+    analyticsCharts.avgTrend = new Chart(ctx, {
+        type:'line',
+        data:{
+            labels,
+            datasets:[
+                { label:'Średnia kwota', data: averages, borderColor:'#0f172a', backgroundColor:'rgba(15,23,42,0.12)', borderWidth:2, tension:0.3, fill:false },
+                { label:'Mediana', data: medians, borderColor:'#8b5cf6', backgroundColor:'rgba(139,92,246,0.15)', borderWidth:2, tension:0.3, fill:false }
+            ]
+        },
+        options:{
+            responsive:true,
+            maintainAspectRatio:false,
+            scales:{ y:{ beginAtZero:true, ticks:{ callback: currencyTicks } } },
+            plugins:{ tooltip:{ callbacks:{ label: context => `${context.dataset.label}: ${fmt(context.parsed.y, state.currency)}` } } }
+        }
+    });
+  }
+
+  function renderAnalyticsCategoryLeaderChart(categoryStats, selectedCatIds) {
+    const canvas = document.getElementById('analytics-category-leader-chart');
+    if(!canvas) return;
+    const ctx = canvas.getContext('2d');
+    destroyAnalyticsChart('categoryLeader');
+
+    const stats = selectedCatIds.map(id => categoryStats[id]).filter(Boolean).sort((a,b)=> (b?.total||0)-(a?.total||0)).slice(0,6);
+    const labels = stats.map(stat => `${stat.category?.emoji||''} ${stat.category?.name||'—'}`.trim());
+    const totals = stats.map(stat => stat.total);
+    const counts = stats.map(stat => stat.count);
+    const averages = stats.map(stat => stat.count ? stat.total / stat.count : 0);
+
+    analyticsCharts.categoryLeader = new Chart(ctx,{
+        data:{
+            labels,
+            datasets:[
+                { type:'bar', label:'Suma', data: totals, backgroundColor:'rgba(190,18,60,0.6)', yAxisID:'y', borderRadius:6 },
+                { type:'bar', label:'Liczba transakcji', data: counts, backgroundColor:'rgba(14,165,233,0.35)', yAxisID:'y1', borderRadius:6 },
+                { type:'line', label:'Średnia kwota', data: averages, borderColor:'#0f172a', backgroundColor:'rgba(15,23,42,0.1)', yAxisID:'y', borderWidth:2, tension:0.3, fill:false }
+            ]
+        },
+        options:{
+            responsive:true,
+            maintainAspectRatio:false,
+            scales:{
+                y:{ beginAtZero:true, ticks:{ callback: currencyTicks } },
+                y1:{ beginAtZero:true, position:'right', grid:{ drawOnChartArea:false }, ticks:{ precision:0 } }
+            },
+            plugins:{
+                tooltip:{
+                    callbacks:{
+                        label: context => context.dataset.label === 'Liczba transakcji'
+                            ? `${context.dataset.label}: ${context.parsed.y}`
+                            : `${context.dataset.label}: ${fmt(context.parsed.y, state.currency)}`
+                    }
+                }
+            }
+        }
+    });
+  }
+
+  function renderAnalyticsCategoryTrendChart(months, categoryStats, selectedCatIds) {
+    const canvas = document.getElementById('analytics-category-trend-chart');
+    if(!canvas) return;
+    const ctx = canvas.getContext('2d');
+    destroyAnalyticsChart('categoryTrend');
+
+    const stats = selectedCatIds.map(id => categoryStats[id]).filter(Boolean).sort((a,b)=> (b?.total||0)-(a?.total||0)).slice(0,5);
+    const datasets = stats.map((stat,idx)=>({
+        label: `${stat.category?.emoji||''} ${stat.category?.name||'—'}`.trim(),
+        data: months.map(ym => stat.months[ym]?.total || 0),
+        borderColor: ANALYTICS_COLORS[idx % ANALYTICS_COLORS.length],
+        backgroundColor: withAlpha(ANALYTICS_COLORS[idx % ANALYTICS_COLORS.length], 0.18),
+        tension: 0.3,
+        fill: false,
+        borderWidth: 2
+    }));
+
+    analyticsCharts.categoryTrend = new Chart(ctx,{
+        type:'line',
+        data:{ labels: months, datasets },
+        options:{
+            responsive:true,
+            maintainAspectRatio:false,
+            scales:{ y:{ beginAtZero:true, ticks:{ callback: currencyTicks } } },
+            plugins:{ tooltip:{ callbacks:{ label: context => `${context.dataset.label}: ${fmt(context.parsed.y, state.currency)}` } } }
+        }
+    });
+  }
+
+  function renderAnalyticsCategoryTrends(months, categoryStats, selectedCatIds) {
+    const table = document.getElementById('analytics-category-trends');
+    if(!table) return;
+    const rows = selectedCatIds.map(id => categoryStats[id]).filter(Boolean);
+    if(rows.length === 0){
+        table.innerHTML = `<tbody><tr><td class="muted" style="text-align:center;" colspan="${months.length+1}">Brak danych dla wybranych kategorii.</td></tr></tbody>`;
+        return;
+    }
+
+    let header = '<thead><tr><th>Kategoria</th>';
     months.forEach(ym => header += `<th>${ym}</th>`);
-    header += `</tr></thead>`;
-    
-    let body = `<tbody>`;
-    categories.forEach(cat => {
-        body += `<tr><td>${cat.emoji||''} ${cat.name}</td>`;
+    header += '</tr></thead>';
+
+    let body = '<tbody>';
+    rows.forEach(stat => {
+        const cat = stat.category;
+        const avgPerMonth = stat.total / (months.length || 1);
+        body += `<tr><td>${cat?.emoji||''} ${cat?.name||'—'}</td>`;
         months.forEach(ym => {
-            const monthData = data[cat.id]?.[ym];
-            if (monthData && monthData.total > 0) {
-                const avg = monthData.total / monthData.count;
-                body += `<td>
-                    ${fmt(monthData.total, state.currency)}
-                    <br>
-                    <span class="tiny muted">(${monthData.count} / ${fmt(avg, state.currency)})</span>
-                </td>`;
+            const monthData = stat.months[ym] || { total:0, count:0, values:[] };
+            const avg = monthData.count ? monthData.total / monthData.count : 0;
+            const ratio = avgPerMonth ? monthData.total / avgPerMonth : 0;
+            const bg = heatColor(ratio);
+            if(monthData.total > 0){
+                body += `<td style="background:${bg}">${fmt(monthData.total, state.currency)}<br><span class="tiny muted">${monthData.count} × ${fmt(avg, state.currency)}</span></td>`;
             } else {
-                body += `<td>${fmt(0, state.currency)}</td>`;
+                body += `<td style="background:${bg}"><span class="muted">—</span></td>`;
             }
         });
-        body += `</tr>`;
+        body += '</tr>';
     });
-    body += `</tbody>`;
+    body += '</tbody>';
 
     table.innerHTML = header + body;
   }
-  
-  function renderAnalyticsTopTransactions(allEntries) {
+
+  function renderAnalyticsCategorySummary(ctx) {
+    const table = document.getElementById('analytics-category-summary');
+    if(!table) return;
+    const { categoryStats, selectedCatIds, totalSelectedExpense, selectedMood, lastMonthSummary, prevMonthSummary } = ctx;
+    const rows = selectedCatIds.map(id => categoryStats[id]).filter(Boolean).map(stat => {
+        const cat = stat.category;
+        const label = `${cat?.emoji||''} ${cat?.name||'—'}`.trim();
+        const avg = stat.count ? stat.total / stat.count : 0;
+        const median = calcMedian(stat.values);
+        const share = totalSelectedExpense > 0 ? (stat.total / totalSelectedExpense) * 100 : 0;
+        const lastYm = lastMonthSummary?.ym;
+        const prevYm = prevMonthSummary?.ym;
+        const lastData = lastYm ? (stat.months[lastYm] || { total:0, count:0, values:[] }) : { total:0, count:0, values:[] };
+        const prevData = prevYm ? (stat.months[prevYm] || { total:0, count:0, values:[] }) : null;
+        const deltaAmount = prevData ? lastData.total - prevData.total : lastData.total;
+        const deltaPercent = prevData && prevData.total > 0 ? (deltaAmount / prevData.total) * 100 : 0;
+        const countDelta = prevData ? lastData.count - prevData.count : lastData.count;
+        const avgLast = lastData.count ? lastData.total / lastData.count : 0;
+        const avgPrev = prevData && prevData.count ? prevData.total / prevData.count : 0;
+        const avgDelta = avgLast - avgPrev;
+        const avgDeltaPercent = avgPrev ? (avgDelta / avgPrev) * 100 : 0;
+        const maxAmount = stat.max?.amount || 0;
+        const maxDate = stat.max?.date || '';
+        return {
+            label,
+            total: stat.total,
+            count: stat.count,
+            avg,
+            median,
+            share,
+            deltaAmount,
+            deltaPercent,
+            countDelta,
+            prevCount: prevData?.count || 0,
+            avgDelta,
+            avgDeltaPercent,
+            maxAmount,
+            maxDate,
+            type: cat?.type || selectedMood
+        };
+    });
+
+    if(rows.length === 0){
+        table.innerHTML = `<tbody><tr><td class="muted" style="text-align:center;" colspan="10">Brak danych dla wybranych kategorii.</td></tr></tbody>`;
+        return;
+    }
+
+    ensureAnalyticsSortDefaults();
+    const sortKey = analyticsUiState.sortField || 'total';
+    const sortDir = analyticsUiState.sortDir === 'asc' ? 1 : -1;
+    rows.sort((a,b) => {
+        if(sortKey === 'label'){
+            return a.label.localeCompare(b.label,'pl',{sensitivity:'base'}) * sortDir;
+        }
+        const av = Number(a[sortKey] || 0);
+        const bv = Number(b[sortKey] || 0);
+        if(av === bv){
+            return a.label.localeCompare(b.label,'pl',{sensitivity:'base'});
+        }
+        return (av - bv) * sortDir;
+    });
+
+    const columns = [
+        { label:'Kategoria', sortKey:'label', formatter: row => row.label },
+        { label:`Suma (${state.currency})`, sortKey:'total', formatter: row => fmt(row.total, state.currency) },
+        { label:'Liczba', sortKey:'count', formatter: row => row.count },
+        { label:'Średnia', sortKey:'avg', formatter: row => fmt(row.avg, state.currency) },
+        { label:'Mediana', sortKey:'median', formatter: row => fmt(row.median, state.currency) },
+        { label:'Udział', sortKey:'share', formatter: row => `${row.share.toFixed(1)}%` },
+        { label:'Zmiana m/m', sortKey:'deltaAmount', formatter: row => formatTrend(row.deltaAmount, row.deltaPercent, row.type) },
+        { label:'Δ liczby', sortKey:'countDelta', formatter: row => formatCountTrend(row.countDelta, row.prevCount, row.type) },
+        { label:'Δ średniej', sortKey:'avgDelta', formatter: row => formatTrend(row.avgDelta, row.avgDeltaPercent, row.type) },
+        { label:'Największa transakcja', sortKey:'maxAmount', formatter: row => row.maxAmount ? `${fmt(row.maxAmount, state.currency)}${row.maxDate ? `<br><span class="tiny muted">${row.maxDate}</span>` : ''}` : '<span class="muted">—</span>' }
+    ];
+
+    let header = '<thead><tr>';
+    columns.forEach(col => {
+        const active = analyticsUiState.sortField === col.sortKey;
+        const indicator = active ? `<span class="sort-indicator">${analyticsUiState.sortDir === 'asc' ? '▲' : '▼'}</span>` : '';
+        header += `<th${col.sortKey ? ` data-sort="${col.sortKey}"` : ''}>${col.label}${indicator}</th>`;
+    });
+    header += '</tr></thead>';
+
+    let body = '<tbody>';
+    rows.forEach(row => {
+        body += '<tr>' + columns.map(col => `<td>${col.formatter(row)}</td>`).join('') + '</tr>';
+    });
+    body += '</tbody>';
+
+    table.innerHTML = header + body;
+
+    table.querySelectorAll('th[data-sort]').forEach(th => {
+        const key = th.dataset.sort;
+        th.onclick = () => {
+            if(analyticsUiState.sortField === key){
+                analyticsUiState.sortDir = analyticsUiState.sortDir === 'asc' ? 'desc' : 'asc';
+            } else {
+                analyticsUiState.sortField = key;
+                analyticsUiState.sortDir = key === 'label' ? 'asc' : 'desc';
+            }
+            saveAnalyticsUiState();
+            renderAnalyticsCategorySummary(ctx);
+        };
+    });
+  }
+
+  function renderAnalyticsMomentumTable(ctx) {
+    const table = document.getElementById('analytics-category-momentum');
+    if(!table) return;
+    const { categoryStats, selectedCatIds, lastMonthSummary, prevMonthSummary, selectedMood } = ctx;
+    if(!lastMonthSummary){
+        table.innerHTML = `<tbody><tr><td class="muted" style="text-align:center;" colspan="7">Wybierz okres obejmujący co najmniej jeden miesiąc.</td></tr></tbody>`;
+        return;
+    }
+
+    const lastYm = lastMonthSummary.ym;
+    const prevYm = prevMonthSummary?.ym;
+    const rows = selectedCatIds.map(id => {
+        const stat = categoryStats[id];
+        if(!stat) return null;
+        const cat = stat.category;
+        const lastData = stat.months[lastYm] || { total:0, count:0, values:[] };
+        const prevData = prevYm ? (stat.months[prevYm] || { total:0, count:0, values:[] }) : null;
+        const avgLast = lastData.count ? lastData.total / lastData.count : 0;
+        const avgPrev = prevData && prevData.count ? prevData.total / prevData.count : 0;
+        const deltaAmount = prevData ? lastData.total - prevData.total : lastData.total;
+        const deltaPercent = prevData && prevData.total > 0 ? (deltaAmount / prevData.total) * 100 : 0;
+        const countDelta = prevData ? lastData.count - prevData.count : lastData.count;
+        const avgDelta = avgLast - avgPrev;
+        const avgDeltaPercent = avgPrev ? (avgDelta / avgPrev) * 100 : 0;
+        const volumeChange = prevData && prevData.total > 0 ? Math.abs(deltaAmount / prevData.total) : (lastData.total ? 1 : 0);
+        const countChange = prevData && prevData.count > 0 ? Math.abs(countDelta / prevData.count) : (countDelta ? 1 : 0);
+        const avgChange = avgPrev ? Math.abs(avgDelta / avgPrev) : (avgLast ? 1 : 0);
+        let comment = 'Stabilnie';
+        if(!prevData || (prevData.total === 0 && prevData.count === 0)) {
+            comment = deltaAmount > 0 ? 'Nowa aktywność' : 'Brak danych porównawczych';
+        } else if(volumeChange < 0.05 && countChange < 0.05) {
+            comment = 'Stabilnie';
+        } else if(countChange > avgChange * 1.2) {
+            comment = deltaAmount >= 0 ? 'Wzrost liczby transakcji' : 'Spadek liczby transakcji';
+        } else if(avgChange > countChange * 1.2) {
+            comment = deltaAmount >= 0 ? 'Wyższe kwoty' : 'Niższe kwoty';
+        } else {
+            comment = deltaAmount >= 0 ? 'Wzrost mieszany' : 'Spadek mieszany';
+        }
+        return { cat, lastData, prevData, avgLast, avgPrev, deltaAmount, deltaPercent, countDelta, avgDelta, avgDeltaPercent, type: cat?.type || selectedMood, comment };
+    }).filter(Boolean);
+
+    if(rows.length === 0){
+        table.innerHTML = `<tbody><tr><td class="muted" style="text-align:center;" colspan="7">Brak danych do porównania.</td></tr></tbody>`;
+        return;
+    }
+
+    let header = '<thead><tr><th>Kategoria</th><th>Ostatni miesiąc</th><th>Poprzedni miesiąc</th><th>Δ suma</th><th>Δ liczby</th><th>Δ średniej</th><th>Komentarz</th></tr></thead>';
+    let body = '<tbody>';
+    rows.forEach(row => {
+        const cat = row.cat;
+        const lastCell = `${fmt(row.lastData.total, state.currency)}<br><span class="tiny muted">${row.lastData.count} × ${fmt(row.avgLast, state.currency)}</span>`;
+        let prevCell = '<span class="muted">—</span>';
+        if(row.prevData){
+            if(row.prevData.total > 0){
+                prevCell = `${fmt(row.prevData.total, state.currency)}<br><span class="tiny muted">${row.prevData.count} × ${fmt(row.avgPrev, state.currency)}</span>`;
+            } else {
+                prevCell = '<span class="muted">—</span>';
+            }
+        }
+        body += `<tr>
+            <td>${cat?.emoji||''} ${cat?.name||'—'}</td>
+            <td>${lastCell}</td>
+            <td>${prevCell}</td>
+            <td>${formatTrend(row.deltaAmount, row.deltaPercent, row.type)}</td>
+            <td>${formatCountTrend(row.countDelta, row.prevData?.count || 0, row.type)}</td>
+            <td>${formatTrend(row.avgDelta, row.avgDeltaPercent, row.type)}</td>
+            <td>${row.comment}</td>
+        </tr>`;
+    });
+    body += '</tbody>';
+    table.innerHTML = header + body;
+  }
+
+  function renderAnalyticsMonthlyBreakdown(ctx) {
+    const table = document.getElementById('analytics-monthly-breakdown');
+    if(!table) return;
+    const { monthlySummaries, selectedCatIds, categoryStats } = ctx;
+    if(!monthlySummaries || monthlySummaries.length === 0){
+        table.innerHTML = `<tbody><tr><td class="muted" style="text-align:center;" colspan="9">Brak danych do wyświetlenia.</td></tr></tbody>`;
+        return;
+    }
+
+    let header = '<thead><tr><th>Miesiąc</th><th>Przychody</th><th>Wydatki (wszystkie)</th><th>Wybrane kategorie</th><th>Liczba transakcji</th><th>Średnia</th><th>Mediana</th><th>Top kategoria</th><th>Bilans</th></tr></thead>';
+    let body = '<tbody>';
+    monthlySummaries.forEach(summary => {
+        const top = selectedCatIds.map(id => ({ id, total: summary.byCategory[id]?.total || 0, count: summary.byCategory[id]?.count || 0 })).sort((a,b)=>b.total - a.total)[0];
+        let topCell = '<span class="muted">—</span>';
+        if(top && top.total > 0){
+            const stat = categoryStats[top.id];
+            const cat = stat?.category;
+            const share = summary.selectedTotal > 0 ? (top.total / summary.selectedTotal) * 100 : 0;
+            topCell = `${cat?.emoji||''} ${cat?.name||'—'}<br><span class="tiny muted">${fmt(top.total, state.currency)} (${share.toFixed(1)}%)</span>`;
+        }
+        const net = summary.incomes - summary.expenses;
+        body += `<tr>
+            <td>${summary.ym}</td>
+            <td>${fmt(summary.incomes, state.currency)}</td>
+            <td>${fmt(summary.expenses, state.currency)}</td>
+            <td>${fmt(summary.selectedTotal, state.currency)}</td>
+            <td>${summary.selectedCount}</td>
+            <td>${fmt(summary.selectedAvg || 0, state.currency)}</td>
+            <td>${fmt(summary.selectedMedian || 0, state.currency)}</td>
+            <td>${topCell}</td>
+            <td class="${net >= 0 ? 'ok' : 'bad'}">${fmt(net, state.currency)}</td>
+        </tr>`;
+    });
+    body += '</tbody>';
+    table.innerHTML = header + body;
+  }
+
+  function renderAnalyticsTopTransactions(ctx) {
       const table = document.getElementById('analytics-top-transactions');
-      const tbody = table.querySelector('tbody') || document.createElement('tbody');
+      if(!table) return;
+      const tbody = document.createElement('tbody');
       table.innerHTML = `<thead><tr><th>Data</th><th>Kategoria</th><th>Kwota</th><th>Notatka</th></tr></thead>`;
       table.appendChild(tbody);
-      
-      const selectedCatIds = Array.from(document.querySelectorAll('.analytics-cat-filter-cb:checked')).map(cb => cb.value);
-    
-      const flattenedExpenses = [];
-      allEntries.forEach(tx => {
-        const processEntry = (entry, categoryId, amount, note) => {
-            if (selectedCatIds.length > 0 && !selectedCatIds.includes(categoryId)) return;
-            const cat = catsById()[categoryId];
-            if(cat && (cat.type === 'expense' || cat.type === 'saving')){
-                flattenedExpenses.push({ date: entry.date, categoryId, amount: -Math.abs(num(amount)), note });
-            }
+
+      const selectedSet = new Set(ctx.selectedCatIds);
+      const catsMap = catsById();
+
+      const flattened = [];
+      (ctx.allEntriesInPeriod || []).forEach(tx => {
+        const processEntry = (entry, categoryId, rawAmount, note) => {
+            const cat = catsMap[categoryId];
+            if(!cat || (cat.type !== 'expense' && cat.type !== 'saving')) return;
+            if(selectedSet.size > 0 && !selectedSet.has(categoryId)) return;
+            const amount = Math.abs(num(rawAmount));
+            if(amount <= 0) return;
+            flattened.push({ date: entry.date, categoryId, amount, note: note || '' });
         };
 
         if(tx.splits && tx.splits.length > 0) {
-            tx.splits.forEach(split => {
-                processEntry(tx, split.categoryId, split.amount, tx.note);
-            });
+            tx.splits.forEach(split => processEntry(tx, split.categoryId, split.amount, tx.note));
         } else {
-            processEntry(tx, tx.categoryId, Math.abs(tx.amount), tx.note);
+            processEntry(tx, tx.categoryId, tx.amount, tx.note);
         }
       });
 
-      const top10 = flattenedExpenses.sort((a,b) => a.amount - b.amount).slice(0, 10);
-      
+      const top10 = flattened.sort((a,b) => b.amount - a.amount).slice(0, 10);
+
       if (top10.length === 0) {
           tbody.innerHTML = `<tr><td colspan="4" class="muted" style="text-align:center;">Brak wydatków w wybranych kategoriach w tym okresie.</td></tr>`;
           return;
       }
-      
+
       tbody.innerHTML = top10.map(e => {
-          const cat = catsById()[e.categoryId];
+          const cat = catsMap[e.categoryId];
+          const cls = cat?.type === 'saving' ? 'ok' : 'bad';
           return `
               <tr>
                   <td>${e.date}</td>
                   <td>${cat ? (cat.emoji||'') + ' ' + cat.name : '—'}</td>
-                  <td class="bad">${fmt(e.amount, state.currency)}</td>
+                  <td class="${cls}">${fmt(e.amount, state.currency)}</td>
                   <td>${e.note || '—'}</td>
               </tr>
           `;

--- a/budget.html
+++ b/budget.html
@@ -87,6 +87,9 @@
     .inventory-table tbody td:first-child b{font-size:13px}
     .inventory-table tbody td .muted{font-size:11px}
     .inventory-table-actions .btn{padding:6px 10px;font-size:12px;border-radius:10px}
+    .inventory-plan-cell{min-width:200px}
+    .inventory-plan-input{width:100%;padding:6px 8px;border:1px solid var(--line);border-radius:8px;font-size:12px;background:#fff;min-width:0}
+    .inventory-plan-summary{margin-top:4px;font-size:11px;line-height:1.4;display:flex;flex-direction:column;gap:2px}
     .delta-up{color:var(--green);font-weight:600}
     .delta-down{color:var(--red);font-weight:600}
     .delta-neutral{color:var(--muted);font-weight:500}
@@ -717,6 +720,11 @@
           <div class="value" id="inv-kpi-stock-worth">—</div>
           <div class="sub" id="inv-kpi-stock-worth-sub">Śr. koszt i czas w magazynie</div>
         </div>
+        <div class="kpi-card light">
+          <div class="label">Planowana sprzedaż</div>
+          <div class="value" id="inv-kpi-plan-worth">—</div>
+          <div class="sub" id="inv-kpi-plan-extra">Brak planów sprzedaży</div>
+        </div>
         <div class="kpi-card">
           <div class="label">Sprzedane pozycje</div>
           <div class="value" id="inv-kpi-sold-count">0</div>
@@ -731,8 +739,8 @@
 
       <form id="inv-import-form" class="inventory-import" style="display:none">
         <h4 class="title" style="font-size:16px;margin:0 0 4px 0">Szybki import / wklejka</h4>
-        <p class="hint">Wklej dane w formacie: marka;model;rozmiar;kwota;data (opcjonalnie). Możesz też użyć CSV lub danych z Excela.</p>
-        <textarea id="inv-import-input" placeholder="Nike;Air Max 1;44;320;2024-05-10&#10;Adidas;Campus 00s;43;280"></textarea>
+        <p class="hint">Wklej dane w formacie: marka;model;rozmiarEU;rozmiarUS;kwota;data;notatka. Możesz pominąć rozmiary lub użyć starego układu z jednym polem rozmiaru.</p>
+        <textarea id="inv-import-input" placeholder="Nike;Air Max 1;44;10;320;2024-05-10&#10;Adidas;Campus 00s;;11;280"></textarea>
         <div class="row" style="justify-content:flex-end;gap:8px;margin-top:8px">
           <button class="btn ghost" type="button" id="inv-import-cancel">Anuluj</button>
           <button class="btn" type="submit">Dodaj pozycje</button>
@@ -750,7 +758,9 @@
         <form id="inv-add-form" class="grid g-4" style="margin-top:12px">
           <label class="tiny">Marka<input name="brand" placeholder="np. Nike" required /></label>
           <label class="tiny">Model<input name="model" placeholder="np. Air Max 1" required /></label>
-          <label class="tiny">Rozmiar<input name="size" placeholder="np. 44 EU" /></label>
+          <label class="tiny">Rozmiar EU<input name="sizeEu" placeholder="np. 44" /></label>
+          <label class="tiny">Rozmiar US<input name="sizeUs" placeholder="np. 10" /></label>
+          <label class="tiny">Dodatkowy opis rozmiaru<input name="size" placeholder="np. 29 cm, M" /></label>
           <label class="tiny">Data zakupu<input name="purchaseDate" type="date" /></label>
           <label class="tiny">Kwota zakupu (PLN)<input name="purchasePrice" inputmode="decimal" placeholder="0,00" required /></label>
           <label class="tiny" style="grid-column:1 / -1">Notatka / źródło<input name="purchaseNote" placeholder="np. Allegro, outlet" /></label>
@@ -762,6 +772,8 @@
         <div class="grid g-4" style="gap:8px">
           <input id="inv-search" placeholder="Szukaj po marce lub modelu" />
           <select id="inv-filter-brand"></select>
+          <select id="inv-filter-size-eu"></select>
+          <select id="inv-filter-size-us"></select>
           <select id="inv-filter-size"></select>
           <select id="inv-sort">
             <option value="newest">Najnowsze</option>
@@ -770,6 +782,8 @@
             <option value="priceAsc">Najtańsze (zakup)</option>
             <option value="convertedDesc">Najwyższa wycena</option>
             <option value="convertedAsc">Najniższa wycena</option>
+            <option value="planDesc">Najwyższa cena planowana</option>
+            <option value="planAsc">Najniższa cena planowana</option>
             <option value="brandAsc">Marka A→Z</option>
             <option value="brandDesc">Marka Z→A</option>
             <option value="ageDesc">Najdłużej na stanie</option>
@@ -796,6 +810,7 @@
                 <th data-sort="product"><span class="th-label">Produkt<span class="sort-indicator"></span></span></th>
                 <th data-sort="purchase"><span class="th-label">Zakup (PLN)<span class="sort-indicator"></span></span></th>
                 <th data-sort="converted"><span class="th-label">Wycena (<span data-inv-currency-label>PLN</span>)<span class="sort-indicator"></span></span></th>
+                <th data-sort="plan"><span class="th-label">Plan sprzedaży (<span data-inv-currency-label>PLN</span>)<span class="sort-indicator"></span></span></th>
                 <th data-sort="age"><span class="th-label">Dni w magazynie<span class="sort-indicator"></span></span></th>
                 <th data-sort="note"><span class="th-label">Notatki<span class="sort-indicator"></span></span></th>
                 <th><span class="th-label">Akcje</span></th>
@@ -931,15 +946,24 @@
       const purchasePrice = num(item?.purchasePrice);
       const purchaseDate = typeof item?.purchaseDate === 'string' ? item.purchaseDate : '';
       const createdAt = item?.createdAt || purchaseDate || fallbackDate;
+      const planRaw = num(item?.planPricePln ?? item?.planPrice);
+      const normalizedPlan = Number.isFinite(planRaw) && planRaw > 0 ? planRaw : null;
+      const planCurrencyRaw = item?.planCurrency ? String(item.planCurrency).toUpperCase() : 'PLN';
+      const allowedPlanCurrency = ['PLN','EUR','USD'];
       return {
         id,
         brand: item?.brand ? String(item.brand) : '',
         model: item?.model ? String(item.model) : '',
         size: item?.size ? String(item.size) : '',
+        sizeEu: item?.sizeEu ? String(item.sizeEu) : '',
+        sizeUs: item?.sizeUs ? String(item.sizeUs) : '',
         purchasePrice,
         purchaseCurrency: 'PLN',
         purchaseDate,
         purchaseNote: item?.purchaseNote ? String(item.purchaseNote) : '',
+        planPricePln: normalizedPlan,
+        planCurrency: allowedPlanCurrency.includes(planCurrencyRaw) ? planCurrencyRaw : 'PLN',
+        planUpdatedAt: item?.planUpdatedAt || null,
         createdAt
       };
     };
@@ -949,11 +973,17 @@
       const salePricePln = num(item?.salePricePln || item?.salePrice);
       const saleFees = num(item?.saleFees);
       const pnlCalculated = salePricePln - purchasePrice - saleFees;
+      const allowedPlanCurrency = ['PLN','EUR','USD'];
+      const planRaw = num(item?.planPricePln ?? item?.planPrice);
+      const normalizedPlan = Number.isFinite(planRaw) && planRaw > 0 ? planRaw : null;
+      const planCurrencyRaw = item?.planCurrency ? String(item.planCurrency).toUpperCase() : 'PLN';
       return {
         id,
         brand: item?.brand ? String(item.brand) : '',
         model: item?.model ? String(item.model) : '',
         size: item?.size ? String(item.size) : '',
+        sizeEu: item?.sizeEu ? String(item.sizeEu) : '',
+        sizeUs: item?.sizeUs ? String(item.sizeUs) : '',
         purchasePrice,
         purchaseCurrency: 'PLN',
         purchaseDate: typeof item?.purchaseDate === 'string' ? item.purchaseDate : '',
@@ -965,6 +995,9 @@
         saleNote: item?.saleNote ? String(item.saleNote) : '',
         salePricePln,
         pnlPln: Number.isFinite(num(item?.pnlPln)) ? num(item.pnlPln) : pnlCalculated,
+        planPricePln: normalizedPlan,
+        planCurrency: allowedPlanCurrency.includes(planCurrencyRaw) ? planCurrencyRaw : 'PLN',
+        planUpdatedAt: item?.planUpdatedAt || null,
         soldAt: item?.soldAt || item?.saleDate || fallbackDate
       };
     };
@@ -1000,6 +1033,8 @@
     if(typeof invUi.searchTerm!=='string') invUi.searchTerm='';
     if(typeof invUi.brandFilter!=='string') invUi.brandFilter='';
     if(typeof invUi.sizeFilter!=='string') invUi.sizeFilter='';
+    if(typeof invUi.sizeEuFilter!=='string') invUi.sizeEuFilter='';
+    if(typeof invUi.sizeUsFilter!=='string') invUi.sizeUsFilter='';
     if(typeof invUi.sortMode!=='string') invUi.sortMode='newest';
     if(typeof invUi.showImport!=='boolean') invUi.showImport=false;
     return st;
@@ -1028,7 +1063,7 @@
           items:[],
           sold:[],
           rates:{base:'PLN',fetchedAt:null,rates:{}},
-          ui:{selectedCurrency:'PLN',searchTerm:'',brandFilter:'',sizeFilter:'',sortMode:'newest',showImport:false}
+          ui:{selectedCurrency:'PLN',searchTerm:'',brandFilter:'',sizeFilter:'',sizeEuFilter:'',sizeUsFilter:'',sortMode:'newest',showImport:false}
         }
       }}
     });
@@ -2674,7 +2709,7 @@
     const section=tab('inventory');
     if(!section) return;
     const inventoryState=inv();
-    const ui=inventoryState.ui || (inventoryState.ui={selectedCurrency:'PLN',searchTerm:'',brandFilter:'',sizeFilter:'',sortMode:'newest',showImport:false});
+    const ui=inventoryState.ui || (inventoryState.ui={selectedCurrency:'PLN',searchTerm:'',brandFilter:'',sizeFilter:'',sizeEuFilter:'',sizeUsFilter:'',sortMode:'newest',showImport:false});
     let selectedCurrency=(ui.selectedCurrency||'PLN').toUpperCase();
     if(!INVENTORY_SUPPORTED_CURRENCIES.includes(selectedCurrency)) selectedCurrency='PLN';
     ui.selectedCurrency=selectedCurrency;
@@ -2684,11 +2719,17 @@
     const search=(ui.searchTerm||'').toLowerCase();
     const brandOptions=Array.from(new Set(items.map(it=>(it.brand||'').trim()).filter(Boolean))).sort((a,b)=>a.localeCompare(b,'pl',{sensitivity:'base'}));
     const sizeOptions=Array.from(new Set(items.map(it=>(it.size||'').trim()).filter(Boolean))).sort((a,b)=>a.localeCompare(b,'pl',{numeric:true,sensitivity:'base'}));
+    const sizeEuOptions=Array.from(new Set(items.map(it=>(it.sizeEu||'').trim()).filter(Boolean))).sort((a,b)=>a.localeCompare(b,'pl',{numeric:true,sensitivity:'base'}));
+    const sizeUsOptions=Array.from(new Set(items.map(it=>(it.sizeUs||'').trim()).filter(Boolean))).sort((a,b)=>a.localeCompare(b,'pl',{numeric:true,sensitivity:'base'}));
     if(ui.brandFilter && !brandOptions.includes(ui.brandFilter)) ui.brandFilter='';
     if(ui.sizeFilter && !sizeOptions.includes(ui.sizeFilter)) ui.sizeFilter='';
+    if(ui.sizeEuFilter && !sizeEuOptions.includes(ui.sizeEuFilter)) ui.sizeEuFilter='';
+    if(ui.sizeUsFilter && !sizeUsOptions.includes(ui.sizeUsFilter)) ui.sizeUsFilter='';
     const brandFilter=ui.brandFilter||'';
     const sizeFilter=ui.sizeFilter||'';
-    const allowedSortModes=new Set(['newest','oldest','priceDesc','priceAsc','brandAsc','brandDesc','convertedDesc','convertedAsc','ageDesc','ageAsc','noteDesc','noteAsc']);
+    const sizeEuFilter=ui.sizeEuFilter||'';
+    const sizeUsFilter=ui.sizeUsFilter||'';
+    const allowedSortModes=new Set(['newest','oldest','priceDesc','priceAsc','brandAsc','brandDesc','convertedDesc','convertedAsc','planAsc','planDesc','ageDesc','ageAsc','noteDesc','noteAsc']);
     let sortMode=ui.sortMode||'newest';
     if(sortMode==='brand') sortMode='brandAsc';
     if(sortMode==='age') sortMode='ageDesc';
@@ -2701,6 +2742,8 @@
       if(search && !combined.includes(search)) return false;
       if(brandFilter && (item.brand||'')!==brandFilter) return false;
       if(sizeFilter && (item.size||'')!==sizeFilter) return false;
+      if(sizeEuFilter && (item.sizeEu||'')!==sizeEuFilter) return false;
+      if(sizeUsFilter && (item.sizeUs||'')!==sizeUsFilter) return false;
       return true;
     });
     const visible=[...filtered];
@@ -2713,12 +2756,23 @@
       if(!computeCache.has(item.id)){
         const purchase=num(item.purchasePrice);
         const rawConverted=selectedCurrency==='PLN'?purchase:convertBetweenCurrencies(purchase,'PLN',selectedCurrency);
+        const planPlnRaw=num(item.planPricePln);
+        const planPln=Number.isFinite(planPlnRaw)&&planPlnRaw>0?planPlnRaw:null;
+        const planConverted=planPln!==null?(selectedCurrency==='PLN'?planPln:convertBetweenCurrencies(planPln,'PLN',selectedCurrency)):null;
+        const planPnl=planPln!==null&&Number.isFinite(purchase)?planPln-purchase:null;
+        const planPnlConverted=planPnl!==null?(selectedCurrency==='PLN'?planPnl:convertBetweenCurrencies(planPnl,'PLN',selectedCurrency)):null;
+        const planRoi=planPnl!==null&&Number.isFinite(purchase)&&purchase!==0?((planPnl/purchase)*100):null;
         computeCache.set(item.id,{
           purchase:Number.isFinite(purchase)?purchase:null,
           converted:Number.isFinite(rawConverted)?rawConverted:null,
           age:inventoryDaysBetween(item.purchaseDate,today),
           product:`${item.brand||''} ${item.model||''}`.trim(),
-          note:(item.purchaseNote||'').trim()
+          note:(item.purchaseNote||'').trim(),
+          planPln,
+          planConverted:Number.isFinite(planConverted)?planConverted:null,
+          planPnl:Number.isFinite(planPnl)?planPnl:null,
+          planPnlConverted:Number.isFinite(planPnlConverted)?planPnlConverted:null,
+          planRoi:Number.isFinite(planRoi)?planRoi:null
         });
       }
       return computeCache.get(item.id);
@@ -2769,6 +2823,12 @@
       case 'convertedAsc':
         visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).converted,getMeta(b).converted,1)));
         break;
+      case 'planDesc':
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).planConverted,getMeta(b).planConverted,-1)));
+        break;
+      case 'planAsc':
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).planConverted,getMeta(b).planConverted,1)));
+        break;
       case 'ageDesc':
         visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).age,getMeta(b).age,-1)));
         break;
@@ -2790,6 +2850,7 @@
       product:['brandAsc','brandDesc'],
       purchase:['priceAsc','priceDesc'],
       converted:['convertedAsc','convertedDesc'],
+      plan:['planAsc','planDesc'],
       age:['ageAsc','ageDesc'],
       note:['noteAsc','noteDesc']
     };
@@ -2840,6 +2901,34 @@
     const filteredAgeArr=filtered.map(it=>inventoryDaysBetween(it.purchaseDate,today)).filter(v=>v!==null);
     const filteredAvgAge=filteredAgeArr.length?filteredAgeArr.reduce((a,b)=>a+b,0)/filteredAgeArr.length:null;
 
+    let plannedCountAll=0;
+    let totalPlanValueAll=0;
+    let totalPlanPurchaseAll=0;
+    let totalPlanPnlAll=0;
+    for(const item of items){
+      const planVal=Number(item.planPricePln);
+      if(!Number.isFinite(planVal) || planVal<=0) continue;
+      plannedCountAll++;
+      const purchaseVal=num(item.purchasePrice);
+      totalPlanValueAll+=planVal;
+      totalPlanPurchaseAll+=purchaseVal;
+      totalPlanPnlAll+=planVal-purchaseVal;
+    }
+    const totalPlanConvertedAll=convertBetweenCurrencies(totalPlanValueAll,'PLN',selectedCurrency);
+    const totalPlanPnlConvertedAll=convertBetweenCurrencies(totalPlanPnlAll,'PLN',selectedCurrency);
+    const planRoiAll=totalPlanPurchaseAll>0?((totalPlanPnlAll/totalPlanPurchaseAll)*100):null;
+
+    let plannedCountFiltered=0;
+    let totalPlanPnlFiltered=0;
+    for(const item of filtered){
+      const planVal=Number(item.planPricePln);
+      if(!Number.isFinite(planVal) || planVal<=0) continue;
+      plannedCountFiltered++;
+      const purchaseVal=num(item.purchasePrice);
+      totalPlanPnlFiltered+=planVal-purchaseVal;
+    }
+    const totalPlanPnlConvertedFiltered=convertBetweenCurrencies(totalPlanPnlFiltered,'PLN',selectedCurrency);
+
     const totalSoldPurchase=sold.reduce((sum,it)=>sum+num(it.purchasePrice),0);
     const totalSoldRevenue=sold.reduce((sum,it)=>sum+num(it.salePricePln),0);
     const totalSoldPnl=sold.reduce((sum,it)=>sum+num(it.pnlPln),0);
@@ -2869,6 +2958,23 @@
       }
       const avgAgeText=avgStockAge!==null?`${avgStockAge.toFixed(0)} dni`:'—';
       stockWorthSub.textContent=`${avgCostText} • Śr. czas w magazynie: ${avgAgeText}`;
+    }
+    const planWorthEl=document.getElementById('inv-kpi-plan-worth');
+    if(planWorthEl){
+      if(plannedCountAll===0) planWorthEl.textContent='—';
+      else if(selectedCurrency==='PLN' || totalPlanConvertedAll===null) planWorthEl.textContent=fmt(totalPlanValueAll,state.currency);
+      else planWorthEl.textContent=`${fmt(totalPlanConvertedAll,displayCurrency)} (${fmt(totalPlanValueAll,state.currency)})`;
+    }
+    const planExtraEl=document.getElementById('inv-kpi-plan-extra');
+    if(planExtraEl){
+      if(plannedCountAll===0){
+        planExtraEl.textContent='Brak planów sprzedaży';
+      }else{
+        const pnlBase=fmt(totalPlanPnlAll,state.currency);
+        const pnlExtra=(selectedCurrency!=='PLN' && totalPlanPnlConvertedAll!==null)?` / ${fmt(totalPlanPnlConvertedAll,displayCurrency)}`:'';
+        const roiText=planRoiAll!==null?`${planRoiAll>=0?'+':''}${planRoiAll.toFixed(1)}%`:'—';
+        planExtraEl.textContent=`PnL potencjał: ${pnlBase}${pnlExtra} • Pozycje: ${plannedCountAll} • ROI: ${roiText}`;
+      }
     }
     const soldCountEl=document.getElementById('inv-kpi-sold-count');
     if(soldCountEl) soldCountEl.textContent=sold.length;
@@ -2951,6 +3057,11 @@
       text+=` • Koszt: ${fmt(filteredCost,state.currency)}`;
       if(selectedCurrency!=='PLN' && filteredConverted!==null) text+=` (${fmt(filteredConverted,displayCurrency)})`;
       if(filteredAvgAge!==null) text+=` • Śr. czas: ${filteredAvgAge.toFixed(0)} dni`;
+      if(plannedCountFiltered>0){
+        const planPnlBase=fmt(totalPlanPnlFiltered,state.currency);
+        const planPnlExtra=(selectedCurrency!=='PLN' && totalPlanPnlConvertedFiltered!==null)?` (${fmt(totalPlanPnlConvertedFiltered,displayCurrency)})`:'';
+        text+=` • Plan PnL: ${planPnlBase}${planPnlExtra}`;
+      }
       summaryEl.textContent=text;
     }
 
@@ -2981,9 +3092,37 @@
       }
     }
 
+    const sizeEuSelect=document.getElementById('inv-filter-size-eu');
+    if(sizeEuSelect){
+      sizeEuSelect.innerHTML='<option value="">Rozmiar EU (wszystkie)</option>'+sizeEuOptions.map(s=>`<option value="${s}">EU ${s}</option>`).join('');
+      sizeEuSelect.value=sizeEuFilter;
+      if(!sizeEuSelect.dataset.bound){
+        sizeEuSelect.dataset.bound='1';
+        sizeEuSelect.onchange=e=>{
+          inv().ui.sizeEuFilter=e.target.value;
+          save(state);
+          renderInventory();
+        };
+      }
+    }
+
+    const sizeUsSelect=document.getElementById('inv-filter-size-us');
+    if(sizeUsSelect){
+      sizeUsSelect.innerHTML='<option value="">Rozmiar US (wszystkie)</option>'+sizeUsOptions.map(s=>`<option value="${s}">US ${s}</option>`).join('');
+      sizeUsSelect.value=sizeUsFilter;
+      if(!sizeUsSelect.dataset.bound){
+        sizeUsSelect.dataset.bound='1';
+        sizeUsSelect.onchange=e=>{
+          inv().ui.sizeUsFilter=e.target.value;
+          save(state);
+          renderInventory();
+        };
+      }
+    }
+
     const sizeSelect=document.getElementById('inv-filter-size');
     if(sizeSelect){
-      sizeSelect.innerHTML='<option value="">Wszystkie rozmiary</option>'+sizeOptions.map(s=>`<option value="${s}">${s}</option>`).join('');
+      sizeSelect.innerHTML='<option value="">Pozostałe rozmiary</option>'+sizeOptions.map(s=>`<option value="${s}">${s}</option>`).join('');
       sizeSelect.value=sizeFilter;
       if(!sizeSelect.dataset.bound){
         sizeSelect.dataset.bound='1';
@@ -3015,6 +3154,8 @@
         inv().ui.searchTerm='';
         inv().ui.brandFilter='';
         inv().ui.sizeFilter='';
+        inv().ui.sizeEuFilter='';
+        inv().ui.sizeUsFilter='';
         inv().ui.sortMode='newest';
         save(state);
         renderInventory();
@@ -3062,6 +3203,8 @@
         const data=new FormData(addForm);
         const brand=String(data.get('brand')||'').trim();
         const model=String(data.get('model')||'').trim();
+        const sizeEu=String(data.get('sizeEu')||'').trim();
+        const sizeUs=String(data.get('sizeUs')||'').trim();
         const size=String(data.get('size')||'').trim();
         const purchaseDate=String(data.get('purchaseDate')||'').trim();
         const price=num(data.get('purchasePrice'));
@@ -3070,17 +3213,22 @@
           alert('Podaj markę, model i kwotę zakupu.');
           return;
         }
-        inventoryState.items.unshift({
-          id:'inv_'+Math.random().toString(36).slice(2),
-          brand,
-          model,
-          size,
-          purchasePrice:price,
-          purchaseCurrency:'PLN',
-          purchaseDate:purchaseDate||'',
-          purchaseNote:note,
-          createdAt:purchaseDate||new Date().toISOString()
-        });
+          inventoryState.items.unshift({
+            id:'inv_'+Math.random().toString(36).slice(2),
+            brand,
+            model,
+            sizeEu,
+            sizeUs,
+            size,
+            purchasePrice:price,
+            purchaseCurrency:'PLN',
+            purchaseDate:purchaseDate||'',
+            purchaseNote:note,
+            planPricePln:null,
+            planCurrency:inventoryState.ui?.selectedCurrency||'PLN',
+            planUpdatedAt:null,
+            createdAt:purchaseDate||new Date().toISOString()
+          });
         save(state);
         addForm.reset();
         renderInventory();
@@ -3101,19 +3249,55 @@
           if(!clean) continue;
           const parts=clean.split(/[,;\t]/).map(p=>p.trim());
           if(parts.length<4) continue;
-          const [brand,model,size,priceStr,...rest]=parts;
+          const brand=parts[0];
+          const model=parts[1];
+          let sizeEu='';
+          let sizeUs='';
+          let size='';
+          let priceStr='';
+          let extras=[];
+          if(parts.length>=5){
+            sizeEu=parts[2]||'';
+            sizeUs=parts[3]||'';
+            priceStr=parts[4]||'';
+            extras=parts.slice(5);
+          }else{
+            size=parts[2]||'';
+            priceStr=parts[3]||'';
+            extras=parts.slice(4);
+          }
           const price=num(priceStr);
           if(!brand || !model || !price) continue;
-          const dateCandidate = rest[0] && /^\d{4}-\d{2}-\d{2}$/.test(rest[0]) ? rest[0] : '';
+          let dateCandidate='';
+          if(extras.length){
+            const firstExtra=extras[0];
+            if(/^\d{4}-\d{2}-\d{2}$/.test(firstExtra)){
+              dateCandidate=firstExtra;
+              extras=extras.slice(1);
+            }
+          }
+          if(!size && extras.length){
+            const possibleSize=extras[0];
+            if(!/^\d{4}-\d{2}-\d{2}$/.test(possibleSize)){
+              size=possibleSize;
+              extras=extras.slice(1);
+            }
+          }
+          const note=extras.filter(Boolean).join(' ');
           inventoryState.items.unshift({
             id:'inv_'+Math.random().toString(36).slice(2),
             brand,
             model,
             size:size||'',
+            sizeEu:sizeEu||'',
+            sizeUs:sizeUs||'',
             purchasePrice:price,
             purchaseCurrency:'PLN',
             purchaseDate:dateCandidate,
-            purchaseNote:'',
+            purchaseNote:note,
+            planPricePln:null,
+            planCurrency:inventoryState.ui?.selectedCurrency||'PLN',
+            planUpdatedAt:null,
             createdAt:dateCandidate||new Date().toISOString()
           });
           added++;
@@ -3184,12 +3368,12 @@
     if(exportBtn && !exportBtn.dataset.bound){
       exportBtn.dataset.bound='1';
       exportBtn.onclick=()=>{
-        const rows=[['status','brand','model','size','purchasePricePLN','purchaseDate','salePrice','saleCurrency','saleDate','saleFees','pnlPLN']];
+        const rows=[['status','brand','model','size','sizeEu','sizeUs','purchasePricePLN','purchaseDate','planPricePLN','salePrice','saleCurrency','saleDate','saleFees','pnlPLN']];
         for(const item of items){
-          rows.push(['active', item.brand||'', item.model||'', item.size||'', num(item.purchasePrice), item.purchaseDate||'', '', '', '', '', '']);
+          rows.push(['active', item.brand||'', item.model||'', item.size||'', item.sizeEu||'', item.sizeUs||'', num(item.purchasePrice), item.purchaseDate||'', item.planPricePln??'', '', '', '', '', '']);
         }
         for(const item of sold){
-          rows.push(['sold', item.brand||'', item.model||'', item.size||'', num(item.purchasePrice), item.purchaseDate||'', num(item.salePrice), item.saleCurrency||'PLN', item.saleDate||'', num(item.saleFees), num(item.pnlPln)]);
+          rows.push(['sold', item.brand||'', item.model||'', item.size||'', item.sizeEu||'', item.sizeUs||'', num(item.purchasePrice), item.purchaseDate||'', item.planPricePln??'', num(item.salePrice), item.saleCurrency||'PLN', item.saleDate||'', num(item.saleFees), num(item.pnlPln)]);
         }
         const csv=rows.map(row=>row.map(value=>`"${String(value??'').replace(/"/g,'""')}"`).join(';')).join('\n');
         const blob=new Blob([csv],{type:'text/csv;charset=utf-8;'});
@@ -3208,7 +3392,7 @@
       activeBody.innerHTML='';
       if(!visible.length){
         const tr=document.createElement('tr');
-        tr.innerHTML='<td colspan="6" class="inventory-empty">Brak pozycji spełniających warunki.</td>';
+        tr.innerHTML='<td colspan="7" class="inventory-empty">Brak pozycji spełniających warunki.</td>';
         activeBody.appendChild(tr);
       }else{
         const todayStr=new Date().toISOString().slice(0,10);
@@ -3223,13 +3407,40 @@
             ? fmt(purchaseValue,displayCurrency)
             : (convertedValue!==null?fmt(convertedValue,displayCurrency):'<span class="muted">Brak kursu</span>');
           const ageLabel=ageValue!==null?`${Math.round(ageValue)} dni`:'—';
-          const sizeLabel=item.size?` • Rozmiar: ${item.size}`:'';
+          const sizeParts=[];
+          if((item.sizeEu||'').trim()) sizeParts.push(`EU ${item.sizeEu}`);
+          if((item.sizeUs||'').trim()) sizeParts.push(`US ${item.sizeUs}`);
+          if((item.size||'').trim()) sizeParts.push(item.size);
+          const sizeInfo=sizeParts.length?`<div class="tiny muted">Rozmiary: ${sizeParts.join(' / ')}</div>`:'';
+          const planPln=meta.planPln;
+          const planConverted=meta.planConverted;
+          const planPnlVal=meta.planPnl;
+          const planPnlConverted=meta.planPnlConverted;
+          const planRoiVal=meta.planRoi;
+          const planInputBase=selectedCurrency==='PLN'?planPln:(planConverted!==null?planConverted:null);
+          const planInputValue=planInputBase!==null?String(planInputBase.toFixed(2)).replace('.',','):'';
+          let planMainText;
+          if(planPln!==null){
+            if(selectedCurrency==='PLN') planMainText=`Plan: ${fmt(planPln,state.currency)}`;
+            else if(planConverted!==null) planMainText=`Plan: ${fmt(planConverted,displayCurrency)} (${fmt(planPln,state.currency)})`;
+            else planMainText=`Plan: ${fmt(planPln,state.currency)} (brak kursu ${selectedCurrency})`;
+          }else{
+            planMainText='Brak planu';
+          }
+          const planMainClass=planPln!==null?'':'muted';
+          let planPnlHtml='';
+          if(planPnlVal!==null){
+            const pnlExtra=(selectedCurrency!=='PLN' && planPnlConverted!==null)?` (${fmt(planPnlConverted,displayCurrency)})`:'';
+            const roiText=planRoiVal!==null?` • ROI: ${planRoiVal>=0?'+':''}${planRoiVal.toFixed(1)}%`:'';
+            planPnlHtml=`<span class="${planPnlVal>=0?'ok':'bad'}">PnL: ${fmt(planPnlVal,state.currency)}${pnlExtra}${roiText}</span>`;
+          }
           const saleOptions=INVENTORY_SUPPORTED_CURRENCIES.map(cur=>`<option value="${cur}" ${cur===selectedCurrency?'selected':''}>${cur}</option>`).join('');
           const tr=document.createElement('tr');
           tr.dataset.id=item.id;
-          tr.innerHTML=`<td><div><b>${item.brand||'—'}</b></div><div class="muted">${item.model||'—'}${sizeLabel}</div></td>
+          tr.innerHTML=`<td><div><b>${item.brand||'—'}</b></div><div class="muted">${item.model||'—'}</div>${sizeInfo}</td>
             <td><div>${fmt(item.purchasePrice,state.currency)}</div><div class="tiny">${item.purchaseDate||'—'}</div></td>
             <td>${convertedHtml}</td>
+            <td class="inventory-plan-cell"><div><input class="inventory-plan-input" data-field="planPrice" inputmode="decimal" placeholder="0,00" value="${planInputValue}" /></div><div class="inventory-plan-summary"><span class="${planMainClass}">${planMainText}</span>${planPnlHtml}</div></td>
             <td>${ageLabel}</td>
             <td>${noteHtml}</td>
             <td>
@@ -3255,7 +3466,9 @@
                 <div class="grid" style="gap:8px">
                   <label class="tiny">Marka<input data-field="brand" value="${item.brand||''}" /></label>
                   <label class="tiny">Model<input data-field="model" value="${item.model||''}" /></label>
-                  <label class="tiny">Rozmiar<input data-field="size" value="${item.size||''}" /></label>
+                  <label class="tiny">Rozmiar EU<input data-field="sizeEu" value="${item.sizeEu||''}" /></label>
+                  <label class="tiny">Rozmiar US<input data-field="sizeUs" value="${item.sizeUs||''}" /></label>
+                  <label class="tiny">Opis rozmiaru<input data-field="size" value="${item.size||''}" /></label>
                   <label class="tiny">Data zakupu<input data-field="purchaseDate" type="date" value="${item.purchaseDate||''}" /></label>
                   <label class="tiny">Kwota (PLN)<input data-field="purchasePrice" inputmode="decimal" value="${String(item.purchasePrice??'').toString().replace('.',',')}" /></label>
                   <label class="tiny" style="grid-column:1 / -1;">Notatka<input data-field="purchaseNote" value="${item.purchaseNote||''}" /></label>
@@ -3267,6 +3480,49 @@
               </div>
             </td>`;
           activeBody.appendChild(tr);
+          const planInput=tr.querySelector('[data-field="planPrice"]');
+          if(planInput){
+            planInput.addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault(); planInput.blur();}});
+            planInput.addEventListener('blur',()=>{
+              const raw=(planInput.value||'').trim();
+              if(!raw){
+                if(item.planPricePln!==null){
+                  item.planPricePln=null;
+                  item.planCurrency=selectedCurrency;
+                  item.planUpdatedAt=new Date().toISOString();
+                  save(state);
+                  renderInventory();
+                }
+                return;
+              }
+              const value=num(raw);
+              if(!value){
+                if(item.planPricePln!==null){
+                  item.planPricePln=null;
+                  item.planCurrency=selectedCurrency;
+                  item.planUpdatedAt=new Date().toISOString();
+                  save(state);
+                  renderInventory();
+                }else{
+                  planInput.value='';
+                }
+                return;
+              }
+              const plnValue=convertBetweenCurrencies(value,selectedCurrency,'PLN');
+              if(plnValue===null){
+                alert(`Brak kursu dla ${selectedCurrency}. Pobierz aktualne kursy.`);
+                renderInventory();
+                return;
+              }
+              if(item.planPricePln!==plnValue || item.planCurrency!==selectedCurrency){
+                item.planPricePln=plnValue;
+                item.planCurrency=selectedCurrency;
+                item.planUpdatedAt=new Date().toISOString();
+                save(state);
+              }
+              renderInventory();
+            });
+          }
           const sellBox=tr.querySelector('.inventory-inline[data-inline="sell"]');
           const editBox=tr.querySelector('.inventory-inline[data-inline="edit"]');
           tr.querySelector('[data-act="sell"]').onclick=()=>{
@@ -3304,6 +3560,8 @@
               brand:item.brand,
               model:item.model,
               size:item.size,
+              sizeEu:item.sizeEu,
+              sizeUs:item.sizeUs,
               purchasePrice:num(item.purchasePrice),
               purchaseCurrency:'PLN',
               purchaseDate:item.purchaseDate,
@@ -3315,6 +3573,9 @@
               saleNote:note,
               salePricePln:saleValue,
               pnlPln:pnl,
+              planPricePln:item.planPricePln??null,
+              planCurrency:item.planCurrency||'PLN',
+              planUpdatedAt:item.planUpdatedAt||null,
               soldAt:new Date().toISOString()
             });
             save(state);
@@ -3324,6 +3585,8 @@
           editBox.querySelector('[data-act="confirm-edit"]').onclick=()=>{
             const brand=editBox.querySelector('[data-field="brand"]').value.trim();
             const model=editBox.querySelector('[data-field="model"]').value.trim();
+            const sizeEu=editBox.querySelector('[data-field="sizeEu"]').value.trim();
+            const sizeUs=editBox.querySelector('[data-field="sizeUs"]').value.trim();
             const size=editBox.querySelector('[data-field="size"]').value.trim();
             const purchaseDate=editBox.querySelector('[data-field="purchaseDate"]').value;
             const purchasePrice=num(editBox.querySelector('[data-field="purchasePrice"]').value);
@@ -3331,6 +3594,8 @@
             if(!brand || !model || !purchasePrice){alert('Podaj markę, model i kwotę zakupu.');return;}
             item.brand=brand;
             item.model=model;
+            item.sizeEu=sizeEu;
+            item.sizeUs=sizeUs;
             item.size=size;
             item.purchaseDate=purchaseDate||'';
             item.purchasePrice=purchasePrice;
@@ -3362,9 +3627,14 @@
           const roiSingle=item.purchasePrice? (item.pnlPln/item.purchasePrice)*100 : null;
           const holdDays=inventoryDaysBetween(item.purchaseDate,item.saleDate||item.soldAt);
           const noteHtml=item.saleNote?item.saleNote:'<span class="muted">—</span>';
+          const sizeParts=[];
+          if((item.sizeEu||'').trim()) sizeParts.push(`EU ${item.sizeEu}`);
+          if((item.sizeUs||'').trim()) sizeParts.push(`US ${item.sizeUs}`);
+          if((item.size||'').trim()) sizeParts.push(item.size);
+          const sizeInfo=sizeParts.length?`<div class="tiny muted">Rozmiary: ${sizeParts.join(' / ')}</div>`:'';
           const tr=document.createElement('tr');
           tr.dataset.id=item.id;
-          tr.innerHTML=`<td><div><b>${item.brand||'—'}</b></div><div class="muted">${item.model||'—'}${item.size?` • ${item.size}`:''}</div></td>
+          tr.innerHTML=`<td><div><b>${item.brand||'—'}</b></div><div class="muted">${item.model||'—'}</div>${sizeInfo}</td>
             <td><div>${fmt(item.purchasePrice,state.currency)}</div><div class="tiny">${item.purchaseDate||'—'}</div></td>
             <td><div>${item.saleDate||'—'}</div><div class="tiny">${fmt(item.salePrice,item.saleCurrency||'PLN')}</div>${item.saleFees?`<div class="tiny">Fee: ${fmt(item.saleFees,state.currency)}</div>`:''}</td>
             <td><div>${fmt(item.salePricePln,state.currency)}</div>${saleConverted!==null?`<div class="tiny">${fmt(saleConverted, displayCurrency)}</div>`:''}</td>
@@ -3380,10 +3650,15 @@
               brand:item.brand,
               model:item.model,
               size:item.size,
+              sizeEu:item.sizeEu||'',
+              sizeUs:item.sizeUs||'',
               purchasePrice:item.purchasePrice,
               purchaseCurrency:'PLN',
               purchaseDate:item.purchaseDate,
               purchaseNote:item.purchaseNote||'',
+              planPricePln:item.planPricePln??null,
+              planCurrency:item.planCurrency||inventoryState.ui?.selectedCurrency||'PLN',
+              planUpdatedAt:item.planUpdatedAt||null,
               createdAt:item.purchaseDate || new Date().toISOString()
             });
             save(state);

--- a/budget.html
+++ b/budget.html
@@ -100,6 +100,20 @@
     .kpi-trend.trend-up{color:var(--green)}
     .kpi-trend.trend-down{color:var(--red)}
     .kpi-trend.trend-flat{color:var(--muted)}
+    .inventory-toolbar{display:flex;flex-wrap:wrap;gap:12px;justify-content:space-between;align-items:flex-start;margin-top:16px}
+    .inventory-toolbar .row{gap:8px;flex-wrap:wrap}
+    .inventory-kpis{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px;margin-top:12px}
+    .inventory-section{margin-top:16px}
+    .inventory-import{margin-top:16px}
+    .inventory-import textarea{width:100%;min-height:120px;border-radius:12px;border:1px dashed var(--line);padding:10px;font-family:inherit}
+    .inventory-inline{margin-top:8px;background:#f8fafc;border:1px dashed var(--line);border-radius:12px;padding:12px}
+    .inventory-inline .grid{grid-template-columns:repeat(auto-fit,minmax(160px,1fr))}
+    .inventory-empty{text-align:center;padding:16px;color:var(--muted);font-size:13px}
+    .inventory-table-actions{display:flex;flex-wrap:wrap;gap:6px}
+    .inventory-badge{display:inline-flex;align-items:center;gap:4px;background:#e2e8f0;border-radius:999px;padding:2px 8px;font-size:11px;color:#475569}
+    .inventory-quick-note{font-size:12px;color:var(--muted);margin-top:4px}
+    .chart-box{position:relative}
+    .chart-empty{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:13px;color:var(--muted)}
   </style>
 </head>
 <body>
@@ -132,6 +146,7 @@
       <button class="tab" data-tab="eom">Salda (EOM)</button>
       <button class="tab" data-tab="goals">Cele</button>
       <button class="tab" data-tab="analytics">Analityka</button>
+      <button class="tab" data-tab="inventory">Inventory</button>
     </div>
 
     <!-- Dashboard -->
@@ -654,6 +669,169 @@
         <table id="analytics-top-transactions"></table>
       </div>
     </section>
+
+    <!-- Inventory -->
+    <section id="tab-inventory" class="card" style="margin-top:12px;display:none">
+      <div class="row" style="align-items:flex-start;justify-content:space-between;gap:12px">
+        <div>
+          <h3 class="title" style="margin-bottom:4px">Magazyn sprzedażowy</h3>
+          <div class="muted" style="max-width:640px">Monitoruj zapasy, wynik i przepływ gotówki z odsprzedaży obuwia oraz ubrań.</div>
+        </div>
+        <div class="inventory-badge">🧾 Stan magazynowy</div>
+      </div>
+
+      <div class="inventory-toolbar">
+        <div class="row">
+          <label class="tiny">Wyświetl w walucie
+            <select id="inv-currency-select" style="min-width:120px">
+              <option value="PLN">PLN</option>
+              <option value="EUR">EUR</option>
+              <option value="USD">USD</option>
+            </select>
+          </label>
+          <button class="btn soft" id="inv-refresh-rates">🔄 Pobierz dzisiejsze kursy</button>
+          <span class="muted" id="inv-rate-info">Brak kursów – pobierz aktualne notowania.</span>
+        </div>
+        <div class="row">
+          <button class="btn ghost" id="inv-toggle-import">📥 Import / wklejka</button>
+          <button class="btn ghost" id="inv-export-btn">⬇️ Eksport CSV</button>
+        </div>
+      </div>
+
+      <div class="inventory-kpis">
+        <div class="kpi-card light">
+          <div class="label">Towar na stanie</div>
+          <div class="value" id="inv-kpi-stock-count">0</div>
+          <div class="sub" id="inv-kpi-stock-extra">Koszt zakupu: —</div>
+        </div>
+        <div class="kpi-card light">
+          <div class="label">Wycena (wybrana waluta)</div>
+          <div class="value" id="inv-kpi-stock-worth">—</div>
+          <div class="sub" id="inv-kpi-stock-worth-sub">Śr. koszt i czas w magazynie</div>
+        </div>
+        <div class="kpi-card">
+          <div class="label">Sprzedane pozycje</div>
+          <div class="value" id="inv-kpi-sold-count">0</div>
+          <div class="sub" id="inv-kpi-sold-revenue">Przychód: —</div>
+        </div>
+        <div class="kpi-card">
+          <div class="label">Zrealizowany wynik</div>
+          <div class="value" id="inv-kpi-sold-pnl">—</div>
+          <div class="sub" id="inv-kpi-sold-roi">ROI: —</div>
+        </div>
+      </div>
+
+      <form id="inv-import-form" class="inventory-import" style="display:none">
+        <h4 class="title" style="font-size:16px;margin:0 0 4px 0">Szybki import / wklejka</h4>
+        <p class="hint">Wklej dane w formacie: marka;model;rozmiar;kwota;data (opcjonalnie). Możesz też użyć CSV lub danych z Excela.</p>
+        <textarea id="inv-import-input" placeholder="Nike;Air Max 1;44;320;2024-05-10&#10;Adidas;Campus 00s;43;280"></textarea>
+        <div class="row" style="justify-content:flex-end;gap:8px;margin-top:8px">
+          <button class="btn ghost" type="button" id="inv-import-cancel">Anuluj</button>
+          <button class="btn" type="submit">Dodaj pozycje</button>
+        </div>
+      </form>
+
+      <div class="card inventory-section">
+        <div class="row" style="align-items:flex-end;gap:12px;justify-content:space-between">
+          <div>
+            <h4 class="title" style="margin:0">Dodaj nowy towar</h4>
+            <div class="muted">Uzupełnij podstawowe informacje, aby śledzić wartość magazynu.</div>
+          </div>
+          <span class="inventory-badge">💡 Możesz też importować hurtowo</span>
+        </div>
+        <form id="inv-add-form" class="grid g-4" style="margin-top:12px">
+          <label class="tiny">Marka<input name="brand" placeholder="np. Nike" required /></label>
+          <label class="tiny">Model<input name="model" placeholder="np. Air Max 1" required /></label>
+          <label class="tiny">Rozmiar<input name="size" placeholder="np. 44 EU" /></label>
+          <label class="tiny">Data zakupu<input name="purchaseDate" type="date" /></label>
+          <label class="tiny">Kwota zakupu (PLN)<input name="purchasePrice" inputmode="decimal" placeholder="0,00" required /></label>
+          <label class="tiny" style="grid-column:1 / -1">Notatka / źródło<input name="purchaseNote" placeholder="np. Allegro, outlet" /></label>
+          <button class="btn" type="submit" style="grid-column:1 / -1">Dodaj do magazynu</button>
+        </form>
+      </div>
+
+      <div class="split-box inventory-section">
+        <div class="grid g-4" style="gap:8px">
+          <input id="inv-search" placeholder="Szukaj po marce lub modelu" />
+          <select id="inv-filter-brand"></select>
+          <select id="inv-filter-size"></select>
+          <select id="inv-sort">
+            <option value="newest">Najnowsze</option>
+            <option value="oldest">Najstarsze</option>
+            <option value="priceDesc">Najdroższe</option>
+            <option value="priceAsc">Najtańsze</option>
+            <option value="brand">Marka A→Z</option>
+            <option value="age">Najdłużej na stanie</option>
+          </select>
+        </div>
+        <div class="row" style="justify-content:space-between;align-items:center;gap:8px;margin-top:8px">
+          <div id="inv-filter-summary" class="inventory-quick-note">Brak pozycji w magazynie.</div>
+          <button class="btn ghost" id="inv-reset-filters" type="button">Wyczyść filtry</button>
+        </div>
+      </div>
+
+      <div class="card inventory-section">
+        <div class="row" style="justify-content:space-between;align-items:flex-end;gap:12px">
+          <h4 class="title" style="margin:0">Towary na sprzedaż</h4>
+          <span class="muted">Kwoty w PLN oraz w wybranej walucie (<span data-inv-currency-label>PLN</span>)</span>
+        </div>
+        <div style="overflow-x:auto;margin-top:8px">
+          <table id="inventory-active-table" class="table-modern">
+            <thead>
+              <tr>
+                <th>Produkt</th>
+                <th>Zakup (PLN)</th>
+                <th>Wycena (<span data-inv-currency-label>PLN</span>)</th>
+                <th>Dni w magazynie</th>
+                <th>Notatki</th>
+                <th>Akcje</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="card inventory-section">
+        <div class="row" style="justify-content:space-between;align-items:flex-end;gap:12px">
+          <h4 class="title" style="margin:0">Sprzedane pozycje</h4>
+          <span class="muted">Wszystkie wartości w PLN oraz w walucie <span data-inv-currency-label>PLN</span></span>
+        </div>
+        <div style="overflow-x:auto;margin-top:8px">
+          <table id="inventory-sold-table" class="table-modern">
+            <thead>
+              <tr>
+                <th>Produkt</th>
+                <th>Zakup</th>
+                <th>Sprzedaż</th>
+                <th>Przychód</th>
+                <th>PnL</th>
+                <th>ROI / czas</th>
+                <th>Uwagi</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="grid g-2 inventory-section">
+        <div class="card" id="inventory-brand-card">
+          <div class="title">Struktura marek (aktywny stock)</div>
+          <div class="chart-box">
+            <canvas id="inventory-brand-chart"></canvas>
+            <div class="chart-empty" id="inventory-brand-empty" style="display:none">Brak danych do wyświetlenia.</div>
+          </div>
+        </div>
+        <div class="card" id="inventory-sales-card">
+          <div class="title">Sprzedaż miesięczna i PnL</div>
+          <div class="chart-box">
+            <canvas id="inventory-sales-chart"></canvas>
+            <div class="chart-empty" id="inventory-sales-empty" style="display:none">Brak historii sprzedaży.</div>
+          </div>
+        </div>
+      </div>
+    </section>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -733,6 +911,69 @@
     if(!Array.isArray(bud.recurringLog)) bud.recurringLog=[];
     // NEW: fixed expense templates
     if(!Array.isArray(bud.fixedTemplates)) bud.fixedTemplates=[];
+
+    const normalizeInventoryItem = (item, fallbackDate) => {
+      const id = typeof item?.id === 'string' ? item.id : 'inv_'+Math.random().toString(36).slice(2);
+      const purchasePrice = num(item?.purchasePrice);
+      const purchaseDate = typeof item?.purchaseDate === 'string' ? item.purchaseDate : '';
+      const createdAt = item?.createdAt || purchaseDate || fallbackDate;
+      return {
+        id,
+        brand: item?.brand ? String(item.brand) : '',
+        model: item?.model ? String(item.model) : '',
+        size: item?.size ? String(item.size) : '',
+        purchasePrice,
+        purchaseCurrency: 'PLN',
+        purchaseDate,
+        purchaseNote: item?.purchaseNote ? String(item.purchaseNote) : '',
+        createdAt
+      };
+    };
+    const normalizeSoldItem = (item, fallbackDate) => {
+      const id = typeof item?.id === 'string' ? item.id : 'inv_'+Math.random().toString(36).slice(2);
+      const purchasePrice = num(item?.purchasePrice);
+      const salePricePln = num(item?.salePricePln || item?.salePrice);
+      const saleFees = num(item?.saleFees);
+      const pnlCalculated = salePricePln - purchasePrice - saleFees;
+      return {
+        id,
+        brand: item?.brand ? String(item.brand) : '',
+        model: item?.model ? String(item.model) : '',
+        size: item?.size ? String(item.size) : '',
+        purchasePrice,
+        purchaseCurrency: 'PLN',
+        purchaseDate: typeof item?.purchaseDate === 'string' ? item.purchaseDate : '',
+        purchaseNote: item?.purchaseNote ? String(item.purchaseNote) : '',
+        salePrice: num(item?.salePrice),
+        saleCurrency: item?.saleCurrency ? String(item.saleCurrency) : 'PLN',
+        saleDate: typeof item?.saleDate === 'string' ? item.saleDate : '',
+        saleFees,
+        saleNote: item?.saleNote ? String(item.saleNote) : '',
+        salePricePln,
+        pnlPln: Number.isFinite(num(item?.pnlPln)) ? num(item.pnlPln) : pnlCalculated,
+        soldAt: item?.soldAt || item?.saleDate || fallbackDate
+      };
+    };
+
+    if(!bud.inventory || typeof bud.inventory!=='object') bud.inventory={};
+    if(!Array.isArray(bud.inventory.items)) bud.inventory.items=[];
+    if(!Array.isArray(bud.inventory.sold)) bud.inventory.sold=[];
+    const nowIso=new Date().toISOString();
+    bud.inventory.items=bud.inventory.items.map(item=>normalizeInventoryItem(item, nowIso));
+    bud.inventory.sold=bud.inventory.sold.map(item=>normalizeSoldItem(item, nowIso));
+    if(!bud.inventory.rates || typeof bud.inventory.rates!=='object') bud.inventory.rates={base:'PLN',fetchedAt:null,rates:{}};
+    bud.inventory.rates.base='PLN';
+    if(!bud.inventory.rates.rates || typeof bud.inventory.rates.rates!=='object') bud.inventory.rates.rates={};
+    bud.inventory.rates.rates.EUR = Number(bud.inventory.rates.rates.EUR)||null;
+    bud.inventory.rates.rates.USD = Number(bud.inventory.rates.rates.USD)||null;
+    if(!bud.inventory.ui || typeof bud.inventory.ui!=='object') bud.inventory.ui={};
+    const invUi=bud.inventory.ui;
+    if(!['PLN','EUR','USD'].includes(invUi.selectedCurrency)) invUi.selectedCurrency='PLN';
+    if(typeof invUi.searchTerm!=='string') invUi.searchTerm='';
+    if(typeof invUi.brandFilter!=='string') invUi.brandFilter='';
+    if(typeof invUi.sizeFilter!=='string') invUi.sizeFilter='';
+    if(typeof invUi.sortMode!=='string') invUi.sortMode='newest';
+    if(typeof invUi.showImport!=='boolean') invUi.showImport=false;
     return st;
   }
 
@@ -754,13 +995,20 @@
         workingMonth:monthKey(),
         createTxOnFixedPay:true,
         recurringTemplates:[],recurringLog:[],
-        fixedTemplates:[] // NEW
+        fixedTemplates:[],
+        inventory:{
+          items:[],
+          sold:[],
+          rates:{base:'PLN',fetchedAt:null,rates:{}},
+          ui:{selectedCurrency:'PLN',searchTerm:'',brandFilter:'',sizeFilter:'',sortMode:'newest',showImport:false}
+        }
       }}
     });
   }
 
   let state = migrateState(load()) || def();
   const b=()=>state.modules.budget;
+  const inv=()=>b().inventory;
 
   // --- Core Helpers ----------------------------------------------------------------
   function ensureMonth(ym){if(!b().monthly[ym]) b().monthly[ym]={ incomes:[], fixed:[] }}
@@ -797,7 +1045,7 @@
     });
   }
   const tabs=document.querySelectorAll('.tab');
-  const sections={dashboard:tab('dashboard'),overview:tab('overview'),incomes:tab('incomes'),fixed:tab('fixed'),variable:tab('variable'),categories:tab('categories'),eom:tab('eom'),goals:tab('goals'),analytics:tab('analytics')};
+  const sections={dashboard:tab('dashboard'),overview:tab('overview'),incomes:tab('incomes'),fixed:tab('fixed'),variable:tab('variable'),categories:tab('categories'),eom:tab('eom'),goals:tab('goals'),analytics:tab('analytics'),inventory:tab('inventory')};
   function tab(id){return document.getElementById('tab-'+id)}
   for(const t of tabs){
     t.addEventListener('click',()=>{
@@ -806,6 +1054,7 @@
       if(t.dataset.tab==='variable'){setDefaultDate()}
       if(t.dataset.tab==='analytics') renderAnalytics(); // Render analytics when tab is clicked
       if(t.dataset.tab==='eom') renderEOMHistory(); // Render history when tab is clicked
+      if(t.dataset.tab==='inventory') renderInventory();
       bindMoneyInputs();
     });
   }
@@ -2201,6 +2450,778 @@
     renderEomAccountsChart(ctx, monthsToShow);
   }
 
+  const DAY_MS = 1000*60*60*24;
+
+  function destroyInventoryChart(key){
+    if(inventoryCharts[key]){
+      inventoryCharts[key].destroy();
+      delete inventoryCharts[key];
+    }
+  }
+
+  function inventoryCurrencyLabel(currency){
+    return currency==='PLN' ? (state.currency || 'PLN') : currency;
+  }
+
+  function convertPlnToCurrency(amount, currency){
+    const value = Number(amount);
+    if(!Number.isFinite(value)) return null;
+    if((currency||'PLN').toUpperCase()==='PLN') return value;
+    const rate = inv().rates?.rates?.[currency];
+    if(!Number.isFinite(rate) || rate<=0) return null;
+    return value * rate;
+  }
+
+  function convertCurrencyToPln(amount, currency){
+    const value = Number(amount);
+    if(!Number.isFinite(value)) return null;
+    if((currency||'PLN').toUpperCase()==='PLN') return value;
+    const rate = inv().rates?.rates?.[currency];
+    if(!Number.isFinite(rate) || rate<=0) return null;
+    return value / rate;
+  }
+
+  function convertBetweenCurrencies(amount, fromCurrency, toCurrency){
+    const value = Number(amount);
+    if(!Number.isFinite(value)) return null;
+    const from = (fromCurrency || 'PLN').toUpperCase();
+    const to = (toCurrency || 'PLN').toUpperCase();
+    if(from === to) return value;
+    if(to === 'PLN') return convertCurrencyToPln(value, from);
+    if(from === 'PLN') return convertPlnToCurrency(value, to);
+    const plnValue = convertCurrencyToPln(value, from);
+    if(plnValue === null) return null;
+    return convertPlnToCurrency(plnValue, to);
+  }
+
+  function inventoryDaysBetween(startDate, endDate=new Date()){
+    if(!startDate) return null;
+    const start = startDate instanceof Date ? startDate : new Date(startDate);
+    const end = endDate instanceof Date ? endDate : new Date(endDate);
+    if(isNaN(start) || isNaN(end)) return null;
+    return Math.max(0,(end - start)/DAY_MS);
+  }
+
+  function renderInventoryBrandChart(items){
+    const canvas=document.getElementById('inventory-brand-chart');
+    const empty=document.getElementById('inventory-brand-empty');
+    if(!canvas) return;
+    const map=new Map();
+    for(const item of items){
+      const brand=(item.brand||'Bez marki').trim()||'Bez marki';
+      const value=num(item.purchasePrice);
+      map.set(brand,(map.get(brand)||0)+value);
+    }
+    const entries=Array.from(map.entries()).sort((a,b)=>b[1]-a[1]).slice(0,8);
+    if(entries.length===0){
+      destroyInventoryChart('brand');
+      if(empty) empty.style.display='flex';
+      canvas.style.display='none';
+      return;
+    }
+    canvas.style.display='block';
+    if(empty) empty.style.display='none';
+    destroyInventoryChart('brand');
+    inventoryCharts.brand=new Chart(canvas.getContext('2d'),{
+      type:'bar',
+      data:{
+        labels:entries.map(e=>e[0]),
+        datasets:[{
+          label:'Koszt zakupu (PLN)',
+          data:entries.map(e=>e[1]),
+          backgroundColor:entries.map((_,idx)=>withAlpha(ANALYTICS_COLORS[idx % ANALYTICS_COLORS.length],0.55)),
+          borderColor:entries.map((_,idx)=>ANALYTICS_COLORS[idx % ANALYTICS_COLORS.length]),
+          borderWidth:1
+        }]
+      },
+      options:{
+        responsive:true,
+        maintainAspectRatio:false,
+        plugins:{
+          legend:{display:false},
+          tooltip:{
+            callbacks:{
+              label:context=>{
+                const value=context.parsed.y;
+                const selected=inv().ui?.selectedCurrency || 'PLN';
+                const converted=convertBetweenCurrencies(value,'PLN',selected);
+                const base=`${fmt(value,state.currency)}`;
+                if(selected==='PLN' || converted===null) return base;
+                return `${base} (${fmt(converted, inventoryCurrencyLabel(selected))})`;
+              }
+            }
+          }
+        },
+        scales:{ y:{ ticks:{ callback: currencyTicks } } }
+      }
+    });
+  }
+
+  function renderInventorySalesChart(soldItems){
+    const canvas=document.getElementById('inventory-sales-chart');
+    const empty=document.getElementById('inventory-sales-empty');
+    if(!canvas) return;
+    const monthly={};
+    for(const item of soldItems){
+      const ym=(item.saleDate || item.soldAt || '').slice(0,7);
+      if(!ym) continue;
+      if(!monthly[ym]) monthly[ym]={revenue:0,pnl:0,count:0};
+      monthly[ym].revenue+=num(item.salePricePln);
+      monthly[ym].pnl+=num(item.pnlPln);
+      monthly[ym].count+=1;
+    }
+    const months=Object.keys(monthly).sort();
+    if(months.length===0){
+      destroyInventoryChart('sales');
+      if(empty) empty.style.display='flex';
+      canvas.style.display='none';
+      return;
+    }
+    canvas.style.display='block';
+    if(empty) empty.style.display='none';
+    destroyInventoryChart('sales');
+    const selected=inv().ui?.selectedCurrency || 'PLN';
+    inventoryCharts.sales=new Chart(canvas.getContext('2d'),{
+      data:{
+        labels:months,
+        datasets:[
+          {
+            type:'line',
+            label:'Przychód (PLN)',
+            data:months.map(m=>monthly[m].revenue),
+            borderColor:'#0f172a',
+            backgroundColor:'rgba(15,23,42,0.12)',
+            borderWidth:2,
+            fill:true,
+            tension:0.35,
+            yAxisID:'y'
+          },
+          {
+            type:'line',
+            label:'PnL (PLN)',
+            data:months.map(m=>monthly[m].pnl),
+            borderColor:'#16a34a',
+            backgroundColor:'rgba(22,163,74,0.12)',
+            borderWidth:2,
+            fill:true,
+            tension:0.35,
+            yAxisID:'y'
+          },
+          {
+            type:'bar',
+            label:'Liczba transakcji',
+            data:months.map(m=>monthly[m].count),
+            backgroundColor:withAlpha('#0ea5e9',0.35),
+            borderColor:'#0ea5e9',
+            borderWidth:1,
+            yAxisID:'y1'
+          }
+        ]
+      },
+      options:{
+        responsive:true,
+        maintainAspectRatio:false,
+        plugins:{
+          tooltip:{
+            callbacks:{
+              afterLabel:context=>{
+                if(context.dataset.yAxisID!=='y') return '';
+                if(selected==='PLN') return '';
+                const converted=convertBetweenCurrencies(context.parsed.y,'PLN',selected);
+                if(converted===null) return '';
+                return ` (${fmt(converted, inventoryCurrencyLabel(selected))})`;
+              }
+            }
+          }
+        },
+        scales:{
+          y:{ position:'left', ticks:{ callback: currencyTicks } },
+          y1:{ position:'right', grid:{ drawOnChartArea:false }, ticks:{ precision:0 } }
+        }
+      }
+    });
+  }
+
+  function renderInventory(){
+    const section=tab('inventory');
+    if(!section) return;
+    const inventoryState=inv();
+    const ui=inventoryState.ui || (inventoryState.ui={selectedCurrency:'PLN',searchTerm:'',brandFilter:'',sizeFilter:'',sortMode:'newest',showImport:false});
+    let selectedCurrency=(ui.selectedCurrency||'PLN').toUpperCase();
+    if(!INVENTORY_SUPPORTED_CURRENCIES.includes(selectedCurrency)) selectedCurrency='PLN';
+    ui.selectedCurrency=selectedCurrency;
+    const displayCurrency=inventoryCurrencyLabel(selectedCurrency);
+    const items=Array.isArray(inventoryState.items)?inventoryState.items:[];
+    const sold=Array.isArray(inventoryState.sold)?inventoryState.sold:[];
+    const search=(ui.searchTerm||'').toLowerCase();
+    const brandOptions=Array.from(new Set(items.map(it=>(it.brand||'').trim()).filter(Boolean))).sort((a,b)=>a.localeCompare(b,'pl',{sensitivity:'base'}));
+    const sizeOptions=Array.from(new Set(items.map(it=>(it.size||'').trim()).filter(Boolean))).sort((a,b)=>a.localeCompare(b,'pl',{numeric:true,sensitivity:'base'}));
+    if(ui.brandFilter && !brandOptions.includes(ui.brandFilter)) ui.brandFilter='';
+    if(ui.sizeFilter && !sizeOptions.includes(ui.sizeFilter)) ui.sizeFilter='';
+    const brandFilter=ui.brandFilter||'';
+    const sizeFilter=ui.sizeFilter||'';
+    const sortMode=ui.sortMode||'newest';
+    const today=new Date();
+    const filtered=items.filter(item=>{
+      const combined=`${item.brand||''} ${item.model||''}`.toLowerCase();
+      if(search && !combined.includes(search)) return false;
+      if(brandFilter && (item.brand||'')!==brandFilter) return false;
+      if(sizeFilter && (item.size||'')!==sizeFilter) return false;
+      return true;
+    });
+    const visible=[...filtered];
+    const getCreated=it=>{
+      const d=it.purchaseDate?new Date(it.purchaseDate):(it.createdAt?new Date(it.createdAt):new Date(0));
+      return isNaN(d)?0:d.getTime();
+    };
+    const getAge=it=>{
+      const diff=inventoryDaysBetween(it.purchaseDate,today);
+      return diff===null?0:diff;
+    };
+    switch(sortMode){
+      case 'oldest':
+        visible.sort((a,b)=>getCreated(a)-getCreated(b));
+        break;
+      case 'priceDesc':
+        visible.sort((a,b)=>num(b.purchasePrice)-num(a.purchasePrice));
+        break;
+      case 'priceAsc':
+        visible.sort((a,b)=>num(a.purchasePrice)-num(b.purchasePrice));
+        break;
+      case 'brand':
+        visible.sort((a,b)=>`${a.brand||''} ${a.model||''}`.localeCompare(`${b.brand||''} ${b.model||''}`,'pl',{sensitivity:'base'}));
+        break;
+      case 'age':
+        visible.sort((a,b)=>getAge(b)-getAge(a));
+        break;
+      case 'newest':
+      default:
+        visible.sort((a,b)=>getCreated(b)-getCreated(a));
+    }
+
+    const totalStockCost=items.reduce((sum,it)=>sum+num(it.purchasePrice),0);
+    const totalStockConverted=convertBetweenCurrencies(totalStockCost,'PLN',selectedCurrency);
+    const avgStockCostPln=items.length?totalStockCost/items.length:0;
+    const avgStockConverted=items.length?convertBetweenCurrencies(avgStockCostPln,'PLN',selectedCurrency):null;
+    const avgStockAgeArr=items.map(it=>inventoryDaysBetween(it.purchaseDate,today)).filter(v=>v!==null);
+    const avgStockAge=avgStockAgeArr.length?avgStockAgeArr.reduce((a,b)=>a+b,0)/avgStockAgeArr.length:null;
+
+    const filteredCost=filtered.reduce((sum,it)=>sum+num(it.purchasePrice),0);
+    const filteredConverted=convertBetweenCurrencies(filteredCost,'PLN',selectedCurrency);
+    const filteredAgeArr=filtered.map(it=>inventoryDaysBetween(it.purchaseDate,today)).filter(v=>v!==null);
+    const filteredAvgAge=filteredAgeArr.length?filteredAgeArr.reduce((a,b)=>a+b,0)/filteredAgeArr.length:null;
+
+    const totalSoldPurchase=sold.reduce((sum,it)=>sum+num(it.purchasePrice),0);
+    const totalSoldRevenue=sold.reduce((sum,it)=>sum+num(it.salePricePln),0);
+    const totalSoldPnl=sold.reduce((sum,it)=>sum+num(it.pnlPln),0);
+    const soldRevenueConverted=convertBetweenCurrencies(totalSoldRevenue,'PLN',selectedCurrency);
+    const soldPnlConverted=convertBetweenCurrencies(totalSoldPnl,'PLN',selectedCurrency);
+    const soldHoldArr=sold.map(it=>inventoryDaysBetween(it.purchaseDate,it.saleDate||it.soldAt)).filter(v=>v!==null);
+    const avgSoldHold=soldHoldArr.length?soldHoldArr.reduce((a,b)=>a+b,0)/soldHoldArr.length:null;
+    const roi=totalSoldPurchase>0?((totalSoldRevenue/totalSoldPurchase)-1)*100:null;
+
+    const stockCountEl=document.getElementById('inv-kpi-stock-count');
+    if(stockCountEl) stockCountEl.textContent=items.length;
+    const stockExtra=document.getElementById('inv-kpi-stock-extra');
+    if(stockExtra) stockExtra.textContent=items.length?`Koszt zakupu: ${fmt(totalStockCost,state.currency)}`:'Koszt zakupu: —';
+    const stockWorth=document.getElementById('inv-kpi-stock-worth');
+    if(stockWorth){
+      if(!items.length) stockWorth.textContent='—';
+      else if(selectedCurrency==='PLN' || totalStockConverted!==null) stockWorth.textContent=fmt(selectedCurrency==='PLN'?totalStockCost:totalStockConverted, displayCurrency);
+      else stockWorth.textContent='Brak kursu';
+    }
+    const stockWorthSub=document.getElementById('inv-kpi-stock-worth-sub');
+    if(stockWorthSub){
+      let avgCostText='Śr. koszt: —';
+      if(items.length){
+        if(selectedCurrency==='PLN') avgCostText=`Śr. koszt: ${fmt(avgStockCostPln,state.currency)}`;
+        else if(avgStockConverted!==null) avgCostText=`Śr. koszt: ${fmt(avgStockConverted,displayCurrency)}`;
+        else avgCostText=`Śr. koszt: ${fmt(avgStockCostPln,state.currency)} (brak kursu ${selectedCurrency})`;
+      }
+      const avgAgeText=avgStockAge!==null?`${avgStockAge.toFixed(0)} dni`:'—';
+      stockWorthSub.textContent=`${avgCostText} • Śr. czas w magazynie: ${avgAgeText}`;
+    }
+    const soldCountEl=document.getElementById('inv-kpi-sold-count');
+    if(soldCountEl) soldCountEl.textContent=sold.length;
+    const soldRevenueEl=document.getElementById('inv-kpi-sold-revenue');
+    if(soldRevenueEl){
+      if(!sold.length) soldRevenueEl.textContent='Brak sprzedaży';
+      else if(selectedCurrency==='PLN' || soldRevenueConverted===null) soldRevenueEl.textContent=`Przychód: ${fmt(totalSoldRevenue,state.currency)}`;
+      else soldRevenueEl.textContent=`Przychód: ${fmt(soldRevenueConverted,displayCurrency)} (${fmt(totalSoldRevenue,state.currency)})`;
+    }
+    const soldPnlEl=document.getElementById('inv-kpi-sold-pnl');
+    if(soldPnlEl){
+      if(!sold.length) soldPnlEl.textContent='—';
+      else if(selectedCurrency==='PLN' || soldPnlConverted===null) soldPnlEl.textContent=fmt(totalSoldPnl,displayCurrency);
+      else soldPnlEl.textContent=fmt(soldPnlConverted,displayCurrency);
+    }
+    const soldRoiEl=document.getElementById('inv-kpi-sold-roi');
+    if(soldRoiEl){
+      if(!sold.length) soldRoiEl.textContent='Brak sprzedaży';
+      else{
+        const roiText=roi!==null?`${roi>=0?'+':''}${roi.toFixed(1)}%`:'—';
+        const pnlBase=fmt(totalSoldPnl,state.currency);
+        const pnlExtra=(selectedCurrency!=='PLN' && soldPnlConverted!==null)?` / ${fmt(soldPnlConverted,displayCurrency)}`:'';
+        const holdText=avgSoldHold!==null?`${avgSoldHold.toFixed(0)} dni`:'—';
+        soldRoiEl.textContent=`PnL: ${pnlBase}${pnlExtra} • ROI: ${roiText} • Śr. trzymanie: ${holdText}`;
+      }
+    }
+
+    const rateInfo=document.getElementById('inv-rate-info');
+    if(rateInfo){
+      const fetchedAt=inventoryState.rates?.fetchedAt;
+      const rates=inventoryState.rates?.rates||{};
+      if(fetchedAt){
+        const dt=new Date(fetchedAt);
+        const formatted=isNaN(dt)?fetchedAt:dt.toLocaleString('pl-PL');
+        const eur=rates.EUR?rates.EUR.toFixed(4):'—';
+        const usd=rates.USD?rates.USD.toFixed(4):'—';
+        rateInfo.textContent=`Kursy z ${formatted} | PLN→EUR ${eur} • PLN→USD ${usd}`;
+      }else{
+        rateInfo.textContent='Brak kursów – pobierz aktualne notowania.';
+      }
+    }
+
+    document.querySelectorAll('[data-inv-currency-label]').forEach(el=>{el.textContent=displayCurrency;});
+
+    const importForm=document.getElementById('inv-import-form');
+    if(importForm) importForm.style.display=ui.showImport?'block':'none';
+
+    const summaryEl=document.getElementById('inv-filter-summary');
+    if(summaryEl){
+      let text=`Widoczne: ${filtered.length} / ${items.length} pozycji`;
+      text+=` • Koszt: ${fmt(filteredCost,state.currency)}`;
+      if(selectedCurrency!=='PLN' && filteredConverted!==null) text+=` (${fmt(filteredConverted,displayCurrency)})`;
+      if(filteredAvgAge!==null) text+=` • Śr. czas: ${filteredAvgAge.toFixed(0)} dni`;
+      summaryEl.textContent=text;
+    }
+
+    const searchInput=document.getElementById('inv-search');
+    if(searchInput){
+      if(searchInput.value!==ui.searchTerm) searchInput.value=ui.searchTerm;
+      if(!searchInput.dataset.bound){
+        searchInput.dataset.bound='1';
+        searchInput.addEventListener('input',e=>{
+          inv().ui.searchTerm=e.target.value;
+          save(state);
+          renderInventory();
+        });
+      }
+    }
+
+    const brandSelect=document.getElementById('inv-filter-brand');
+    if(brandSelect){
+      brandSelect.innerHTML='<option value="">Wszystkie marki</option>'+brandOptions.map(b=>`<option value="${b}">${b}</option>`).join('');
+      brandSelect.value=brandFilter;
+      if(!brandSelect.dataset.bound){
+        brandSelect.dataset.bound='1';
+        brandSelect.onchange=e=>{
+          inv().ui.brandFilter=e.target.value;
+          save(state);
+          renderInventory();
+        };
+      }
+    }
+
+    const sizeSelect=document.getElementById('inv-filter-size');
+    if(sizeSelect){
+      sizeSelect.innerHTML='<option value="">Wszystkie rozmiary</option>'+sizeOptions.map(s=>`<option value="${s}">${s}</option>`).join('');
+      sizeSelect.value=sizeFilter;
+      if(!sizeSelect.dataset.bound){
+        sizeSelect.dataset.bound='1';
+        sizeSelect.onchange=e=>{
+          inv().ui.sizeFilter=e.target.value;
+          save(state);
+          renderInventory();
+        };
+      }
+    }
+
+    const sortSelect=document.getElementById('inv-sort');
+    if(sortSelect){
+      sortSelect.value=sortMode;
+      if(!sortSelect.dataset.bound){
+        sortSelect.dataset.bound='1';
+        sortSelect.onchange=e=>{
+          inv().ui.sortMode=e.target.value;
+          save(state);
+          renderInventory();
+        };
+      }
+    }
+
+    const resetBtn=document.getElementById('inv-reset-filters');
+    if(resetBtn && !resetBtn.dataset.bound){
+      resetBtn.dataset.bound='1';
+      resetBtn.onclick=()=>{
+        inv().ui.searchTerm='';
+        inv().ui.brandFilter='';
+        inv().ui.sizeFilter='';
+        inv().ui.sortMode='newest';
+        save(state);
+        renderInventory();
+      };
+    }
+
+    const currencySelect=document.getElementById('inv-currency-select');
+    if(currencySelect){
+      currencySelect.value=selectedCurrency;
+      if(!currencySelect.dataset.bound){
+        currencySelect.dataset.bound='1';
+        currencySelect.onchange=e=>{
+          inv().ui.selectedCurrency=e.target.value;
+          save(state);
+          renderInventory();
+        };
+      }
+    }
+
+    const toggleImport=document.getElementById('inv-toggle-import');
+    if(toggleImport && !toggleImport.dataset.bound){
+      toggleImport.dataset.bound='1';
+      toggleImport.onclick=()=>{
+        inv().ui.showImport=!inv().ui.showImport;
+        save(state);
+        renderInventory();
+      };
+    }
+
+    const cancelImport=document.getElementById('inv-import-cancel');
+    if(cancelImport && !cancelImport.dataset.bound){
+      cancelImport.dataset.bound='1';
+      cancelImport.onclick=()=>{
+        inv().ui.showImport=false;
+        save(state);
+        renderInventory();
+      };
+    }
+
+    const addForm=document.getElementById('inv-add-form');
+    if(addForm && !addForm.dataset.bound){
+      addForm.dataset.bound='1';
+      addForm.onsubmit=e=>{
+        e.preventDefault();
+        const data=new FormData(addForm);
+        const brand=String(data.get('brand')||'').trim();
+        const model=String(data.get('model')||'').trim();
+        const size=String(data.get('size')||'').trim();
+        const purchaseDate=String(data.get('purchaseDate')||'').trim();
+        const price=num(data.get('purchasePrice'));
+        const note=String(data.get('purchaseNote')||'').trim();
+        if(!brand || !model || !price){
+          alert('Podaj markę, model i kwotę zakupu.');
+          return;
+        }
+        inventoryState.items.unshift({
+          id:'inv_'+Math.random().toString(36).slice(2),
+          brand,
+          model,
+          size,
+          purchasePrice:price,
+          purchaseCurrency:'PLN',
+          purchaseDate:purchaseDate||'',
+          purchaseNote:note,
+          createdAt:purchaseDate||new Date().toISOString()
+        });
+        save(state);
+        addForm.reset();
+        renderInventory();
+      };
+    }
+
+    if(importForm && !importForm.dataset.bound){
+      importForm.dataset.bound='1';
+      importForm.onsubmit=e=>{
+        e.preventDefault();
+        const textarea=document.getElementById('inv-import-input');
+        const raw=(textarea.value||'').trim();
+        if(!raw){alert('Wklej dane do importu.');return;}
+        const lines=raw.split(/\n+/);
+        let added=0;
+        for(const line of lines){
+          const clean=line.trim();
+          if(!clean) continue;
+          const parts=clean.split(/[,;\t]/).map(p=>p.trim());
+          if(parts.length<4) continue;
+          const [brand,model,size,priceStr,...rest]=parts;
+          const price=num(priceStr);
+          if(!brand || !model || !price) continue;
+          const dateCandidate = rest[0] && /^\d{4}-\d{2}-\d{2}$/.test(rest[0]) ? rest[0] : '';
+          inventoryState.items.unshift({
+            id:'inv_'+Math.random().toString(36).slice(2),
+            brand,
+            model,
+            size:size||'',
+            purchasePrice:price,
+            purchaseCurrency:'PLN',
+            purchaseDate:dateCandidate,
+            purchaseNote:'',
+            createdAt:dateCandidate||new Date().toISOString()
+          });
+          added++;
+        }
+        if(added===0){alert('Nie udało się rozpoznać żadnej pozycji.');return;}
+        textarea.value='';
+        inv().ui.showImport=false;
+        save(state);
+        alert(`Dodano ${added} pozycji do magazynu.`);
+        renderInventory();
+      };
+    }
+
+    const refreshBtn=document.getElementById('inv-refresh-rates');
+    if(refreshBtn && !refreshBtn.dataset.bound){
+      refreshBtn.dataset.bound='1';
+      refreshBtn.onclick=async()=>{
+        const original=refreshBtn.textContent;
+        refreshBtn.disabled=true;
+        refreshBtn.textContent='Pobieranie...';
+        try{
+          const res=await fetch(INVENTORY_RATES_API);
+          if(!res.ok) throw new Error(`HTTP ${res.status}`);
+          const data=await res.json();
+          if(!data?.rates) throw new Error('Brak danych');
+          inventoryState.rates={
+            base:'PLN',
+            fetchedAt:new Date().toISOString(),
+            rates:{
+              EUR:Number(data.rates.EUR)||null,
+              USD:Number(data.rates.USD)||null
+            }
+          };
+          save(state);
+          renderInventory();
+          alert('Kursy zostały zaktualizowane.');
+        }catch(err){
+          console.error('Inventory rates error',err);
+          alert('Nie udało się pobrać kursów. Spróbuj ponownie później.');
+        }finally{
+          refreshBtn.disabled=false;
+          refreshBtn.textContent=original;
+        }
+      };
+    }
+
+    const exportBtn=document.getElementById('inv-export-btn');
+    if(exportBtn && !exportBtn.dataset.bound){
+      exportBtn.dataset.bound='1';
+      exportBtn.onclick=()=>{
+        const rows=[['status','brand','model','size','purchasePricePLN','purchaseDate','salePrice','saleCurrency','saleDate','saleFees','pnlPLN']];
+        for(const item of items){
+          rows.push(['active', item.brand||'', item.model||'', item.size||'', num(item.purchasePrice), item.purchaseDate||'', '', '', '', '', '']);
+        }
+        for(const item of sold){
+          rows.push(['sold', item.brand||'', item.model||'', item.size||'', num(item.purchasePrice), item.purchaseDate||'', num(item.salePrice), item.saleCurrency||'PLN', item.saleDate||'', num(item.saleFees), num(item.pnlPln)]);
+        }
+        const csv=rows.map(row=>row.map(value=>`"${String(value??'').replace(/"/g,'""')}"`).join(';')).join('\n');
+        const blob=new Blob([csv],{type:'text/csv;charset=utf-8;'});
+        const url=URL.createObjectURL(blob);
+        const link=document.createElement('a');
+        link.href=url;
+        link.download=`inventory_${new Date().toISOString().slice(0,10)}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        setTimeout(()=>{URL.revokeObjectURL(url);link.remove();},0);
+      };
+    }
+
+    const activeBody=document.querySelector('#inventory-active-table tbody');
+    if(activeBody){
+      activeBody.innerHTML='';
+      if(!visible.length){
+        const tr=document.createElement('tr');
+        tr.innerHTML='<td colspan="6" class="inventory-empty">Brak pozycji spełniających warunki.</td>';
+        activeBody.appendChild(tr);
+      }else{
+        const todayStr=new Date().toISOString().slice(0,10);
+        for(const item of visible){
+          const converted=selectedCurrency==='PLN'?num(item.purchasePrice):convertBetweenCurrencies(item.purchasePrice,'PLN',selectedCurrency);
+          const age=inventoryDaysBetween(item.purchaseDate,today);
+          const noteHtml=item.purchaseNote?item.purchaseNote:'<span class="muted">—</span>';
+          const convertedHtml=selectedCurrency==='PLN'?fmt(item.purchasePrice,displayCurrency):(converted!==null?fmt(converted,displayCurrency):'<span class="muted">Brak kursu</span>');
+          const ageLabel=age!==null?`${Math.round(age)} dni`:'—';
+          const sizeLabel=item.size?` • Rozmiar: ${item.size}`:'';
+          const saleOptions=INVENTORY_SUPPORTED_CURRENCIES.map(cur=>`<option value="${cur}" ${cur===selectedCurrency?'selected':''}>${cur}</option>`).join('');
+          const tr=document.createElement('tr');
+          tr.dataset.id=item.id;
+          tr.innerHTML=`<td><div><b>${item.brand||'—'}</b></div><div class="muted">${item.model||'—'}${sizeLabel}</div></td>
+            <td><div>${fmt(item.purchasePrice,state.currency)}</div><div class="tiny">${item.purchaseDate||'—'}</div></td>
+            <td>${convertedHtml}</td>
+            <td>${ageLabel}</td>
+            <td>${noteHtml}</td>
+            <td>
+              <div class="inventory-table-actions">
+                <button class="btn soft" data-act="sell">Sprzedaj</button>
+                <button class="btn ghost" data-act="edit">Edytuj</button>
+                <button class="btn danger" data-act="remove">Usuń</button>
+              </div>
+              <div class="inventory-inline" data-inline="sell" style="display:none">
+                <div class="grid" style="gap:8px">
+                  <label class="tiny">Cena sprzedaży<input data-field="salePrice" inputmode="decimal" placeholder="0,00" /></label>
+                  <label class="tiny">Waluta<select data-field="saleCurrency">${saleOptions}</select></label>
+                  <label class="tiny">Data sprzedaży<input data-field="saleDate" type="date" value="${todayStr}" /></label>
+                  <label class="tiny">Koszty/fee (PLN)<input data-field="saleFees" inputmode="decimal" placeholder="0" /></label>
+                  <label class="tiny" style="grid-column:1 / -1;">Notatka<input data-field="saleNote" placeholder="np. platforma, klient" /></label>
+                </div>
+                <div class="row" style="justify-content:flex-end;gap:8px;margin-top:8px">
+                  <button class="btn ghost" data-act="cancel-sell">Anuluj</button>
+                  <button class="btn" data-act="confirm-sell">Zatwierdź sprzedaż</button>
+                </div>
+              </div>
+              <div class="inventory-inline" data-inline="edit" style="display:none">
+                <div class="grid" style="gap:8px">
+                  <label class="tiny">Marka<input data-field="brand" value="${item.brand||''}" /></label>
+                  <label class="tiny">Model<input data-field="model" value="${item.model||''}" /></label>
+                  <label class="tiny">Rozmiar<input data-field="size" value="${item.size||''}" /></label>
+                  <label class="tiny">Data zakupu<input data-field="purchaseDate" type="date" value="${item.purchaseDate||''}" /></label>
+                  <label class="tiny">Kwota (PLN)<input data-field="purchasePrice" inputmode="decimal" value="${String(item.purchasePrice??'').toString().replace('.',',')}" /></label>
+                  <label class="tiny" style="grid-column:1 / -1;">Notatka<input data-field="purchaseNote" value="${item.purchaseNote||''}" /></label>
+                </div>
+                <div class="row" style="justify-content:flex-end;gap:8px;margin-top:8px">
+                  <button class="btn ghost" data-act="cancel-edit">Anuluj</button>
+                  <button class="btn" data-act="confirm-edit">Zapisz</button>
+                </div>
+              </div>
+            </td>`;
+          activeBody.appendChild(tr);
+          const sellBox=tr.querySelector('.inventory-inline[data-inline="sell"]');
+          const editBox=tr.querySelector('.inventory-inline[data-inline="edit"]');
+          tr.querySelector('[data-act="sell"]').onclick=()=>{
+            sellBox.style.display=sellBox.style.display==='none'?'block':'none';
+            editBox.style.display='none';
+          };
+          tr.querySelector('[data-act="edit"]').onclick=()=>{
+            editBox.style.display=editBox.style.display==='none'?'block':'none';
+            sellBox.style.display='none';
+          };
+          tr.querySelector('[data-act="remove"]').onclick=()=>{
+            if(!confirm('Usunąć tę pozycję z magazynu?')) return;
+            inventoryState.items=inventoryState.items.filter(x=>x.id!==item.id);
+            save(state);
+            renderInventory();
+          };
+          sellBox.querySelector('[data-act="cancel-sell"]').onclick=()=>{sellBox.style.display='none';};
+          sellBox.querySelector('[data-act="confirm-sell"]').onclick=()=>{
+            const price=num(sellBox.querySelector('[data-field="salePrice"]').value);
+            const currency=sellBox.querySelector('[data-field="saleCurrency"]').value || 'PLN';
+            const saleDate=sellBox.querySelector('[data-field="saleDate"]').value || todayStr;
+            const fees=num(sellBox.querySelector('[data-field="saleFees"]').value);
+            const note=sellBox.querySelector('[data-field="saleNote"]').value || '';
+            if(!price){alert('Podaj cenę sprzedaży.');return;}
+            const salePricePln = convertBetweenCurrencies(price,currency,'PLN');
+            if(currency!=='PLN' && salePricePln===null){
+              alert(`Brak kursu dla ${currency}. Pobierz aktualne kursy.`);
+              return;
+            }
+            const saleValue = currency==='PLN'?price:salePricePln;
+            const pnl = saleValue - num(item.purchasePrice) - fees;
+            inventoryState.items=inventoryState.items.filter(x=>x.id!==item.id);
+            inventoryState.sold.unshift({
+              id:item.id,
+              brand:item.brand,
+              model:item.model,
+              size:item.size,
+              purchasePrice:num(item.purchasePrice),
+              purchaseCurrency:'PLN',
+              purchaseDate:item.purchaseDate,
+              purchaseNote:item.purchaseNote,
+              salePrice:price,
+              saleCurrency:currency,
+              saleDate,
+              saleFees:fees,
+              saleNote:note,
+              salePricePln:saleValue,
+              pnlPln:pnl,
+              soldAt:new Date().toISOString()
+            });
+            save(state);
+            renderInventory();
+          };
+          editBox.querySelector('[data-act="cancel-edit"]').onclick=()=>{editBox.style.display='none';};
+          editBox.querySelector('[data-act="confirm-edit"]').onclick=()=>{
+            const brand=editBox.querySelector('[data-field="brand"]').value.trim();
+            const model=editBox.querySelector('[data-field="model"]').value.trim();
+            const size=editBox.querySelector('[data-field="size"]').value.trim();
+            const purchaseDate=editBox.querySelector('[data-field="purchaseDate"]').value;
+            const purchasePrice=num(editBox.querySelector('[data-field="purchasePrice"]').value);
+            const note=editBox.querySelector('[data-field="purchaseNote"]').value.trim();
+            if(!brand || !model || !purchasePrice){alert('Podaj markę, model i kwotę zakupu.');return;}
+            item.brand=brand;
+            item.model=model;
+            item.size=size;
+            item.purchaseDate=purchaseDate||'';
+            item.purchasePrice=purchasePrice;
+            item.purchaseNote=note;
+            item.createdAt=item.createdAt || item.purchaseDate || new Date().toISOString();
+            save(state);
+            renderInventory();
+          };
+        }
+      }
+    }
+
+    const soldBody=document.querySelector('#inventory-sold-table tbody');
+    if(soldBody){
+      soldBody.innerHTML='';
+      if(!sold.length){
+        const tr=document.createElement('tr');
+        tr.innerHTML='<td colspan="7" class="inventory-empty">Brak zarejestrowanych sprzedaży.</td>';
+        soldBody.appendChild(tr);
+      }else{
+        const sortedSold=[...sold].sort((a,b)=>{
+          const dateA=new Date(a.saleDate || a.soldAt || 0).getTime();
+          const dateB=new Date(b.saleDate || b.soldAt || 0).getTime();
+          return dateB-dateA;
+        });
+        for(const item of sortedSold){
+          const saleConverted=selectedCurrency==='PLN'?null:convertBetweenCurrencies(item.salePricePln,'PLN',selectedCurrency);
+          const pnlConverted=selectedCurrency==='PLN'?null:convertBetweenCurrencies(item.pnlPln,'PLN',selectedCurrency);
+          const roiSingle=item.purchasePrice? (item.pnlPln/item.purchasePrice)*100 : null;
+          const holdDays=inventoryDaysBetween(item.purchaseDate,item.saleDate||item.soldAt);
+          const noteHtml=item.saleNote?item.saleNote:'<span class="muted">—</span>';
+          const tr=document.createElement('tr');
+          tr.dataset.id=item.id;
+          tr.innerHTML=`<td><div><b>${item.brand||'—'}</b></div><div class="muted">${item.model||'—'}${item.size?` • ${item.size}`:''}</div></td>
+            <td><div>${fmt(item.purchasePrice,state.currency)}</div><div class="tiny">${item.purchaseDate||'—'}</div></td>
+            <td><div>${item.saleDate||'—'}</div><div class="tiny">${fmt(item.salePrice,item.saleCurrency||'PLN')}</div>${item.saleFees?`<div class="tiny">Fee: ${fmt(item.saleFees,state.currency)}</div>`:''}</td>
+            <td><div>${fmt(item.salePricePln,state.currency)}</div>${saleConverted!==null?`<div class="tiny">${fmt(saleConverted, displayCurrency)}</div>`:''}</td>
+            <td><div class="${item.pnlPln>=0?'ok':'bad'}">${fmt(item.pnlPln,state.currency)}</div>${pnlConverted!==null?`<div class="tiny">${fmt(pnlConverted, displayCurrency)}</div>`:''}</td>
+            <td><div>${roiSingle!==null && Number.isFinite(roiSingle)?`${roiSingle>=0?'+':''}${roiSingle.toFixed(1)}%`:'—'}</div><div class="tiny">Czas: ${holdDays!==null?`${Math.round(holdDays)} dni`:'—'}</div></td>
+            <td>${noteHtml}<div class="inventory-table-actions" style="margin-top:6px"><button class="btn ghost" data-act="restore">Przywróć</button><button class="btn danger" data-act="delete-sold">Usuń</button></div></td>`;
+          soldBody.appendChild(tr);
+          tr.querySelector('[data-act="restore"]').onclick=()=>{
+            if(!confirm('Przywrócić tę pozycję do magazynu?')) return;
+            inventoryState.sold=inventoryState.sold.filter(x=>x.id!==item.id);
+            inventoryState.items.unshift({
+              id:item.id,
+              brand:item.brand,
+              model:item.model,
+              size:item.size,
+              purchasePrice:item.purchasePrice,
+              purchaseCurrency:'PLN',
+              purchaseDate:item.purchaseDate,
+              purchaseNote:item.purchaseNote||'',
+              createdAt:item.purchaseDate || new Date().toISOString()
+            });
+            save(state);
+            renderInventory();
+          };
+          tr.querySelector('[data-act="delete-sold"]').onclick=()=>{
+            if(!confirm('Usunąć zapis sprzedaży?')) return;
+            inventoryState.sold=inventoryState.sold.filter(x=>x.id!==item.id);
+            save(state);
+            renderInventory();
+          };
+        }
+      }
+    }
+
+    renderInventoryBrandChart(items);
+    renderInventorySalesChart(sold);
+    bindMoneyInputs(section);
+  }
+
+
   // --- Goals ------------------------------------------------------------------
   function renderGoals(){
     const list = document.getElementById('goal-list');
@@ -2527,6 +3548,9 @@
     monthlySort:{field:'ym',dir:'desc'}
   };
   const ANALYTICS_COLORS=['#0ea5e9','#ef4444','#16a34a','#f97316','#8b5cf6','#14b8a6','#facc15','#6366f1','#0f172a'];
+  const INVENTORY_SUPPORTED_CURRENCIES=['PLN','EUR','USD'];
+  const INVENTORY_RATES_API='https://api.exchangerate.host/latest?base=PLN&symbols=EUR,USD';
+  const inventoryCharts={};
 
   function loadAnalyticsUiState(){
     try{
@@ -3855,6 +4879,7 @@
     safeRender(renderFixed,'Fixed');
     safeRender(renderVariable,'Variable');
     safeRender(renderCategories,'Categories');
+    safeRender(renderInventory,'Inventory');
     safeRender(renderGoalsAndEOM,'Goals+EOM');
     bindMoneyInputs();
   }

--- a/budget.html
+++ b/budget.html
@@ -85,6 +85,21 @@
     .chart-box.tall{height:320px}
     .chart-box.wide{height:280px}
     .insight-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;border:1px solid var(--line);font-size:12px;background:#f8fafc;margin-right:6px;margin-top:4px}
+    .insight-row{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
+    .eom-panel{background:#f8fafc;border:1px solid var(--line);border-radius:14px;padding:16px}
+    .eom-panel .title{font-size:18px;margin:0 0 6px 0}
+    .table-modern thead th{background:#f1f5f9;font-weight:600;font-size:13px;color:#475569;border-bottom:1px solid var(--line)}
+    .table-modern tbody tr:nth-child(even){background:#f8fafc}
+    .table-modern td{vertical-align:top}
+    .kpi-card{background:#0f172a;color:#fff;border-radius:14px;padding:16px;display:flex;flex-direction:column;gap:6px;min-height:120px}
+    .kpi-card.light{background:#f8fafc;color:#0f172a;border:1px solid var(--line)}
+    .kpi-card .label{font-size:12px;text-transform:uppercase;letter-spacing:0.08em;opacity:0.7}
+    .kpi-card .value{font-size:26px;font-weight:700}
+    .kpi-card .sub{font-size:12px;opacity:0.8}
+    .kpi-trend{font-size:12px;font-weight:600}
+    .kpi-trend.trend-up{color:var(--green)}
+    .kpi-trend.trend-down{color:var(--red)}
+    .kpi-trend.trend-flat{color:var(--muted)}
   </style>
 </head>
 <body>
@@ -358,35 +373,92 @@
 
     <!-- EOM -->
     <section id="tab-eom" class="card" style="margin-top:12px;display:none">
-      <h3 class="title">Salda kont (EOM)</h3>
-      <p id="eom-prompt" class="tiny"></p>
-      <form id="acct-form" class="grid g-3" style="gap:8px;margin-bottom:8px">
-        <input name="name" placeholder="Dodaj konto (np. Oszczędności, Dług na karcie)" style="grid-column: span 2;"/>
-        <button class="btn soft" type="submit">Dodaj konto</button>
-      </form>
-      <table id="eom-table">
-        <thead></thead>
-        <tbody id="eom-rows"></tbody>
-      </table>
-      <div class="row" style="margin-top:8px">
-        <div class="muted">Suma sald (Majątek Netto): <b id="eom-total">0</b></div>
-        <button id="eom-save" class="btn">Zapisz salda</button>
+      <div class="row" style="align-items:flex-start;gap:12px">
+        <div>
+          <h3 class="title" style="margin-bottom:4px">Salda i majątek netto</h3>
+          <p id="eom-prompt" class="tiny"></p>
+        </div>
+        <div class="row" style="gap:8px;align-items:center">
+          <div class="tiny muted" style="display:flex;align-items:center;gap:6px">Aktywny miesiąc <span class="pill" id="eom-active-month"></span></div>
+          <button class="btn soft" type="button" id="eom-copy-last">Skopiuj poprzedni zapis</button>
+        </div>
       </div>
 
-      <div style="margin-top:24px">
-        <h4 class="title">Historia sald i majątku netto</h4>
-        <p class="tiny">Zobacz, jak zmieniały się salda Twoich kont oraz całkowity majątek netto na przestrzeni ostatnich miesięcy.</p>
-        <div class="row" style="gap:8px; margin-bottom:8px; justify-content: flex-start;">
-           <label for="eom-history-months" style="width: auto;">Pokaż ostatnie:</label>
-           <select id="eom-history-months" style="width: auto;">
+      <div id="eom-kpis" class="grid g-4" style="margin-top:16px"></div>
+      <div id="eom-insights" class="insight-row"></div>
+
+      <div class="grid g-2" style="margin-top:16px;gap:16px">
+        <div class="eom-panel">
+          <div class="row" style="align-items:flex-end;gap:12px">
+            <div>
+              <div class="title" style="margin-bottom:4px">Rejestr sald</div>
+              <p class="tiny">Dodaj konta i uzupełnij ich stany na koniec miesiąca. Dane są przechowywane lokalnie w przeglądarce.</p>
+            </div>
+            <label class="tiny" style="display:flex;flex-direction:column;gap:4px;align-items:flex-start">
+              Filtr kont
+              <select id="eom-account-filter" style="min-width:180px">
+                <option value="all">Wszystkie konta</option>
+                <option value="positive">Saldo dodatnie</option>
+                <option value="negative">Saldo ujemne</option>
+              </select>
+            </label>
+          </div>
+          <form id="acct-form" class="grid g-3" style="gap:8px;margin:12px 0">
+            <input name="name" placeholder="Dodaj konto (np. Oszczędności, Dług na karcie)" style="grid-column: span 2;"/>
+            <button class="btn soft" type="submit">Dodaj konto</button>
+          </form>
+          <div style="overflow-x:auto">
+            <table id="eom-table" class="table-modern">
+              <thead></thead>
+              <tbody id="eom-rows"></tbody>
+            </table>
+          </div>
+          <div class="row" style="margin-top:12px">
+            <div class="muted">Suma sald (Majątek Netto): <b id="eom-total">0</b></div>
+            <div class="row" style="gap:8px">
+              <button class="btn ghost" type="button" id="eom-reset-inputs">Wyczyść pola</button>
+              <button id="eom-save" class="btn" type="button">Zapisz salda</button>
+            </div>
+          </div>
+        </div>
+        <div class="eom-panel">
+          <div class="title" style="margin-bottom:4px">Trendy majątku</div>
+          <p class="tiny">Zobacz, jak zmienia się łączny majątek netto oraz które konta odpowiadają za największe ruchy.</p>
+          <div class="chart-box tall"><canvas id="eom-networth-chart"></canvas></div>
+          <div class="chart-box tall" style="margin-top:16px"><canvas id="eom-accounts-chart"></canvas></div>
+          <div style="margin-top:16px;overflow-x:auto">
+            <table id="eom-change-table" class="table-modern table-sortable">
+              <thead></thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="eom-panel" style="margin-top:16px">
+        <div class="row" style="align-items:flex-end;gap:12px">
+          <div>
+            <div class="title" style="margin-bottom:4px">Historia sald i majątku netto</div>
+            <p class="tiny">Analizuj zmiany w czasie, aby wychwycić trendy, rekordy i anomalie.</p>
+          </div>
+          <label class="tiny" style="display:flex;flex-direction:column;gap:4px;align-items:flex-start">
+            Zakres miesięcy
+            <select id="eom-history-months" style="min-width:160px">
               <option value="3">3 miesiące</option>
               <option value="6" selected>6 miesięcy</option>
               <option value="12">12 miesięcy</option>
               <option value="all">Wszystkie</option>
-           </select>
+            </select>
+          </label>
         </div>
-        <div style="overflow-x: auto;">
-          <table id="eom-accounts-history">
+        <div style="overflow-x:auto;margin-top:12px">
+          <table id="eom-accounts-history" class="table-modern">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <div style="overflow-x:auto;margin-top:16px">
+          <table id="eom-monthly-summary" class="table-modern table-sortable">
             <thead></thead>
             <tbody></tbody>
           </table>
@@ -1401,130 +1473,732 @@
   }
 
   // --- EOM --------------------------------------------------------------------
-  function renderEOM(){
-    const ym = b().workingMonth;
-    document.getElementById('eom-prompt').innerHTML = `Wprowadź salda swoich kont na koniec <b>bieżącego</b> miesiąca (${ym}).`;
-    
-    const tableHeader = document.getElementById('eom-table').querySelector('thead');
-    tableHeader.innerHTML = `<tr><th>Konto</th><th>Saldo na koniec miesiąca (${ym})</th><th></th></tr>`;
-
-    const tbody=document.getElementById('eom-rows'); tbody.innerHTML='';
-    const rows=(b().accounts||[]).map(a=>({accountId:a.id,name:a.name,balance:(b().eom||[]).find(e=>e.ym===ym && e.accountId===a.id)?.balance||''}));
-    
-    for(const r of rows){
-      const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${r.name}</td><td><input inputmode="decimal" data-id="${r.accountId}" value="${String(r.balance).replace('.',',')}" placeholder="0,00"/></td><td><button class="btn danger" data-del="${r.accountId}">Usuń</button></td>`;
-      tr.querySelector('button[data-del]').onclick=()=>{
-        const used = (b().transactions||[]).some(t=>t.accountId===r.accountId);
-        if(used){alert('Nie można usunąć: konto ma powiązane transakcje.'); return;}
-        if(!confirm('Usunąć konto i powiązane salda EOM?')) return;
-        state.modules.budget.accounts = (b().accounts||[]).filter(x=>x.id!==r.accountId);
-        state.modules.budget.eom = (b().eom||[]).filter(e=>e.accountId!==r.accountId);
-        save(state); renderAll();
-      };
-      tbody.appendChild(tr);
+  function destroyEomChart(key){
+    if(eomCharts[key]){
+      eomCharts[key].destroy();
+      delete eomCharts[key];
     }
-    const total=()=>Array.from(tbody.querySelectorAll('input')).reduce((s,i)=>s+num(i.value),0);
-    document.getElementById('eom-total').textContent=fmt(total(),state.currency);
-    tbody.oninput=()=> document.getElementById('eom-total').textContent=fmt(total(),state.currency);
-    document.getElementById('eom-save').onclick=()=>{
-      const inputs=Array.from(tbody.querySelectorAll('input'));
-      for(const inp of inputs){
-        const accountId=inp.dataset.id; const bal=num(inp.value)||0;
-        state.modules.budget.eom = (b().eom||[]).filter(e=>!(e.ym===ym && e.accountId===accountId));
-        state.modules.budget.eom.push({ym:ym,accountId,balance:bal});
-      }
-      save(state); renderEOM(); renderEOMHistory();
+  }
+
+  function sumBalances(map){
+    return Object.values(map || {}).reduce((sum, val) => sum + (Number(val) || 0), 0);
+  }
+
+  function buildEomContext(){
+    const accounts = b().accounts || [];
+    const entries = (b().eom || []).map(entry => ({
+      ym: String(entry.ym),
+      accountId: entry.accountId,
+      balance: num(entry.balance)
+    })).filter(entry => entry.ym && entry.accountId);
+
+    const monthBalances = {};
+    const accountHistory = {};
+
+    for(const entry of entries){
+      if(!monthBalances[entry.ym]) monthBalances[entry.ym] = {};
+      monthBalances[entry.ym][entry.accountId] = entry.balance;
+      if(!accountHistory[entry.accountId]) accountHistory[entry.accountId] = [];
+      accountHistory[entry.accountId].push({ ym: entry.ym, balance: entry.balance });
+    }
+
+    Object.values(accountHistory).forEach(hist => hist.sort((a,b) => a.ym.localeCompare(b.ym)));
+
+    const months = Object.keys(monthBalances).sort();
+    const workingYm = b().workingMonth;
+    const workingBalances = monthBalances[workingYm] || {};
+    const hasWorking = Object.keys(workingBalances).length > 0;
+    const latestMonth = months.length ? months[months.length - 1] : null;
+    const focusMonth = hasWorking ? workingYm : latestMonth;
+    const focusPrevMonth = focusMonth ? months.filter(m => m < focusMonth).pop() || null : null;
+    const focusBalances = focusMonth ? (monthBalances[focusMonth] || {}) : {};
+    const focusPrevBalances = focusPrevMonth ? (monthBalances[focusPrevMonth] || {}) : {};
+    const netWorthByMonth = months.map(ym => ({ ym, total: sumBalances(monthBalances[ym]) }));
+
+    return {
+      accounts,
+      accountHistory,
+      monthBalances,
+      months,
+      workingYm,
+      workingBalances,
+      hasWorking,
+      latestMonth,
+      focusMonth,
+      focusPrevMonth,
+      focusBalances,
+      focusPrevBalances,
+      netWorthByMonth
     };
-    renderEOMHistory(); 
+  }
+
+  function entryForMonth(history, ym){
+    if(!history) return null;
+    return history.find(item => item.ym === ym) || null;
+  }
+
+  function lastEntryBefore(history, ym){
+    if(!history) return null;
+    let prev = null;
+    for(const item of history){
+      if(item.ym < ym){
+        prev = item;
+      } else if(item.ym >= ym){
+        break;
+      }
+    }
+    return prev;
+  }
+
+  function computeAccountStatsForMonth(ctx, targetMonth){
+    if(!targetMonth) return [];
+    const { accounts, accountHistory } = ctx;
+    return accounts.map(acc => {
+      const history = accountHistory[acc.id] || [];
+      const historyUpTo = history.filter(item => item.ym <= targetMonth);
+      if(historyUpTo.length === 0) return null;
+      const currentEntry = entryForMonth(history, targetMonth);
+      const prevEntry = lastEntryBefore(history, targetMonth);
+      const delta = (currentEntry || prevEntry) ? ((currentEntry?.balance ?? 0) - (prevEntry?.balance ?? 0)) : null;
+      const deltaPct = prevEntry && prevEntry.balance ? (delta / Math.abs(prevEntry.balance)) * 100 : null;
+      const lastThree = historyUpTo.slice(-3);
+      const avg3 = lastThree.length ? lastThree.reduce((sum, item) => sum + item.balance, 0) / lastThree.length : null;
+      const trendVsAvg = currentEntry && avg3 !== null ? currentEntry.balance - avg3 : null;
+      const maxEntry = historyUpTo.reduce((max, item) => !max || item.balance > max.balance ? item : max, null);
+      const minEntry = historyUpTo.reduce((min, item) => !min || item.balance < min.balance ? item : min, null);
+      return {
+        account: acc,
+        current: currentEntry ? currentEntry.balance : null,
+        currentYm: currentEntry?.ym || targetMonth,
+        previous: prevEntry ? prevEntry.balance : null,
+        previousYm: prevEntry?.ym || null,
+        delta,
+        deltaPct,
+        avg3,
+        trendVsAvg,
+        maxEntry,
+        minEntry
+      };
+    }).filter(Boolean);
+  }
+
+  function computeMonthlySummary(ctx){
+    const { months, monthBalances, accounts, accountHistory } = ctx;
+    return months.map(ym => {
+      const balances = monthBalances[ym] || {};
+      const netWorth = sumBalances(balances);
+      const prevMonth = months.filter(m => m < ym).pop() || null;
+      const prevBalances = prevMonth ? (monthBalances[prevMonth] || {}) : {};
+      const prevNetWorth = prevMonth !== null ? sumBalances(prevBalances) : null;
+      const delta = prevNetWorth !== null ? netWorth - prevNetWorth : null;
+      let positive = 0;
+      let negative = 0;
+      for(const value of Object.values(balances)){
+        const val = Number(value) || 0;
+        if(val >= 0) positive += val;
+        else negative += val;
+      }
+      const base = positive + Math.abs(negative);
+      const debtShare = base ? (Math.abs(negative) / base) * 100 : 0;
+      let best = null;
+      let worst = null;
+      for(const acc of accounts){
+        const history = accountHistory[acc.id] || [];
+        if(history.length === 0) continue;
+        const current = entryForMonth(history, ym)?.balance ?? null;
+        const prevEntry = lastEntryBefore(history, ym);
+        if(current === null && !prevEntry) continue;
+        const deltaAcc = (current ?? 0) - (prevEntry?.balance ?? 0);
+        if(!best || deltaAcc > best.delta) best = { account: acc, delta: deltaAcc };
+        if(!worst || deltaAcc < worst.delta) worst = { account: acc, delta: deltaAcc };
+      }
+      return { ym, netWorth, delta, positive, negative, debtShare, best, worst };
+    });
+  }
+
+  function renderDeltaBadge(delta){
+    if(delta === null || delta === undefined) return '<span class="delta-neutral">—</span>';
+    if(Math.abs(delta) < 0.005) return '<span class="delta-neutral">—</span>';
+    const cls = delta > 0 ? 'delta-up' : 'delta-down';
+    const sign = delta > 0 ? '+' : '';
+    return `<span class="${cls}">${sign}${fmt(delta, state.currency)}</span>`;
+  }
+
+  function renderEomKpis(ctx, accountStats){
+    const container = document.getElementById('eom-kpis');
+    if(!container) return;
+    if(!ctx.months.length){
+      container.innerHTML = `<p class="muted" style="grid-column:1 / -1;text-align:center;">Dodaj pierwsze salda, aby zobaczyć wskaźniki.</p>`;
+      return;
+    }
+    const netWorth = sumBalances(ctx.focusBalances);
+    const prevNetWorth = ctx.focusPrevMonth ? sumBalances(ctx.focusPrevBalances) : null;
+    const delta = prevNetWorth !== null ? netWorth - prevNetWorth : null;
+    const deltaExists = delta !== null && Math.abs(delta) >= 0.005;
+    const deltaValue = deltaExists ? `${delta > 0 ? '+' : ''}${fmt(delta, state.currency)}` : '—';
+    let changeInfo = '<span class="kpi-trend trend-flat">Brak danych do porównania</span>';
+    if(deltaExists){
+      const deltaPct = prevNetWorth ? (delta / prevNetWorth) * 100 : null;
+      const pctText = deltaPct !== null ? ` (${delta > 0 ? '+' : ''}${deltaPct.toFixed(1)}%)` : '';
+      changeInfo = `<span class="kpi-trend ${delta > 0 ? 'trend-up' : 'trend-down'}">${delta > 0 ? 'Wzrost' : 'Spadek'} ${delta > 0 ? '+' : ''}${fmt(delta, state.currency)}${pctText}</span>`;
+    }
+    const positive = Object.values(ctx.focusBalances).reduce((sum, val) => sum + (Number(val) >= 0 ? Number(val) : 0), 0);
+    const liabilities = Object.values(ctx.focusBalances).reduce((sum, val) => sum + (Number(val) < 0 ? Number(val) : 0), 0);
+    const base = positive + Math.abs(liabilities);
+    const debtShare = base ? (Math.abs(liabilities) / base) * 100 : 0;
+    const bestAccount = accountStats.filter(row => Number.isFinite(row.delta)).sort((a,b) => (b.delta || 0) - (a.delta || 0))[0];
+    const worstAccount = accountStats.filter(row => Number.isFinite(row.delta)).sort((a,b) => (a.delta || 0) - (b.delta || 0))[0];
+    const bestLine = bestAccount && Math.abs(bestAccount.delta || 0) >= 0.005
+      ? `<div><span class="ok">▲ ${bestAccount.account.name}</span> ${fmt(bestAccount.delta, state.currency)}</div>`
+      : '<div class="muted">Brak wzrostów</div>';
+    const worstLine = worstAccount && Math.abs(worstAccount.delta || 0) >= 0.005
+      ? `<div><span class="bad">▼ ${worstAccount.account.name}</span> ${fmt(worstAccount.delta, state.currency)}</div>`
+      : '<div class="muted">Brak spadków</div>';
+    const focusLabel = ctx.focusMonth
+      ? (ctx.focusMonth === ctx.workingYm ? `Dane z ${ctx.focusMonth}` : `Ostatni zapis: ${ctx.focusMonth}`)
+      : 'Brak zapisów';
+
+    container.innerHTML = `
+      <div class="kpi-card">
+        <div class="label">Majątek netto</div>
+        <div class="value">${fmt(netWorth, state.currency)}</div>
+        <div class="sub">${focusLabel}</div>
+      </div>
+      <div class="kpi-card light">
+        <div class="label">Zmiana m/m</div>
+        <div class="value">${deltaValue}</div>
+        ${changeInfo}
+      </div>
+      <div class="kpi-card light">
+        <div class="label">Największe ruchy</div>
+        ${bestLine}
+        ${worstLine}
+      </div>
+      <div class="kpi-card light">
+        <div class="label">Struktura</div>
+        <div>Płynne aktywa: <b>${fmt(positive, state.currency)}</b></div>
+        <div>Zobowiązania: <b>${fmt(Math.abs(liabilities), state.currency)}</b></div>
+        <div class="sub">Dług to ${debtShare.toFixed(1)}% portfela</div>
+      </div>
+    `;
+  }
+
+  function renderEomInsights(ctx, summaryRows){
+    const container = document.getElementById('eom-insights');
+    if(!container) return;
+    if(!ctx.months.length){
+      container.innerHTML = '';
+      return;
+    }
+    const insights = [];
+    if(ctx.netWorthByMonth.length){
+      const record = ctx.netWorthByMonth.reduce((max, item) => item.total > (max?.total ?? -Infinity) ? item : max, null);
+      if(record){
+        insights.push(`<span class="insight-pill">📈 Rekord: ${record.ym} — ${fmt(record.total, state.currency)}</span>`);
+      }
+      const low = ctx.netWorthByMonth.reduce((min, item) => item.total < (min?.total ?? Infinity) ? item : min, null);
+      if(low && low.ym !== record?.ym){
+        insights.push(`<span class="insight-pill">📉 Najniższy poziom: ${low.ym} — ${fmt(low.total, state.currency)}</span>`);
+      }
+    }
+    const swing = summaryRows.filter(row => row.delta !== null && Math.abs(row.delta) >= 0.005)
+      .sort((a,b) => Math.abs((b.delta || 0)) - Math.abs((a.delta || 0)))[0];
+    if(swing){
+      insights.push(`<span class="insight-pill">${swing.delta > 0 ? '🟢' : '🔻'} Największa zmiana: ${swing.ym} ${swing.delta > 0 ? '+' : ''}${fmt(swing.delta, state.currency)}</span>`);
+    }
+    const total = sumBalances(ctx.focusBalances);
+    if(total){
+      let top = null;
+      for(const acc of ctx.accounts){
+        const value = ctx.focusBalances[acc.id];
+        if(value === undefined) continue;
+        const share = (value / total) * 100;
+        if(!top || Math.abs(share) > Math.abs(top.share)){
+          top = { account: acc, value, share };
+        }
+      }
+      if(top){
+        insights.push(`<span class="insight-pill">${top.value >= 0 ? '🏦' : '💳'} ${top.account.name}: ${fmt(top.value, state.currency)} (${top.share.toFixed(1)}%)</span>`);
+      }
+    }
+    const liabilities = Object.values(ctx.focusBalances).filter(v => Number(v) < 0).reduce((sum, val) => sum + Number(val), 0);
+    if(liabilities){
+      const base = Object.values(ctx.focusBalances).reduce((sum, val) => sum + Math.abs(Number(val) || 0), 0);
+      const ratio = base ? (Math.abs(liabilities) / base) * 100 : 0;
+      insights.push(`<span class="insight-pill">⚠️ Długi: ${fmt(Math.abs(liabilities), state.currency)} (${ratio.toFixed(1)}% aktywów)</span>`);
+    }
+    container.innerHTML = insights.join('');
+  }
+
+  function renderEomHistoryTable(ctx, monthsToShow){
+    const table = document.getElementById('eom-accounts-history');
+    if(!table) return;
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    if(thead) thead.innerHTML = '';
+    if(tbody) tbody.innerHTML = '';
+    if(!monthsToShow.length){
+      if(tbody) tbody.innerHTML = `<tr><td class="muted" style="text-align:center;padding:16px;">Brak danych historycznych do wyświetlenia.</td></tr>`;
+      return;
+    }
+    if(!thead || !tbody) return;
+    let header = '<tr><th>Miesiąc</th>';
+    for(const acc of ctx.accounts){ header += `<th>${acc.name}</th>`; }
+    header += '<th>Majątek netto</th><th>Zmiana m/m</th></tr>';
+    thead.innerHTML = header;
+    let prevNetWorth = null;
+    for(const ym of monthsToShow){
+      const balances = ctx.monthBalances[ym] || {};
+      const prevMonth = ctx.months.filter(m => m < ym).pop() || null;
+      const prevBalances = prevMonth ? (ctx.monthBalances[prevMonth] || {}) : {};
+      let row = `<td><b>${ym}</b></td>`;
+      for(const acc of ctx.accounts){
+        const value = balances[acc.id];
+        if(value === undefined){
+          row += '<td class="muted">—</td>';
+        } else {
+          const prevVal = prevBalances[acc.id];
+          let change = '';
+          if(prevVal !== undefined){
+            const diff = value - prevVal;
+            if(Math.abs(diff) >= 0.005){
+              change = `<br><span class="tiny ${diff >= 0 ? 'ok' : 'bad'}">${diff >= 0 ? '+' : ''}${fmt(diff, state.currency)}</span>`;
+            }
+          }
+          row += `<td>${fmt(value, state.currency)}${change}</td>`;
+        }
+      }
+      const netWorth = sumBalances(balances);
+      const deltaTotal = prevNetWorth !== null ? netWorth - prevNetWorth : null;
+      row += `<td><b>${fmt(netWorth, state.currency)}</b></td>`;
+      row += `<td>${deltaTotal === null ? '<span class="muted">—</span>' : renderDeltaBadge(deltaTotal)}</td>`;
+      const tr = document.createElement('tr');
+      tr.innerHTML = row;
+      tbody.appendChild(tr);
+      prevNetWorth = netWorth;
+    }
+  }
+
+  function renderEomChangeTable(ctx, accountStats){
+    const table = document.getElementById('eom-change-table');
+    if(!table) return;
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    if(thead) thead.innerHTML = '';
+    if(tbody) tbody.innerHTML = '';
+    if(!accountStats.length){
+      if(tbody) tbody.innerHTML = `<tr><td colspan="7" class="muted" style="text-align:center;padding:16px;">Brak historii kont do analizy.</td></tr>`;
+      return;
+    }
+    if(!thead || !tbody) return;
+    const sortState = eomUiState.changeSort;
+    const cols = [
+      { label:'Konto', key:'name' },
+      { label:`Saldo (${ctx.focusMonth || ctx.workingYm})`, key:'current' },
+      { label:ctx.focusPrevMonth ? `Poprzednio (${ctx.focusPrevMonth})` : 'Poprzednio', key:'previous' },
+      { label:'Zmiana m/m', key:'delta' },
+      { label:'Zmiana %', key:'deltaPct' },
+      { label:'vs średnia 3m', key:'trendVsAvg' },
+      { label:'Rekord', key:'max' }
+    ];
+    thead.innerHTML = '<tr>' + cols.map(col => {
+      const active = sortState.field === col.key;
+      const indicator = active ? `<span class="sort-indicator">${sortState.dir === 'asc' ? '▲' : '▼'}</span>` : '';
+      return `<th data-sort="${col.key}">${col.label}${indicator}</th>`;
+    }).join('') + '</tr>';
+
+    const rows = accountStats.map(stat => ({
+      ...stat,
+      name: stat.account.name,
+      max: stat.maxEntry?.balance ?? null
+    }));
+
+    rows.sort((a,b) => {
+      const dir = sortState.dir === 'asc' ? 1 : -1;
+      const key = sortState.field;
+      if(key === 'name') return a.name.localeCompare(b.name, 'pl', { sensitivity:'base' }) * dir;
+      const mapValue = (row) => {
+        switch(key){
+          case 'current': return row.current ?? -Infinity;
+          case 'previous': return row.previous ?? -Infinity;
+          case 'delta': return row.delta ?? 0;
+          case 'deltaPct': return row.deltaPct ?? -Infinity;
+          case 'trendVsAvg': return row.trendVsAvg ?? -Infinity;
+          case 'max': return row.maxEntry?.balance ?? -Infinity;
+          default: return row[key] ?? 0;
+        }
+      };
+      const av = mapValue(a);
+      const bv = mapValue(b);
+      if(av === bv) return a.name.localeCompare(b.name, 'pl', { sensitivity:'base' }) * dir;
+      return (av - bv) * dir;
+    });
+
+    tbody.innerHTML = rows.map(row => {
+      const currentHtml = row.current === null
+        ? '<span class="muted">—</span>'
+        : `${fmt(row.current, state.currency)}${row.currentYm && row.currentYm !== ctx.focusMonth ? `<br><span class="tiny muted">${row.currentYm}</span>` : ''}`;
+      const previousHtml = row.previous === null
+        ? '<span class="muted">—</span>'
+        : `${fmt(row.previous, state.currency)}${row.previousYm ? `<br><span class="tiny muted">${row.previousYm}</span>` : ''}`;
+      const deltaHtml = row.delta === null ? '<span class="muted">—</span>' : renderDeltaBadge(row.delta);
+      const pctHtml = row.deltaPct === null ? '<span class="muted">—</span>' : `<span class="${row.deltaPct >= 0 ? 'ok' : 'bad'}">${row.deltaPct >= 0 ? '+' : ''}${row.deltaPct.toFixed(1)}%</span>`;
+      const avgHtml = row.trendVsAvg === null ? '<span class="muted">—</span>' : renderDeltaBadge(row.trendVsAvg);
+      const maxHtml = row.maxEntry
+        ? `${fmt(row.maxEntry.balance, state.currency)}<br><span class="tiny muted">${row.maxEntry.ym}</span>`
+        : '<span class="muted">—</span>';
+      return `<tr><td>${row.name}</td><td>${currentHtml}</td><td>${previousHtml}</td><td>${deltaHtml}</td><td>${pctHtml}</td><td>${avgHtml}</td><td>${maxHtml}</td></tr>`;
+    }).join('');
+
+    thead.querySelectorAll('th[data-sort]').forEach(th => {
+      const key = th.dataset.sort;
+      th.onclick = () => {
+        if(eomUiState.changeSort.field === key){
+          eomUiState.changeSort.dir = eomUiState.changeSort.dir === 'asc' ? 'desc' : 'asc';
+        } else {
+          eomUiState.changeSort.field = key;
+          eomUiState.changeSort.dir = key === 'name' ? 'asc' : 'desc';
+        }
+        renderEOMHistory();
+      };
+    });
+  }
+
+  function renderEomMonthlySummary(summaryRows){
+    const table = document.getElementById('eom-monthly-summary');
+    if(!table) return;
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    if(thead) thead.innerHTML = '';
+    if(tbody) tbody.innerHTML = '';
+    if(!summaryRows.length){
+      if(tbody) tbody.innerHTML = `<tr><td colspan="8" class="muted" style="text-align:center;padding:16px;">Brak danych historycznych do zestawienia.</td></tr>`;
+      return;
+    }
+    if(!thead || !tbody) return;
+    const sortState = eomUiState.monthlySort;
+    const cols = [
+      { label:'Miesiąc', key:'ym' },
+      { label:'Majątek netto', key:'netWorth' },
+      { label:'Zmiana m/m', key:'delta' },
+      { label:'Największy wzrost', key:'best' },
+      { label:'Największy spadek', key:'worst' },
+      { label:'Saldo dodatnie', key:'positive' },
+      { label:'Saldo ujemne', key:'negative' },
+      { label:'Udział długu', key:'debtShare' }
+    ];
+    thead.innerHTML = '<tr>' + cols.map(col => {
+      const active = sortState.field === col.key;
+      const indicator = active ? `<span class="sort-indicator">${sortState.dir === 'asc' ? '▲' : '▼'}</span>` : '';
+      return `<th data-sort="${col.key}">${col.label}${indicator}</th>`;
+    }).join('') + '</tr>';
+
+    const rows = [...summaryRows];
+    rows.sort((a,b) => {
+      const dir = sortState.dir === 'asc' ? 1 : -1;
+      const key = sortState.field;
+      if(key === 'ym') return a.ym.localeCompare(b.ym) * dir;
+      if(key === 'best'){
+        const av = a.best ? a.best.delta : -Infinity;
+        const bv = b.best ? b.best.delta : -Infinity;
+        if(av === bv) return a.ym.localeCompare(b.ym) * dir;
+        return (av - bv) * dir;
+      }
+      if(key === 'worst'){
+        const av = a.worst ? a.worst.delta : Infinity;
+        const bv = b.worst ? b.worst.delta : Infinity;
+        if(av === bv) return a.ym.localeCompare(b.ym) * dir;
+        return (av - bv) * dir;
+      }
+      const av = Number(a[key] ?? 0);
+      const bv = Number(b[key] ?? 0);
+      if(av === bv) return a.ym.localeCompare(b.ym) * dir;
+      return (av - bv) * dir;
+    });
+
+    tbody.innerHTML = rows.map(row => {
+      const deltaHtml = row.delta === null ? '<span class="muted">—</span>' : renderDeltaBadge(row.delta);
+      const bestHtml = row.best
+        ? `<div>${row.best.account.name}</div><div class="tiny ok">${row.best.delta > 0 ? '+' : ''}${fmt(row.best.delta, state.currency)}</div>`
+        : '<span class="muted">—</span>';
+      const worstHtml = row.worst
+        ? `<div>${row.worst.account.name}</div><div class="tiny bad">${row.worst.delta > 0 ? '+' : ''}${fmt(row.worst.delta, state.currency)}</div>`
+        : '<span class="muted">—</span>';
+      return `<tr><td><b>${row.ym}</b></td><td>${fmt(row.netWorth, state.currency)}</td><td>${deltaHtml}</td><td>${bestHtml}</td><td>${worstHtml}</td><td>${fmt(row.positive, state.currency)}</td><td>${fmt(Math.abs(row.negative), state.currency)}</td><td>${row.debtShare.toFixed(1)}%</td></tr>`;
+    }).join('');
+
+    thead.querySelectorAll('th[data-sort]').forEach(th => {
+      const key = th.dataset.sort;
+      th.onclick = () => {
+        if(eomUiState.monthlySort.field === key){
+          eomUiState.monthlySort.dir = eomUiState.monthlySort.dir === 'asc' ? 'desc' : 'asc';
+        } else {
+          eomUiState.monthlySort.field = key;
+          eomUiState.monthlySort.dir = key === 'ym' ? 'desc' : 'desc';
+        }
+        renderEOMHistory();
+      };
+    });
+  }
+
+  function renderEomNetWorthChart(ctx, monthsToShow){
+    const canvas = document.getElementById('eom-networth-chart');
+    if(!canvas) return;
+    destroyEomChart('netWorth');
+    if(!monthsToShow.length) return;
+    const labels = monthsToShow;
+    const data = labels.map(ym => sumBalances(ctx.monthBalances[ym] || {}));
+    eomCharts.netWorth = new Chart(canvas.getContext('2d'), {
+      type:'line',
+      data:{
+        labels,
+        datasets:[{
+          label:'Majątek netto',
+          data,
+          borderColor:'#0f172a',
+          backgroundColor:'rgba(15,23,42,0.12)',
+          borderWidth:2,
+          tension:0.35,
+          fill:true
+        }]
+      },
+      options:{
+        responsive:true,
+        maintainAspectRatio:false,
+        plugins:{
+          legend:{ display:false },
+          tooltip:{ callbacks:{ label: context => `${fmt(context.parsed.y, state.currency)}` } }
+        },
+        scales:{
+          y:{ ticks:{ callback: currencyTicks } }
+        }
+      }
+    });
+  }
+
+  function renderEomAccountsChart(ctx, monthsToShow){
+    const canvas = document.getElementById('eom-accounts-chart');
+    if(!canvas) return;
+    destroyEomChart('accounts');
+    if(!monthsToShow.length) return;
+    const ranked = ctx.accounts.map(acc => ({
+      acc,
+      value: Math.abs(ctx.focusBalances[acc.id] ?? 0)
+    })).sort((a,b) => b.value - a.value).slice(0, 6);
+    if(!ranked.length) return;
+    const datasets = ranked.map((item, idx) => {
+      const history = ctx.accountHistory[item.acc.id] || [];
+      return {
+        label: item.acc.name,
+        data: monthsToShow.map(ym => {
+          const entry = entryForMonth(history, ym);
+          return entry ? entry.balance : null;
+        }),
+        borderColor: ANALYTICS_COLORS[idx % ANALYTICS_COLORS.length],
+        backgroundColor: withAlpha(ANALYTICS_COLORS[idx % ANALYTICS_COLORS.length], 0.14),
+        borderWidth:2,
+        tension:0.35,
+        fill:false,
+        spanGaps:true
+      };
+    });
+    eomCharts.accounts = new Chart(canvas.getContext('2d'), {
+      type:'line',
+      data:{ labels: monthsToShow, datasets },
+      options:{
+        responsive:true,
+        maintainAspectRatio:false,
+        plugins:{
+          legend:{ position:'bottom' },
+          tooltip:{ callbacks:{ label: context => `${context.dataset.label}: ${fmt(context.parsed.y, state.currency)}` } }
+        },
+        scales:{
+          y:{ ticks:{ callback: currencyTicks } }
+        }
+      }
+    });
+  }
+
+  function renderEOM(){
+    const ctx = buildEomContext();
+    const ym = ctx.workingYm;
+    const prompt = document.getElementById('eom-prompt');
+    if(prompt){
+      const lastInfo = ctx.hasWorking
+        ? 'Masz już zapisane salda dla tego miesiąca — możesz je zaktualizować.'
+        : ctx.latestMonth ? `Ostatnio zapisano dane dla ${ctx.latestMonth}.` : 'To będzie Twój pierwszy zapis sald.';
+      prompt.innerHTML = `Wprowadź salda swoich kont na koniec miesiąca <b>${ym}</b>. <span class="muted">${lastInfo}</span>`;
+    }
+    const badge = document.getElementById('eom-active-month');
+    if(badge) badge.textContent = ym;
+
+    const tableHeader = document.getElementById('eom-table')?.querySelector('thead');
+    if(tableHeader){
+      tableHeader.innerHTML = `<tr><th>Konto</th><th>Ostatni zapis</th><th>Saldo ${ym}</th><th>Zmiana</th><th></th></tr>`;
+    }
+
+    const tbody = document.getElementById('eom-rows');
+    if(!tbody) return;
+    tbody.innerHTML = '';
+
+    const updateTotal = () => {
+      const total = Array.from(tbody.querySelectorAll('input')).reduce((sum, input) => sum + (input.value.trim() ? num(input.value) : 0), 0);
+      const totalEl = document.getElementById('eom-total');
+      if(totalEl) totalEl.textContent = fmt(total, state.currency);
+    };
+
+    const filterSel = document.getElementById('eom-account-filter');
+    const filterValue = filterSel ? filterSel.value : 'all';
+    if(filterSel && !filterSel.dataset.bound){
+      filterSel.dataset.bound = '1';
+      filterSel.addEventListener('change', renderEOM);
+    }
+
+    const rows = ctx.accounts.map(acc => {
+      const history = ctx.accountHistory[acc.id] || [];
+      const currentEntry = entryForMonth(history, ym);
+      const prevEntry = lastEntryBefore(history, ym);
+      const referenceValue = currentEntry ? currentEntry.balance : (prevEntry ? prevEntry.balance : 0);
+      if(filterValue === 'positive' && referenceValue <= 0) return null;
+      if(filterValue === 'negative' && referenceValue >= 0) return null;
+      return { acc, currentEntry, prevEntry };
+    }).filter(Boolean);
+
+    const updateFns = [];
+
+    if(rows.length === 0){
+      tbody.innerHTML = `<tr><td colspan="5" class="muted" style="text-align:center;padding:16px;">Brak kont do wyświetlenia. Dodaj konto lub zmień filtr.</td></tr>`;
+    } else {
+      for(const row of rows){
+        const acc = row.acc;
+        const prevEntry = row.prevEntry;
+        const previousBalance = prevEntry ? prevEntry.balance : null;
+        const previousLabel = prevEntry
+          ? `${fmt(prevEntry.balance, state.currency)}<br><span class="tiny muted">${prevEntry.ym}</span>`
+          : '<span class="muted">Brak danych</span>';
+        const currentValue = row.currentEntry ? String(row.currentEntry.balance).replace('.',',') : '';
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><div><b>${acc.name}</b></div></td>
+          <td>${previousLabel}</td>
+          <td><input inputmode="decimal" data-id="${acc.id}" value="${currentValue}" placeholder="0,00"/></td>
+          <td data-delta="${acc.id}"><span class="muted">—</span></td>
+          <td><button class="btn danger" data-del="${acc.id}">Usuń</button></td>
+        `;
+        const input = tr.querySelector('input');
+        const deltaCell = tr.querySelector('[data-delta]');
+        const updateRow = () => {
+          const raw = input.value.trim() === '' ? null : num(input.value);
+          if(raw === null){
+            deltaCell.innerHTML = '<span class="muted">—</span>';
+          } else {
+            const baseline = previousBalance ?? 0;
+            deltaCell.innerHTML = renderDeltaBadge(raw - baseline);
+          }
+          updateTotal();
+        };
+        updateFns.push(updateRow);
+        input.addEventListener('input', updateRow);
+        tr.querySelector('button[data-del]').onclick = () => {
+          const used = (b().transactions || []).some(t => t.accountId === acc.id);
+          if(used){ alert('Nie można usunąć: konto ma powiązane transakcje.'); return; }
+          if(!confirm('Usunąć konto i powiązane salda EOM?')) return;
+          state.modules.budget.accounts = (b().accounts || []).filter(x => x.id !== acc.id);
+          state.modules.budget.eom = (b().eom || []).filter(e => e.accountId !== acc.id);
+          save(state);
+          renderAll();
+        };
+        tbody.appendChild(tr);
+      }
+    }
+
+    updateFns.forEach(fn => fn());
+    updateTotal();
     bindMoneyInputs(tbody);
-    document.getElementById('eom-history-months').onchange = renderEOMHistory;
+
+    const saveBtn = document.getElementById('eom-save');
+    if(saveBtn){
+      saveBtn.onclick = () => {
+        const inputs = Array.from(tbody.querySelectorAll('input'));
+        for(const inp of inputs){
+          const accountId = inp.dataset.id;
+          const raw = inp.value.trim();
+          state.modules.budget.eom = (b().eom || []).filter(e => !(e.ym === ym && e.accountId === accountId));
+          if(raw !== ''){
+            const bal = num(inp.value) || 0;
+            state.modules.budget.eom.push({ ym, accountId, balance: bal });
+          }
+        }
+        save(state);
+        renderEOM();
+        renderEOMHistory();
+      };
+    }
+
+    const copyBtn = document.getElementById('eom-copy-last');
+    if(copyBtn){
+      copyBtn.onclick = () => {
+        for(const row of rows){
+          const history = ctx.accountHistory[row.acc.id] || [];
+          const source = lastEntryBefore(history, ym) || history[history.length - 1];
+          if(!source) continue;
+          const input = tbody.querySelector(`input[data-id="${row.acc.id}"]`);
+          if(input){
+            input.value = String(source.balance).replace('.',',');
+            input.dispatchEvent(new Event('input', { bubbles:true }));
+          }
+        }
+      };
+    }
+
+    const resetBtn = document.getElementById('eom-reset-inputs');
+    if(resetBtn){
+      resetBtn.onclick = () => {
+        tbody.querySelectorAll('input').forEach(inp => {
+          inp.value = '';
+          inp.dispatchEvent(new Event('input', { bubbles:true }));
+        });
+      };
+    }
+
+    renderEOMHistory();
   }
 
   function renderEOMHistory(){
-    const historyTable = document.getElementById('eom-accounts-history');
-    const thead = historyTable.querySelector('thead');
-    const tbody = historyTable.querySelector('tbody');
-    thead.innerHTML = '';
-    tbody.innerHTML = '';
-
-    const accounts = b().accounts || [];
-    const eomData = b().eom || [];
-
-    if (accounts.length === 0 || eomData.length === 0) {
-        tbody.innerHTML = `<tr><td colspan="100%" style="text-align:center; padding: 16px;" class="muted">Brak zdefiniowanych kont lub historii sald. Dodaj konto i zapisz saldo, aby zobaczyć historię.</td></tr>`;
-        return;
+    const ctx = buildEomContext();
+    const select = document.getElementById('eom-history-months');
+    let limitValue = select ? select.value : '6';
+    if(select && !select.dataset.bound){
+      select.dataset.bound = '1';
+      select.addEventListener('change', renderEOMHistory);
     }
-    
-    const dataByMonth = eomData.reduce((acc, entry) => {
-        if (!acc[entry.ym]) acc[entry.ym] = {};
-        acc[entry.ym][entry.accountId] = entry.balance;
-        return acc;
-    }, {});
+    const months = ctx.months;
+    const monthsToShow = !months.length
+      ? []
+      : (limitValue === 'all' ? months : months.slice(-Number(limitValue || 6)));
 
-    const allMonths = Object.keys(dataByMonth).sort();
-    
-    let monthLimit = document.getElementById('eom-history-months').value;
-    const monthsToShow = monthLimit === 'all' ? allMonths : allMonths.slice(-monthLimit);
-
-    if (monthsToShow.length === 0) {
-        tbody.innerHTML = `<tr><td colspan="${accounts.length + 3}" style="text-align:center; padding: 16px;" class="muted">Brak danych historycznych do wyświetlenia dla wybranego okresu.</td></tr>`;
-        return;
+    if(!months.length){
+      renderEomKpis(ctx, []);
+      renderEomInsights(ctx, []);
+      renderEomHistoryTable(ctx, []);
+      renderEomChangeTable(ctx, []);
+      renderEomMonthlySummary([]);
+      destroyEomChart('netWorth');
+      destroyEomChart('accounts');
+      return;
     }
 
-    let headerHtml = '<tr><th>Miesiąc</th>';
-    accounts.forEach(acc => headerHtml += `<th>${acc.name}</th>`);
-    headerHtml += '<th>Majątek Netto</th><th>Zmiana m/m</th></tr>';
-    thead.innerHTML = headerHtml;
+    const focusTarget = ctx.focusMonth || ctx.latestMonth || months[months.length - 1];
+    const accountStats = computeAccountStatsForMonth(ctx, focusTarget);
+    const monthlySummary = computeMonthlySummary(ctx);
 
-    let previousNetWorth = null;
-    const firstMonthIndex = allMonths.indexOf(monthsToShow[0]);
-    if (firstMonthIndex > 0) {
-        const prevMonthYm = allMonths[firstMonthIndex - 1];
-        previousNetWorth = accounts.reduce((sum, acc) => sum + (num(dataByMonth[prevMonthYm]?.[acc.id]) || 0), 0);
-    }
-    
-    for (const ym of monthsToShow) {
-        const tr = document.createElement('tr');
-        let rowHtml = `<td><b>${ym}</b></td>`;
-        let currentNetWorth = 0;
-        const prevYm = ymAdd(ym, -1);
-
-        accounts.forEach(acc => {
-            const balance = dataByMonth[ym]?.[acc.id];
-            const prevBalance = dataByMonth[prevYm]?.[acc.id];
-            
-            if (typeof balance === 'number') {
-                let changeHtml = '';
-                if (typeof prevBalance === 'number') {
-                    const change = balance - prevBalance;
-                    if (change !== 0) {
-                       const changeClass = change > 0 ? 'ok' : 'bad';
-                       changeHtml = ` <span class="tiny ${changeClass}">(${change > 0 ? '+' : ''}${fmt(change, state.currency)})</span>`;
-                    }
-                }
-                rowHtml += `<td>${fmt(balance, state.currency)}${changeHtml}</td>`;
-                currentNetWorth += balance;
-            } else {
-                rowHtml += `<td class="muted">—</td>`;
-            }
-        });
-        
-        let totalChangeHtml = '<td class="muted">—</td>';
-        if (previousNetWorth !== null) {
-            const change = currentNetWorth - previousNetWorth;
-            const changeClass = change >= 0 ? 'ok' : 'bad';
-            totalChangeHtml = `<td class="${changeClass}">${change >= 0 ? '+' : ''}${fmt(change, state.currency)}</td>`;
-        }
-        
-        rowHtml += `<td><b>${fmt(currentNetWorth, state.currency)}</b></td>`;
-        rowHtml += totalChangeHtml;
-
-        tr.innerHTML = rowHtml;
-        tbody.appendChild(tr);
-
-        previousNetWorth = currentNetWorth;
-    }
+    renderEomKpis(ctx, accountStats);
+    renderEomInsights(ctx, monthlySummary);
+    renderEomHistoryTable(ctx, monthsToShow);
+    renderEomChangeTable(ctx, accountStats);
+    renderEomMonthlySummary(monthlySummary.filter(row => monthsToShow.includes(row.ym)));
+    renderEomNetWorthChart(ctx, monthsToShow);
+    renderEomAccountsChart(ctx, monthsToShow);
   }
 
   // --- Goals ------------------------------------------------------------------
@@ -1847,6 +2521,11 @@
   const ANALYTICS_STATE_KEY='lifeos_budget_filters_v1';
   let analyticsUiState = loadAnalyticsUiState();
   const analyticsCharts={};
+  const eomCharts={};
+  const eomUiState={
+    changeSort:{field:'delta',dir:'desc'},
+    monthlySort:{field:'ym',dir:'desc'}
+  };
   const ANALYTICS_COLORS=['#0ea5e9','#ef4444','#16a34a','#f97316','#8b5cf6','#14b8a6','#facc15','#6366f1','#0f172a'];
 
   function loadAnalyticsUiState(){

--- a/budget.html
+++ b/budget.html
@@ -77,8 +77,16 @@
     .analytics-month-chip{padding:6px 10px;border-radius:10px;border:1px solid var(--line);background:#fff;cursor:pointer;font-size:12px;transition:all .2s ease}
     .analytics-month-chip.active{background:#0f172a;color:#fff;border-color:#0f172a}
     .analytics-month-chip:hover{border-color:var(--blue)}
-    .table-sortable th{cursor:pointer;position:relative;white-space:nowrap}
-    .table-sortable th .sort-indicator{font-size:10px;margin-left:4px}
+    .table-sortable th{position:relative;white-space:nowrap}
+    .table-sortable th[data-sort]{cursor:pointer}
+    .table-sortable th .sort-indicator{font-size:10px;margin-left:4px;color:var(--muted)}
+    .table-sortable th.sorted-asc,.table-sortable th.sorted-desc{color:#0f172a}
+    .table-sortable th.sorted-asc .sort-indicator,.table-sortable th.sorted-desc .sort-indicator{color:#0f172a}
+    .th-label{display:inline-flex;align-items:center;gap:4px}
+    .inventory-table thead th,.inventory-table tbody td{padding:6px 8px;font-size:12px;line-height:1.3}
+    .inventory-table tbody td:first-child b{font-size:13px}
+    .inventory-table tbody td .muted{font-size:11px}
+    .inventory-table-actions .btn{padding:6px 10px;font-size:12px;border-radius:10px}
     .delta-up{color:var(--green);font-weight:600}
     .delta-down{color:var(--red);font-weight:600}
     .delta-neutral{color:var(--muted);font-weight:500}
@@ -758,10 +766,16 @@
           <select id="inv-sort">
             <option value="newest">Najnowsze</option>
             <option value="oldest">Najstarsze</option>
-            <option value="priceDesc">Najdroższe</option>
-            <option value="priceAsc">Najtańsze</option>
-            <option value="brand">Marka A→Z</option>
-            <option value="age">Najdłużej na stanie</option>
+            <option value="priceDesc">Najdroższe (zakup)</option>
+            <option value="priceAsc">Najtańsze (zakup)</option>
+            <option value="convertedDesc">Najwyższa wycena</option>
+            <option value="convertedAsc">Najniższa wycena</option>
+            <option value="brandAsc">Marka A→Z</option>
+            <option value="brandDesc">Marka Z→A</option>
+            <option value="ageDesc">Najdłużej na stanie</option>
+            <option value="ageAsc">Najkrócej na stanie</option>
+            <option value="noteAsc">Notatka A→Z</option>
+            <option value="noteDesc">Notatka Z→A</option>
           </select>
         </div>
         <div class="row" style="justify-content:space-between;align-items:center;gap:8px;margin-top:8px">
@@ -776,15 +790,15 @@
           <span class="muted">Kwoty w PLN oraz w wybranej walucie (<span data-inv-currency-label>PLN</span>)</span>
         </div>
         <div style="overflow-x:auto;margin-top:8px">
-          <table id="inventory-active-table" class="table-modern">
+          <table id="inventory-active-table" class="table-modern table-sortable inventory-table">
             <thead>
               <tr>
-                <th>Produkt</th>
-                <th>Zakup (PLN)</th>
-                <th>Wycena (<span data-inv-currency-label>PLN</span>)</th>
-                <th>Dni w magazynie</th>
-                <th>Notatki</th>
-                <th>Akcje</th>
+                <th data-sort="product"><span class="th-label">Produkt<span class="sort-indicator"></span></span></th>
+                <th data-sort="purchase"><span class="th-label">Zakup (PLN)<span class="sort-indicator"></span></span></th>
+                <th data-sort="converted"><span class="th-label">Wycena (<span data-inv-currency-label>PLN</span>)<span class="sort-indicator"></span></span></th>
+                <th data-sort="age"><span class="th-label">Dni w magazynie<span class="sort-indicator"></span></span></th>
+                <th data-sort="note"><span class="th-label">Notatki<span class="sort-indicator"></span></span></th>
+                <th><span class="th-label">Akcje</span></th>
               </tr>
             </thead>
             <tbody></tbody>
@@ -798,7 +812,7 @@
           <span class="muted">Wszystkie wartości w PLN oraz w walucie <span data-inv-currency-label>PLN</span></span>
         </div>
         <div style="overflow-x:auto;margin-top:8px">
-          <table id="inventory-sold-table" class="table-modern">
+          <table id="inventory-sold-table" class="table-modern inventory-table">
             <thead>
               <tr>
                 <th>Produkt</th>
@@ -2674,7 +2688,13 @@
     if(ui.sizeFilter && !sizeOptions.includes(ui.sizeFilter)) ui.sizeFilter='';
     const brandFilter=ui.brandFilter||'';
     const sizeFilter=ui.sizeFilter||'';
-    const sortMode=ui.sortMode||'newest';
+    const allowedSortModes=new Set(['newest','oldest','priceDesc','priceAsc','brandAsc','brandDesc','convertedDesc','convertedAsc','ageDesc','ageAsc','noteDesc','noteAsc']);
+    let sortMode=ui.sortMode||'newest';
+    if(sortMode==='brand') sortMode='brandAsc';
+    if(sortMode==='age') sortMode='ageDesc';
+    if(sortMode==='converted') sortMode='convertedDesc';
+    if(!allowedSortModes.has(sortMode)) sortMode='newest';
+    ui.sortMode=sortMode;
     const today=new Date();
     const filtered=items.filter(item=>{
       const combined=`${item.brand||''} ${item.model||''}`.toLowerCase();
@@ -2688,30 +2708,125 @@
       const d=it.purchaseDate?new Date(it.purchaseDate):(it.createdAt?new Date(it.createdAt):new Date(0));
       return isNaN(d)?0:d.getTime();
     };
-    const getAge=it=>{
-      const diff=inventoryDaysBetween(it.purchaseDate,today);
-      return diff===null?0:diff;
+    const computeCache=new Map();
+    const getMeta=item=>{
+      if(!computeCache.has(item.id)){
+        const purchase=num(item.purchasePrice);
+        const rawConverted=selectedCurrency==='PLN'?purchase:convertBetweenCurrencies(purchase,'PLN',selectedCurrency);
+        computeCache.set(item.id,{
+          purchase:Number.isFinite(purchase)?purchase:null,
+          converted:Number.isFinite(rawConverted)?rawConverted:null,
+          age:inventoryDaysBetween(item.purchaseDate,today),
+          product:`${item.brand||''} ${item.model||''}`.trim(),
+          note:(item.purchaseNote||'').trim()
+        });
+      }
+      return computeCache.get(item.id);
+    };
+    const compareNumeric=(a,b,dir=1)=>{
+      const aVal=Number.isFinite(a)?a:null;
+      const bVal=Number.isFinite(b)?b:null;
+      if(aVal===null && bVal===null) return 0;
+      if(aVal===null) return 1;
+      if(bVal===null) return -1;
+      return dir*(aVal-bVal);
+    };
+    const compareString=(a,b,dir=1)=>{
+      const textA=(a||'').toString().trim();
+      const textB=(b||'').toString().trim();
+      const emptyA=textA.length===0;
+      const emptyB=textB.length===0;
+      if(emptyA && emptyB) return 0;
+      if(emptyA) return 1;
+      if(emptyB) return -1;
+      return dir*textA.localeCompare(textB,'pl',{sensitivity:'base'});
+    };
+    const fallbackCompare=(a,b)=>getCreated(b)-getCreated(a);
+    const withFallback=cmp=>(a,b)=>{
+      const result=cmp(a,b);
+      if(result!==0) return result;
+      return fallbackCompare(a,b);
     };
     switch(sortMode){
       case 'oldest':
         visible.sort((a,b)=>getCreated(a)-getCreated(b));
         break;
       case 'priceDesc':
-        visible.sort((a,b)=>num(b.purchasePrice)-num(a.purchasePrice));
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).purchase,getMeta(b).purchase,-1)));
         break;
       case 'priceAsc':
-        visible.sort((a,b)=>num(a.purchasePrice)-num(b.purchasePrice));
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).purchase,getMeta(b).purchase,1)));
         break;
-      case 'brand':
-        visible.sort((a,b)=>`${a.brand||''} ${a.model||''}`.localeCompare(`${b.brand||''} ${b.model||''}`,'pl',{sensitivity:'base'}));
+      case 'brandAsc':
+        visible.sort(withFallback((a,b)=>compareString(getMeta(a).product,getMeta(b).product,1)));
         break;
-      case 'age':
-        visible.sort((a,b)=>getAge(b)-getAge(a));
+      case 'brandDesc':
+        visible.sort(withFallback((a,b)=>compareString(getMeta(a).product,getMeta(b).product,-1)));
+        break;
+      case 'convertedDesc':
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).converted,getMeta(b).converted,-1)));
+        break;
+      case 'convertedAsc':
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).converted,getMeta(b).converted,1)));
+        break;
+      case 'ageDesc':
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).age,getMeta(b).age,-1)));
+        break;
+      case 'ageAsc':
+        visible.sort(withFallback((a,b)=>compareNumeric(getMeta(a).age,getMeta(b).age,1)));
+        break;
+      case 'noteDesc':
+        visible.sort(withFallback((a,b)=>compareString(getMeta(a).note,getMeta(b).note,-1)));
+        break;
+      case 'noteAsc':
+        visible.sort(withFallback((a,b)=>compareString(getMeta(a).note,getMeta(b).note,1)));
         break;
       case 'newest':
       default:
         visible.sort((a,b)=>getCreated(b)-getCreated(a));
     }
+
+    const headerSortOrders={
+      product:['brandAsc','brandDesc'],
+      purchase:['priceAsc','priceDesc'],
+      converted:['convertedAsc','convertedDesc'],
+      age:['ageAsc','ageDesc'],
+      note:['noteAsc','noteDesc']
+    };
+    const headerCells=document.querySelectorAll('#inventory-active-table thead th[data-sort]');
+    headerCells.forEach(th=>{
+      if(!th.dataset.bound){
+        th.dataset.bound='1';
+        th.addEventListener('click',()=>{
+          const key=th.dataset.sort;
+          const order=headerSortOrders[key];
+          if(!order || !order.length) return;
+          const current=inv().ui.sortMode||'newest';
+          let next=order[0];
+          if(order.includes(current)){
+            const idx=order.indexOf(current);
+            next=order[(idx+1)%order.length];
+          }
+          inv().ui.sortMode=next;
+          save(state);
+          renderInventory();
+        });
+      }
+    });
+    headerCells.forEach(th=>{
+      const indicator=th.querySelector('.sort-indicator');
+      if(indicator) indicator.textContent='';
+      th.classList.remove('sorted-asc','sorted-desc');
+      th.removeAttribute('aria-sort');
+      const key=th.dataset.sort;
+      const order=headerSortOrders[key];
+      if(order && order.includes(sortMode)){
+        const index=order.indexOf(sortMode);
+        if(indicator) indicator.textContent=index===0?'▲':'▼';
+        th.classList.add(index===0?'sorted-asc':'sorted-desc');
+        th.setAttribute('aria-sort',index===0?'ascending':'descending');
+      }
+    });
 
     const totalStockCost=items.reduce((sum,it)=>sum+num(it.purchasePrice),0);
     const totalStockConverted=convertBetweenCurrencies(totalStockCost,'PLN',selectedCurrency);
@@ -3098,11 +3213,16 @@
       }else{
         const todayStr=new Date().toISOString().slice(0,10);
         for(const item of visible){
-          const converted=selectedCurrency==='PLN'?num(item.purchasePrice):convertBetweenCurrencies(item.purchasePrice,'PLN',selectedCurrency);
-          const age=inventoryDaysBetween(item.purchaseDate,today);
-          const noteHtml=item.purchaseNote?item.purchaseNote:'<span class="muted">—</span>';
-          const convertedHtml=selectedCurrency==='PLN'?fmt(item.purchasePrice,displayCurrency):(converted!==null?fmt(converted,displayCurrency):'<span class="muted">Brak kursu</span>');
-          const ageLabel=age!==null?`${Math.round(age)} dni`:'—';
+          const meta=getMeta(item);
+          const purchaseValue=meta.purchase ?? num(item.purchasePrice);
+          const convertedValue=meta.converted;
+          const ageValue=meta.age;
+          const noteText=meta.note || item.purchaseNote || '';
+          const noteHtml=noteText?noteText:'<span class="muted">—</span>';
+          const convertedHtml=selectedCurrency==='PLN'
+            ? fmt(purchaseValue,displayCurrency)
+            : (convertedValue!==null?fmt(convertedValue,displayCurrency):'<span class="muted">Brak kursu</span>');
+          const ageLabel=ageValue!==null?`${Math.round(ageValue)} dni`:'—';
           const sizeLabel=item.size?` • Rozmiar: ${item.size}`:'';
           const saleOptions=INVENTORY_SUPPORTED_CURRENCIES.map(cur=>`<option value="${cur}" ${cur===selectedCurrency?'selected':''}>${cur}</option>`).join('');
           const tr=document.createElement('tr');

--- a/budget.html
+++ b/budget.html
@@ -966,6 +966,20 @@
     if(!bud.inventory.rates.rates || typeof bud.inventory.rates.rates!=='object') bud.inventory.rates.rates={};
     bud.inventory.rates.rates.EUR = Number(bud.inventory.rates.rates.EUR)||null;
     bud.inventory.rates.rates.USD = Number(bud.inventory.rates.rates.USD)||null;
+    if(!bud.inventory.rates.mids || typeof bud.inventory.rates.mids!=='object') bud.inventory.rates.mids={};
+    const eurMidCached=Number(bud.inventory.rates.mids.EUR);
+    const usdMidCached=Number(bud.inventory.rates.mids.USD);
+    bud.inventory.rates.mids.EUR=Number.isFinite(eurMidCached)&&eurMidCached>0?eurMidCached:null;
+    bud.inventory.rates.mids.USD=Number.isFinite(usdMidCached)&&usdMidCached>0?usdMidCached:null;
+    if(!bud.inventory.rates.mids.EUR && Number.isFinite(bud.inventory.rates.rates.EUR) && bud.inventory.rates.rates.EUR>0){
+      bud.inventory.rates.mids.EUR=1/bud.inventory.rates.rates.EUR;
+    }
+    if(!bud.inventory.rates.mids.USD && Number.isFinite(bud.inventory.rates.rates.USD) && bud.inventory.rates.rates.USD>0){
+      bud.inventory.rates.mids.USD=1/bud.inventory.rates.rates.USD;
+    }
+    if(typeof bud.inventory.rates.effectiveDate!=='string') bud.inventory.rates.effectiveDate=null;
+    if(typeof bud.inventory.rates.tableNo!=='string') bud.inventory.rates.tableNo=null;
+    if(typeof bud.inventory.rates.source!=='string') bud.inventory.rates.source='';
     if(!bud.inventory.ui || typeof bud.inventory.ui!=='object') bud.inventory.ui={};
     const invUi=bud.inventory.ui;
     if(!['PLN','EUR','USD'].includes(invUi.selectedCurrency)) invUi.selectedCurrency='PLN';
@@ -2769,16 +2783,45 @@
 
     const rateInfo=document.getElementById('inv-rate-info');
     if(rateInfo){
-      const fetchedAt=inventoryState.rates?.fetchedAt;
       const rates=inventoryState.rates?.rates||{};
-      if(fetchedAt){
-        const dt=new Date(fetchedAt);
-        const formatted=isNaN(dt)?fetchedAt:dt.toLocaleString('pl-PL');
-        const eur=rates.EUR?rates.EUR.toFixed(4):'—';
-        const usd=rates.USD?rates.USD.toFixed(4):'—';
-        rateInfo.textContent=`Kursy z ${formatted} | PLN→EUR ${eur} • PLN→USD ${usd}`;
-      }else{
+      const hasRates=Object.values(rates).some(v=>Number.isFinite(v)&&v>0);
+      if(!hasRates){
         rateInfo.textContent='Brak kursów – pobierz aktualne notowania.';
+      }else{
+        const effectiveDate=inventoryState.rates?.effectiveDate;
+        const fetchedAt=inventoryState.rates?.fetchedAt;
+        let dateLabel='';
+        if(typeof effectiveDate==='string' && effectiveDate){
+          const dt=new Date(`${effectiveDate}T00:00:00`);
+          dateLabel=isNaN(dt)?effectiveDate:dt.toLocaleDateString('pl-PL');
+        }else if(fetchedAt){
+          const dt=new Date(fetchedAt);
+          dateLabel=isNaN(dt)?fetchedAt:dt.toLocaleString('pl-PL');
+        }
+        const sourceLabel=inventoryState.rates?.source?` (${inventoryState.rates.source})`:'';
+        const prefix=`Kursy${dateLabel?` z ${dateLabel}`:''}${sourceLabel}`;
+        const segments=[];
+        const eurRate=rates.EUR;
+        if(Number.isFinite(eurRate)&&eurRate>0){
+          const storedMid=inventoryState.rates?.mids?.EUR;
+          const eurMid=Number.isFinite(storedMid)&&storedMid>0?storedMid:(1/eurRate);
+          let text=`1 PLN → EUR ${eurRate.toFixed(4)}`;
+          if(Number.isFinite(eurMid)&&eurMid>0) text+=` (1 EUR → PLN ${eurMid.toFixed(4)})`;
+          segments.push(text);
+        }else{
+          segments.push('1 PLN → EUR —');
+        }
+        const usdRate=rates.USD;
+        if(Number.isFinite(usdRate)&&usdRate>0){
+          const storedMid=inventoryState.rates?.mids?.USD;
+          const usdMid=Number.isFinite(storedMid)&&storedMid>0?storedMid:(1/usdRate);
+          let text=`1 PLN → USD ${usdRate.toFixed(4)}`;
+          if(Number.isFinite(usdMid)&&usdMid>0) text+=` (1 USD → PLN ${usdMid.toFixed(4)})`;
+          segments.push(text);
+        }else{
+          segments.push('1 PLN → USD —');
+        }
+        rateInfo.textContent=`${prefix} | ${segments.join(' • ')}`;
       }
     }
 
@@ -2977,16 +3020,36 @@
         refreshBtn.disabled=true;
         refreshBtn.textContent='Pobieranie...';
         try{
-          const res=await fetch(INVENTORY_RATES_API);
+          const res=await fetch(INVENTORY_RATES_API,{headers:{'Accept':'application/json'}});
           if(!res.ok) throw new Error(`HTTP ${res.status}`);
           const data=await res.json();
-          if(!data?.rates) throw new Error('Brak danych');
+          const tables=Array.isArray(data)?data:[data];
+          const table=tables.find(t=>Array.isArray(t?.rates)&&t.rates.length);
+          if(!table) throw new Error('Brak tabeli kursowej NBP');
+          const ratesList=Array.isArray(table.rates)?table.rates:[];
+          const eurEntry=ratesList.find(r=>r.code==='EUR');
+          const usdEntry=ratesList.find(r=>r.code==='USD');
+          const eurMid=Number(eurEntry?.mid);
+          const usdMid=Number(usdEntry?.mid);
+          const eurRate=Number.isFinite(eurMid)&&eurMid>0?1/eurMid:null;
+          const usdRate=Number.isFinite(usdMid)&&usdMid>0?1/usdMid:null;
+          if(!eurRate && !usdRate) throw new Error('Brak kursów EUR/USD w tabeli NBP');
+          const effectiveDate=typeof table.effectiveDate==='string'?table.effectiveDate:null;
+          const tableNo=typeof table.no==='string'?table.no:null;
+          const sourceLabel=tableNo?`NBP tabela A (${tableNo})`:'NBP tabela A';
           inventoryState.rates={
             base:'PLN',
             fetchedAt:new Date().toISOString(),
+            effectiveDate,
+            tableNo,
+            source:sourceLabel,
             rates:{
-              EUR:Number(data.rates.EUR)||null,
-              USD:Number(data.rates.USD)||null
+              EUR:eurRate,
+              USD:usdRate
+            },
+            mids:{
+              EUR:Number.isFinite(eurMid)&&eurMid>0?eurMid:null,
+              USD:Number.isFinite(usdMid)&&usdMid>0?usdMid:null
             }
           };
           save(state);
@@ -2994,7 +3057,7 @@
           alert('Kursy zostały zaktualizowane.');
         }catch(err){
           console.error('Inventory rates error',err);
-          alert('Nie udało się pobrać kursów. Spróbuj ponownie później.');
+          alert('Nie udało się pobrać kursów z NBP. Spróbuj ponownie później.');
         }finally{
           refreshBtn.disabled=false;
           refreshBtn.textContent=original;
@@ -3549,7 +3612,7 @@
   };
   const ANALYTICS_COLORS=['#0ea5e9','#ef4444','#16a34a','#f97316','#8b5cf6','#14b8a6','#facc15','#6366f1','#0f172a'];
   const INVENTORY_SUPPORTED_CURRENCIES=['PLN','EUR','USD'];
-  const INVENTORY_RATES_API='https://api.exchangerate.host/latest?base=PLN&symbols=EUR,USD';
+  const INVENTORY_RATES_API='https://api.nbp.pl/api/exchangerates/tables/A/last/1?format=json';
   const inventoryCharts={};
 
   function loadAnalyticsUiState(){

--- a/budget.html
+++ b/budget.html
@@ -73,6 +73,10 @@
     .analytics-filter-actions{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
     .analytics-filter-actions .btn{padding:6px 10px;font-size:13px}
     .analytics-summary{font-size:12px;color:var(--muted);margin-top:4px}
+    .analytics-month-picker{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+    .analytics-month-chip{padding:6px 10px;border-radius:10px;border:1px solid var(--line);background:#fff;cursor:pointer;font-size:12px;transition:all .2s ease}
+    .analytics-month-chip.active{background:#0f172a;color:#fff;border-color:#0f172a}
+    .analytics-month-chip:hover{border-color:var(--blue)}
     .table-sortable th{cursor:pointer;position:relative;white-space:nowrap}
     .table-sortable th .sort-indicator{font-size:10px;margin-left:4px}
     .delta-up{color:var(--green);font-weight:600}
@@ -455,18 +459,25 @@
 
     <!-- Analytics -->
     <section id="tab-analytics" class="card" style="margin-top:12px;display:none">
-      <div class="row">
-        <h3 class="title">Centrum Analityczne</h3>
-        <div class="row" style="gap:8px;align-items:center">
-          <label for="analytics-period" class="tiny">Okres:</label>
-          <select id="analytics-period" style="width:auto">
-            <option value="1" selected>Bieżący miesiąc</option>
-            <option value="3">Ostatnie 3 miesiące</option>
-            <option value="6">Ostatnie 6 miesięcy</option>
-            <option value="12">Ostatnie 12 miesięcy</option>
-            <option value="all">Wszystkie dane</option>
-          </select>
+      <div class="row" style="align-items:center">
+        <h3 class="title" style="margin-bottom:0">Centrum Analityczne</h3>
+      </div>
+
+      <div class="analytics-filter-card">
+        <div class="row" style="align-items:flex-start;gap:12px">
+          <div style="flex:1">
+            <div class="title" style="margin:0;font-size:18px">Zakres miesięcy</div>
+            <div id="analytics-month-summary" class="analytics-summary">Kliknij miesiące, aby ustawić dokładny okres analizy.</div>
+          </div>
+          <div class="analytics-filter-actions" id="analytics-month-quick">
+            <button class="btn soft" data-range="current">Bieżący</button>
+            <button class="btn soft" data-range="last3">Ostatnie 3</button>
+            <button class="btn soft" data-range="last6">Ostatnie 6</button>
+            <button class="btn soft" data-range="year">Bieżący rok</button>
+            <button class="btn soft" data-range="all">Wszystkie</button>
+          </div>
         </div>
+        <div id="analytics-month-picker" class="analytics-month-picker"></div>
       </div>
 
       <div class="analytics-filter-card">
@@ -1841,17 +1852,18 @@
   function loadAnalyticsUiState(){
     try{
       const raw=localStorage.getItem(ANALYTICS_STATE_KEY);
-      if(!raw) return {selectedCategoryIds:[],sortField:'total',sortDir:'desc',searchTerm:''};
+      if(!raw) return {selectedCategoryIds:[],sortField:'total',sortDir:'desc',searchTerm:'',selectedMonths:null};
       const parsed=JSON.parse(raw);
       return {
         selectedCategoryIds:Array.isArray(parsed?.selectedCategoryIds)?parsed.selectedCategoryIds:[],
         sortField:typeof parsed?.sortField==='string'?parsed.sortField:'total',
         sortDir:parsed?.sortDir==='asc'?'asc':'desc',
-        searchTerm:typeof parsed?.searchTerm==='string'?parsed.searchTerm:''
+        searchTerm:typeof parsed?.searchTerm==='string'?parsed.searchTerm:'',
+        selectedMonths:Array.isArray(parsed?.selectedMonths)?parsed.selectedMonths:null
       };
     }catch(err){
       console.warn('Nie można odczytać ustawień analityki',err);
-      return {selectedCategoryIds:[],sortField:'total',sortDir:'desc',searchTerm:''};
+      return {selectedCategoryIds:[],sortField:'total',sortDir:'desc',searchTerm:'',selectedMonths:null};
     }
   }
   function saveAnalyticsUiState(){
@@ -1867,6 +1879,40 @@
   function setAnalyticsSelectedCategories(ids){
     analyticsUiState.selectedCategoryIds=Array.from(new Set(ids));
     saveAnalyticsUiState();
+  }
+  function setAnalyticsSelectedMonths(months){
+    const unique=Array.from(new Set(Array.isArray(months)?months:[])).sort();
+    analyticsUiState.selectedMonths=unique;
+    saveAnalyticsUiState();
+  }
+  function getAnalyticsAvailableMonths(){
+    const months=new Set();
+    (b().transactions||[]).forEach(t=>{if(t?.date) months.add(t.date.slice(0,7));});
+    if(b().monthly){
+      Object.keys(b().monthly).forEach(ym=>months.add(ym));
+    }
+    return Array.from(months).sort();
+  }
+  function defaultAnalyticsMonths(allMonths){
+    if(!allMonths.length) return [];
+    const current=b().workingMonth;
+    if(current && allMonths.includes(current)) return [current];
+    return [allMonths[allMonths.length-1]];
+  }
+  function getAnalyticsSelectedMonths(allMonths){
+    const currentRaw=Array.isArray(analyticsUiState.selectedMonths)?analyticsUiState.selectedMonths:[];
+    const currentSorted=[...currentRaw].sort();
+    let valid=currentRaw.filter(m=>allMonths.includes(m));
+    if(valid.length===0 && allMonths.length>0){
+      valid=defaultAnalyticsMonths(allMonths);
+    }
+    const normalized=Array.from(new Set(valid)).sort();
+    const changed=normalized.length!==currentSorted.length || normalized.some((m,i)=>m!==currentSorted[i]);
+    if(changed){
+      analyticsUiState.selectedMonths=normalized;
+      saveAnalyticsUiState();
+    }
+    return normalized;
   }
   function ensureAnalyticsSortDefaults(){
     if(!analyticsUiState.sortField) analyticsUiState.sortField='total';
@@ -1930,6 +1976,100 @@
   }
 
   // --- Analytics --------------------------------------------------------------
+  function renderAnalyticsMonthPicker(allMonths, selectedMonths){
+    const container=document.getElementById('analytics-month-picker');
+    const summary=document.getElementById('analytics-month-summary');
+    const quick=document.getElementById('analytics-month-quick');
+    if(!container) return;
+
+    container.innerHTML='';
+
+    if(!allMonths.length){
+      if(summary){
+        summary.textContent='Brak danych historycznych. Dodaj transakcje lub przychody, aby rozpocząć analizę.';
+      }
+      if(quick){ quick.style.display='none'; }
+      return;
+    }
+
+    if(quick){ quick.style.display='flex'; }
+
+    const selectedSet=new Set(selectedMonths);
+    const monthsForDisplay=[...allMonths].sort().reverse();
+    monthsForDisplay.forEach(ym=>{
+      const chip=document.createElement('button');
+      chip.type='button';
+      chip.className='analytics-month-chip'+(selectedSet.has(ym)?' active':'');
+      chip.textContent=ym;
+      chip.onclick=()=>{
+        const current=getAnalyticsSelectedMonths(allMonths);
+        const next=new Set(current);
+        if(next.has(ym)){
+          if(next.size===1) return;
+          next.delete(ym);
+        }else{
+          next.add(ym);
+        }
+        setAnalyticsSelectedMonths(Array.from(next));
+        renderAnalytics();
+      };
+      container.appendChild(chip);
+    });
+
+    if(summary){
+      if(selectedMonths.length<=1){
+        const ym=selectedMonths[0]||'—';
+        summary.textContent=`Wybrany miesiąc: ${ym}. Dodaj kolejne, aby zobaczyć porównania.`;
+      }else{
+        const first=selectedMonths[0];
+        const last=selectedMonths[selectedMonths.length-1];
+        const prev=selectedMonths[selectedMonths.length-2];
+        summary.textContent=`Wybrane miesiące: ${selectedMonths.length} (${first} → ${last}). Porównania MoM: ${last} vs ${prev}.`;
+      }
+    }
+
+    if(quick){
+      quick.querySelectorAll('button[data-range]').forEach(btn=>{
+        btn.onclick=()=>{
+          const range=btn.dataset.range;
+          let selection=[];
+          switch(range){
+            case 'current':{
+              const current=b().workingMonth;
+              if(current && allMonths.includes(current)) selection=[current];
+              else selection=defaultAnalyticsMonths(allMonths);
+              break;
+            }
+            case 'last3':
+              selection=allMonths.slice(-3);
+              break;
+            case 'last6':
+              selection=allMonths.slice(-6);
+              break;
+            case 'year':{
+              const workingYear=(b().workingMonth||'').slice(0,4);
+              if(workingYear){ selection=allMonths.filter(m=>m.startsWith(workingYear)); }
+              if(!selection.length){
+                const nowYear=String(new Date().getFullYear());
+                selection=allMonths.filter(m=>m.startsWith(nowYear));
+              }
+              if(!selection.length){ selection=allMonths.slice(-12); }
+              break;
+            }
+            case 'all':
+              selection=[...allMonths];
+              break;
+            default:
+              selection=defaultAnalyticsMonths(allMonths);
+          }
+          if(!selection.length){ selection=defaultAnalyticsMonths(allMonths); }
+          setAnalyticsSelectedMonths(selection);
+          renderAnalytics();
+        };
+      });
+    }
+  }
+
   function renderAnalyticsFilterPanel(expenseCats, categoryStats, totalExpense) {
     const list = document.getElementById('analytics-category-filter-list');
     const searchInput = document.getElementById('analytics-category-search');
@@ -2063,202 +2203,199 @@
   }
 
   function renderAnalytics(){
-    document.getElementById('analytics-period').onchange = renderAnalytics;
+    const allMonths=getAnalyticsAvailableMonths();
+    const selectedMonths=getAnalyticsSelectedMonths(allMonths);
+    renderAnalyticsMonthPicker(allMonths, selectedMonths);
 
-    const period = document.getElementById('analytics-period').value;
-    const allMonthsRaw = [...new Set(b().transactions.map(t => t.date.slice(0, 7)))];
-    if (b().monthly) {
-        Object.keys(b().monthly).forEach(ym => {
-            if (!allMonthsRaw.includes(ym)) allMonthsRaw.push(ym);
-        });
-    }
-    const allMonths = [...new Set(allMonthsRaw)].sort();
+    ensureAnalyticsSortDefaults();
+    const expenseCats=analyticsExpenseCategories();
 
-    let monthsToAnalyze;
-    if (period === 'all') {
-        monthsToAnalyze = allMonths;
-    } else if (period === '1') {
-        monthsToAnalyze = [b().workingMonth];
-    } else {
-        const monthCount = parseInt(period, 10);
-        const endIndex = allMonths.indexOf(b().workingMonth);
-        if (endIndex > -1) {
-            const startIndex = Math.max(0, endIndex - monthCount + 1);
-            monthsToAnalyze = allMonths.slice(startIndex, endIndex + 1);
-        } else {
-            monthsToAnalyze = allMonths.slice(-monthCount);
-        }
-    }
-
-    if (monthsToAnalyze.length === 0) {
-      document.getElementById('analytics-kpis').innerHTML = `<p class="muted" style="grid-column: 1 / -1; text-align:center;">Brak danych do analizy w wybranym okresie.</p>`;
+    if(selectedMonths.length===0){
+      const emptyStats={};
+      for(const cat of expenseCats){
+        emptyStats[cat.id]={
+          category:cat,
+          total:0,
+          count:0,
+          values:[],
+          months:{},
+          max:{amount:0,date:''},
+          min:{amount:0,date:''}
+        };
+      }
+      renderAnalyticsFilterPanel(expenseCats, emptyStats, 0);
+      const message=allMonths.length? 'Wybierz miesiące, aby zobaczyć analizy.' : 'Brak danych historycznych do analizy.';
+      const kpiBox=document.getElementById('analytics-kpis');
+      if(kpiBox){kpiBox.innerHTML=`<p class='muted' style='grid-column:1 / -1; text-align:center;'>${message}</p>`;}
+      const placeholder=`<tbody><tr><td class='muted' style='text-align:center;'>${message}</td></tr></tbody>`;
+      ['analytics-category-summary','analytics-category-momentum','analytics-monthly-breakdown','analytics-top-transactions'].forEach(id=>{
+        const el=document.getElementById(id);
+        if(el) el.innerHTML=placeholder;
+      });
+      const matrix=document.getElementById('analytics-category-trends');
+      if(matrix) matrix.innerHTML=placeholder;
+      ['incomeExpense','categoryShare','monthlyActivity','avgTrend','categoryLeader','categoryTrend'].forEach(key=>destroyAnalyticsChart(key));
       return;
     }
 
-    ensureAnalyticsSortDefaults();
-    const expenseCats = analyticsExpenseCategories();
-    const selectedCatIds = getActiveAnalyticsCategoryIds(expenseCats);
-    const selectedCatSet = new Set(selectedCatIds);
-    const catsMap = catsById();
+    const monthsToAnalyze=selectedMonths;
+    const monthsSet=new Set(monthsToAnalyze);
+    const selectedCatIds=getActiveAnalyticsCategoryIds(expenseCats);
+    const selectedCatSet=new Set(selectedCatIds);
+    const catsMap=catsById();
 
-    const firstMonth = monthsToAnalyze[0];
-    const lastMonth = monthsToAnalyze[monthsToAnalyze.length - 1];
+    const allEntriesInPeriod=b().transactions.filter(t=>monthsSet.has(t.date.slice(0,7)));
 
-    const allEntriesInPeriod = b().transactions.filter(t => {
-        const ym = t.date.slice(0, 7);
-        return ym >= firstMonth && ym <= lastMonth;
-    });
+    const categoryStats={};
+    const monthlySummaries=[];
+    let totalIncome=0;
+    let totalExpenseAll=0;
+    let totalSelectedExpense=0;
+    let totalSelectedCount=0;
+    let totalEntriesAll=0;
+    const selectedAmounts=[];
 
-    const categoryStats = {};
-    const monthlySummaries = [];
-    let totalIncome = 0;
-    let totalExpenseAll = 0;
-    let totalSelectedExpense = 0;
-    let totalSelectedCount = 0;
-    let totalEntriesAll = 0;
-    const selectedAmounts = [];
+    monthsToAnalyze.forEach(ym=>{
+      ensureMonth(ym);
+      const monthIncome=b().monthly[ym].incomes.reduce((s,x)=>s+num(x.amount),0);
+      totalIncome+=monthIncome;
 
-    monthsToAnalyze.forEach(ym => {
-        ensureMonth(ym);
-        const monthIncome = b().monthly[ym].incomes.reduce((s, x) => s + num(x.amount), 0);
-        totalIncome += monthIncome;
+      const monthEntries=entriesForMonth(ym);
+      let monthExpense=0;
+      let monthSelectedTotal=0;
+      let monthSelectedCount=0;
+      const monthSelectedValues=[];
+      const byCategory={};
 
-        const monthEntries = entriesForMonth(ym);
-        let monthExpense = 0;
-        let monthSelectedTotal = 0;
-        let monthSelectedCount = 0;
-        const monthSelectedValues = [];
-        const byCategory = {};
+      monthEntries.forEach(e=>{
+        const cat=catsMap[e.categoryId];
+        if(!cat || (cat.type!=='expense' && cat.type!=='saving')) return;
+        const amount=Math.abs(e.amount);
+        monthExpense+=amount;
+        totalExpenseAll+=amount;
+        totalEntriesAll+=1;
 
-        monthEntries.forEach(e => {
-            const cat = catsMap[e.categoryId];
-            if(!cat || (cat.type !== 'expense' && cat.type !== 'saving')) return;
-            const amount = Math.abs(e.amount);
-            monthExpense += amount;
-            totalExpenseAll += amount;
-            totalEntriesAll += 1;
-
-            let stat = categoryStats[cat.id];
-            if(!stat){
-                stat = categoryStats[cat.id] = {
-                    category: cat,
-                    total: 0,
-                    count: 0,
-                    values: [],
-                    months: {},
-                    max: { amount: 0, date: '' },
-                    min: { amount: Infinity, date: '' }
-                };
-            }
-            stat.total += amount;
-            stat.count += 1;
-            stat.values.push(amount);
-            if(!stat.months[ym]) stat.months[ym] = { total: 0, count: 0, values: [] };
-            stat.months[ym].total += amount;
-            stat.months[ym].count += 1;
-            stat.months[ym].values.push(amount);
-            if(amount > stat.max.amount) stat.max = { amount, date: e.date };
-            if(amount < stat.min.amount) stat.min = { amount, date: e.date };
-
-            if(!byCategory[cat.id]) byCategory[cat.id] = { total: 0, count: 0, values: [] };
-            byCategory[cat.id].total += amount;
-            byCategory[cat.id].count += 1;
-            byCategory[cat.id].values.push(amount);
-
-            if(selectedCatSet.has(cat.id)){
-                monthSelectedTotal += amount;
-                monthSelectedCount += 1;
-                totalSelectedExpense += amount;
-                totalSelectedCount += 1;
-                selectedAmounts.push(amount);
-                monthSelectedValues.push(amount);
-            }
-        });
-
-        monthlySummaries.push({
-            ym,
-            incomes: monthIncome,
-            expenses: monthExpense,
-            selectedTotal: monthSelectedTotal,
-            selectedCount: monthSelectedCount,
-            selectedAvg: monthSelectedCount ? monthSelectedTotal / monthSelectedCount : 0,
-            selectedMedian: calcMedian(monthSelectedValues),
-            byCategory
-        });
-    });
-
-    expenseCats.forEach(cat => {
-        if(!categoryStats[cat.id]){
-            categoryStats[cat.id] = {
-                category: cat,
-                total: 0,
-                count: 0,
-                values: [],
-                months: {},
-                max: { amount: 0, date: '' },
-                min: { amount: 0, date: '' }
-            };
-        } else if(categoryStats[cat.id].min.amount === Infinity){
-            categoryStats[cat.id].min = { amount: 0, date: '' };
+        let stat=categoryStats[cat.id];
+        if(!stat){
+          stat=categoryStats[cat.id]={
+            category:cat,
+            total:0,
+            count:0,
+            values:[],
+            months:{},
+            max:{amount:0,date:''},
+            min:{amount:Infinity,date:''}
+          };
         }
+        stat.total+=amount;
+        stat.count+=1;
+        stat.values.push(amount);
+        if(!stat.months[ym]) stat.months[ym]={total:0,count:0,values:[]};
+        stat.months[ym].total+=amount;
+        stat.months[ym].count+=1;
+        stat.months[ym].values.push(amount);
+        if(amount>stat.max.amount) stat.max={amount,date:e.date};
+        if(amount<stat.min.amount) stat.min={amount,date:e.date};
+
+        if(!byCategory[cat.id]) byCategory[cat.id]={total:0,count:0,values:[]};
+        byCategory[cat.id].total+=amount;
+        byCategory[cat.id].count+=1;
+        byCategory[cat.id].values.push(amount);
+
+        if(selectedCatSet.has(cat.id)){
+          monthSelectedTotal+=amount;
+          monthSelectedCount+=1;
+          totalSelectedExpense+=amount;
+          totalSelectedCount+=1;
+          selectedAmounts.push(amount);
+          monthSelectedValues.push(amount);
+        }
+      });
+
+      monthlySummaries.push({
+        ym,
+        incomes:monthIncome,
+        expenses:monthExpense,
+        selectedTotal:monthSelectedTotal,
+        selectedCount:monthSelectedCount,
+        selectedAvg:monthSelectedCount ? monthSelectedTotal/monthSelectedCount : 0,
+        selectedMedian:calcMedian(monthSelectedValues),
+        byCategory
+      });
     });
 
-    const monthsCount = monthsToAnalyze.length;
-    const netChange = totalIncome - totalExpenseAll;
-    const avgSavingsRate = totalIncome > 0 ? (netChange / totalIncome) * 100 : 0;
-    const selectedAvg = totalSelectedCount ? totalSelectedExpense / totalSelectedCount : 0;
-    const selectedMedian = calcMedian(selectedAmounts);
-    const selectedShare = totalExpenseAll > 0 ? (totalSelectedExpense / totalExpenseAll) * 100 : 0;
-    const lastMonthSummary = monthlySummaries[monthlySummaries.length - 1];
-    const prevMonthSummary = monthlySummaries.length >= 2 ? monthlySummaries[monthlySummaries.length - 2] : null;
-    const lastVsPrevAmount = prevMonthSummary ? lastMonthSummary.selectedTotal - prevMonthSummary.selectedTotal : 0;
-    const lastVsPrevPercent = (prevMonthSummary && prevMonthSummary.selectedTotal > 0)
-        ? (lastVsPrevAmount / prevMonthSummary.selectedTotal) * 100
-        : 0;
-    const lastCountDelta = prevMonthSummary ? lastMonthSummary.selectedCount - prevMonthSummary.selectedCount : 0;
-    const lastAvg = lastMonthSummary.selectedCount ? lastMonthSummary.selectedTotal / lastMonthSummary.selectedCount : 0;
-    const prevAvg = prevMonthSummary && prevMonthSummary.selectedCount ? prevMonthSummary.selectedTotal / prevMonthSummary.selectedCount : 0;
-    const avgDelta = lastAvg - prevAvg;
-    const avgDeltaPct = prevAvg ? (avgDelta / prevAvg) * 100 : 0;
+    expenseCats.forEach(cat=>{
+      if(!categoryStats[cat.id]){
+        categoryStats[cat.id]={
+          category:cat,
+          total:0,
+          count:0,
+          values:[],
+          months:{},
+          max:{amount:0,date:''},
+          min:{amount:0,date:''}
+        };
+      }else if(categoryStats[cat.id].min.amount===Infinity){
+        categoryStats[cat.id].min={amount:0,date:''};
+      }
+    });
 
-    const selectedTypeTotals = selectedCatIds.reduce((acc, id) => {
-        const cat = catsMap[id];
-        if(!cat) return acc;
-        if(cat.type === 'saving') acc.saving += categoryStats[id]?.total || 0;
-        else acc.expense += categoryStats[id]?.total || 0;
-        return acc;
-    }, {expense:0, saving:0});
-    const selectedMood = selectedTypeTotals.saving > selectedTypeTotals.expense ? 'saving' : 'expense';
+    const monthsCount=monthsToAnalyze.length;
+    const netChange=totalIncome-totalExpenseAll;
+    const avgSavingsRate=totalIncome>0?(netChange/totalIncome)*100:0;
+    const selectedAvg=totalSelectedCount?totalSelectedExpense/totalSelectedCount:0;
+    const selectedMedian=calcMedian(selectedAmounts);
+    const selectedShare=totalExpenseAll>0?(totalSelectedExpense/totalExpenseAll)*100:0;
+    const lastMonthSummary=monthlySummaries[monthlySummaries.length-1];
+    const prevMonthSummary=monthlySummaries.length>=2?monthlySummaries[monthlySummaries.length-2]:null;
+    const lastVsPrevAmount=prevMonthSummary?lastMonthSummary.selectedTotal-prevMonthSummary.selectedTotal:0;
+    const lastVsPrevPercent=(prevMonthSummary && prevMonthSummary.selectedTotal>0)
+      ?(lastVsPrevAmount/prevMonthSummary.selectedTotal)*100
+      :0;
+    const lastCountDelta=prevMonthSummary?lastMonthSummary.selectedCount-prevMonthSummary.selectedCount:0;
+    const lastAvg=lastMonthSummary.selectedCount?lastMonthSummary.selectedTotal/lastMonthSummary.selectedCount:0;
+    const prevAvg=prevMonthSummary && prevMonthSummary.selectedCount?prevMonthSummary.selectedTotal/prevMonthSummary.selectedCount:0;
+    const avgDelta=lastAvg-prevAvg;
+    const avgDeltaPct=prevAvg?(avgDelta/prevAvg)*100:0;
+    const selectedTypeTotals=selectedCatIds.reduce((acc,id)=>{
+      const cat=categoryStats[id]?.category;
+      if(!cat) return acc;
+      acc[cat.type]=(acc[cat.type]||0)+(categoryStats[id]?.total||0);
+      return acc;
+    },{expense:0,saving:0});
+    const selectedMood=selectedTypeTotals.saving>selectedTypeTotals.expense?'saving':'expense';
+    const largestCategory=selectedCatIds
+      .map(id=>categoryStats[id])
+      .filter(Boolean)
+      .sort((a,b)=>(b?.total||0)-(a?.total||0))[0]||null;
 
-    const largestCategory = selectedCatIds.map(id => categoryStats[id]).filter(Boolean).sort((a,b) => (b?.total||0) - (a?.total||0))[0] || null;
-
-    const analyticsContext = {
-        months: monthsToAnalyze,
-        monthlySummaries,
-        categoryStats,
-        selectedCatIds,
-        totalSelectedExpense,
-        totalSelectedCount,
-        selectedAvg,
-        selectedMedian,
-        selectedShare,
-        totalExpenseAll,
-        totalIncome,
-        netChange,
-        avgSavingsRate,
-        monthsCount,
-        lastMonthSummary,
-        prevMonthSummary,
-        lastVsPrevAmount,
-        lastVsPrevPercent,
-        lastCountDelta,
-        avgDelta,
-        avgDeltaPct,
-        selectedMood,
-        largestCategory,
-        allEntriesInPeriod,
-        totalEntriesAll,
-        selectedTypeTotals
+    const analyticsContext={
+      months:monthsToAnalyze,
+      monthlySummaries,
+      categoryStats,
+      selectedCatIds,
+      totalSelectedExpense,
+      totalSelectedCount,
+      selectedAvg,
+      selectedMedian,
+      selectedShare,
+      totalExpenseAll,
+      totalIncome,
+      netChange,
+      avgSavingsRate,
+      monthsCount,
+      lastMonthSummary,
+      prevMonthSummary,
+      lastVsPrevAmount,
+      lastVsPrevPercent,
+      lastCountDelta,
+      avgDelta,
+      avgDeltaPct,
+      selectedMood,
+      largestCategory,
+      allEntriesInPeriod,
+      totalEntriesAll,
+      selectedTypeTotals
     };
 
     renderAnalyticsFilterPanel(expenseCats, categoryStats, totalExpenseAll);
@@ -2276,7 +2413,6 @@
     renderAnalyticsMonthlyBreakdown(analyticsContext);
     renderAnalyticsTopTransactions(analyticsContext);
   }
-
   function renderAnalyticsIncomeExpenseChart(monthlySummaries) {
     const canvas = document.getElementById('analytics-income-expense-chart');
     if(!canvas) return;


### PR DESCRIPTION
## Summary
- redesign the analytics tab with a dedicated filter panel, expanded KPI cards and additional charts
- add interactive category selection, new comparative tables and month-over-month diagnostics for spotting trends
- refactor analytics rendering logic to aggregate monthly stats, update charts and tables, and reuse selections across widgets

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf8dea33dc8331a3ea51a1e0bb6e1a