### PR TITLE
Revamp trainings dashboard layout and planning flow

### DIFF
--- a/tasks.html
+++ b/tasks.html
@@ -1,0 +1,659 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LifeOS — Zadania Pro</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    :root, [data-theme="light"]{
+      --accent-h: 222; --accent-s: 83%; --accent-l: 53%;
+      --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
+      --accent-weak: hsl(var(--accent-h) 60% 94%);
+      --bg:#f6f7fb; --card:#ffffff; --ink:#0f172a; --muted:#667085; --line:#e7eaf0;
+      --surface:#f9fafb;
+      --green:#059669;--red:#dc2626;--orange:#ea580c;--blue:#2563eb;--purple:#7c3aed;--yellow:#eab308;
+      --prio-high-bg: #fee2e2; --prio-high-text: #b91c1c;
+      --prio-medium-bg: #ffedd5; --prio-medium-text: #c2410c;
+      --prio-low-bg: #f1f5f9; --prio-low-text: #475569;
+      --cat-work-bg: #f5f3ff; --cat-work-text: #5b21b6; --cat-work-border: #8b5cf6;
+      --cat-private-bg: #f0fdf4; --cat-private-text: #166534; --cat-private-border: #22c55e;
+      --shadow-sm:0 1px 2px 0 rgb(0 0 0 / 0.05);
+      --shadow:0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.04);
+      --shadow-md:0 6px 16px -6px rgb(0 0 0 / 0.12);
+    }
+    @keyframes fadeIn { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes fadeOut { from { opacity: 1; } to { opacity: 0; transform: scale(0.95); } }
+    .task-enter { animation: fadeIn 0.3s ease-out forwards; }
+    .task-exit { animation: fadeOut 0.3s ease-in forwards; }
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--ink);font-family: 'Inter', system-ui,-apple-system,Segoe UI,Roboto; font-size: 12px; line-height: 1.5;}
+    .wrap{max-width:1200px;margin:0 auto;padding:32px 24px}
+    .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:24px;box-shadow: var(--shadow); transition: all .3s ease;}
+    .row{display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap}
+    .muted{color:var(--muted)}
+    .title{margin:0 0 8px 0;font-weight:700; font-size: 15px;}
+    .btn{display:inline-flex;gap:8px;align-items:center;justify-content:center;border-radius:12px;padding:10px 16px;border:1px solid var(--line);background:var(--surface);color:var(--ink);cursor:pointer; text-decoration: none; font-weight: 600; transition: all .2s ease;}
+    .btn:hover{transform: translateY(-1px); box-shadow: var(--shadow-sm); border-color:hsl(var(--accent-h) 30% 75% / .6)}
+    .btn.primary{background:var(--accent);color:#fff;border-color:transparent}
+    .btn.danger{background:#fee2e2;border-color:#fecdd3;color:#b91c1c}
+    .btn.danger:hover{background:#fecdd3}
+    .btn svg { width: 16px; height: 16px; }
+    input,select,textarea{border:1px solid var(--line);border-radius:10px;padding:10px 12px;background:var(--card);color:var(--ink);width:100%; font-family: inherit; font-size: 12px; transition: border-color .2s, box-shadow .2s;}
+    input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px hsl(var(--accent-h) 90% 60% / .35); }
+    .grid{display:grid;gap:16px}
+    .g-3{grid-template-columns:repeat(3,minmax(0,1fr))}
+    @media(max-width:900px){.g-3{grid-template-columns:1fr}}
+    .tabs{display:flex;gap:8px;flex-wrap:wrap; margin-bottom: 16px; border-bottom: 1px solid var(--line); padding-bottom: 8px;}
+    .tab{padding:8px 14px;border-radius:8px; cursor:pointer; font-weight: 600; border: 1px solid transparent; color: var(--muted); transition: all .2s;}
+    .tab:hover{background: var(--surface); color: var(--ink);}
+    .tab.active{background:var(--card);color:var(--ink);border-color:var(--line); box-shadow: var(--shadow-sm);}
+    
+    /* Task table styles */
+    .task-table { width: 100%; border-collapse: collapse; }
+    .task-table th, .task-table td { padding: 12px 8px; text-align: left; border-bottom: 1px solid var(--line); transition: background-color .2s; vertical-align: middle; }
+    .task-table th { font-size: 10px; color: var(--muted); text-transform: uppercase; font-weight: 600;}
+    .task-table tr:last-child td { border-bottom: none; }
+    .task-table .task-title-cell { font-weight: 600; cursor: pointer; }
+    .task-table .subtasks-row { display: none; }
+    .task-table .subtasks-content { background: var(--surface); padding: 12px; }
+    .task-table input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); }
+    .task-table tbody tr:not(.task-group-header):hover { background-color: var(--surface); }
+    .task-title.task-done { text-decoration: line-through; color: var(--muted); font-weight: 400; }
+    .task-group-header td { background-color: var(--surface); color: var(--muted); font-weight: 700; text-transform: uppercase; font-size: 10px; padding: 6px 8px; border-top: 2px solid var(--line); border-bottom: 2px solid var(--line); }
+    .task-group-header.overdue-header td { background-color: #fff1f2; color: var(--red); }
+    .task-group-header.completed-header td { background-color: #f0fdf4; color: var(--green); }
+    .task-actions .btn { padding: 6px; }
+
+    /* Tags & Pills */
+    .pill { display:inline-block;padding:3px 10px;border-radius:999px;font-size:10px; font-weight: 600; }
+    .pill.prio-high { background-color: var(--prio-high-bg); color: var(--prio-high-text); }
+    .pill.prio-medium { background-color: var(--prio-medium-bg); color: var(--prio-medium-text); }
+    .pill.prio-low { background-color: var(--prio-low-bg); color: var(--prio-low-text); }
+    .pill.cat-work { background-color: var(--cat-work-bg); color: var(--cat-work-text); }
+    .pill.cat-private { background-color: var(--cat-private-bg); color: var(--cat-private-text); }
+    .tags-container { display: flex; flex-wrap: wrap; gap: 4px; }
+    .tag-pill { background-color: var(--accent-weak); color: var(--accent); padding: 3px 10px; border-radius: 999px; font-size: 10px; font-weight: 600; }
+    
+    /* Subtasks */
+    .subtask-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
+    .subtask-item { display: flex; align-items: center; gap: 8px; font-size: 11px; background: var(--card); padding: 8px; border-radius: 8px; }
+    .subtask-item input[type="checkbox"] { width: 16px; height: 16px; }
+    .subtask-item.done span { text-decoration: line-through; color: var(--muted); }
+    .progress-bar-container { width: 100px; height: 8px; background-color: var(--line); border-radius: 4px; overflow: hidden; }
+    .progress-bar { height: 100%; background-color: var(--accent); transition: width .3s ease; }
+    
+    /* Modal */
+    .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(15, 23, 42, 0.6); display: flex; justify-content: center; align-items: center; z-index: 1000; backdrop-filter: blur(4px); animation: fadeIn 0.2s ease-out; }
+    .modal-card { background: var(--card); padding: 24px; border-radius: 16px; box-shadow: var(--shadow-md); max-width: 400px; width: 90%; text-align: center; }
+    #modal-text { font-size: 13px; margin: 0 0 20px 0; color: var(--ink); }
+    .modal-actions { margin-top: 20px; display: flex; justify-content: center; gap: 8px; }
+
+    /* Stats */
+    .stats-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
+    @media(max-width: 768px) { .stats-grid { grid-template-columns: 1fr; } }
+    .chart-container { position: relative; }
+
+    /* Calendar */
+    .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); border: 1px solid var(--line); border-radius: 12px; overflow: hidden;}
+    .calendar-header { text-align: center; padding: 8px; background: var(--surface); font-weight: 600; font-size: 11px; border-bottom: 1px solid var(--line); }
+    .calendar-day { border-right: 1px solid var(--line); border-top: 1px solid var(--line); padding: 4px; font-size: 11px; display: flex; flex-direction: column; min-height: 100px; }
+    .calendar-day:nth-child(-n+7) { border-top: none; }
+    .calendar-day:nth-child(7n) { border-right: none; }
+    .day-number { font-weight: 600; margin-bottom: 4px; }
+    .calendar-tasks { display: flex; flex-direction: column; gap: 4px; }
+    .calendar-task-pill { padding: 2px 8px; border-radius: 6px; font-size: 10px; white-space: normal; word-break: break-word; cursor: pointer; border-left: 3px solid transparent; }
+    .calendar-task-pill.work { border-left-color: var(--cat-work-border); }
+    .calendar-task-pill.private { border-left-color: var(--cat-private-border); }
+    .calendar-task-pill.prio-high { background-color: var(--prio-high-bg); color: var(--prio-high-text); }
+    .calendar-task-pill.prio-medium { background-color: var(--prio-medium-bg); color: var(--prio-medium-text); }
+    .calendar-task-pill.prio-low { background-color: var(--prio-low-bg); color: var(--prio-low-text); }
+    .calendar-task-pill.task-done { text-decoration: line-through; opacity: 0.7; }
+    
+    /* Segmented Control */
+    .segmented-control { display: flex; background: var(--surface); border-radius: 10px; padding: 4px; }
+    .segment { flex: 1; text-align: center; padding: 6px; border-radius: 8px; cursor: pointer; font-weight: 500; transition: background .2s, color .2s; }
+    .segment.active { background: var(--card); box-shadow: var(--shadow-sm); color: var(--ink); }
+
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="row" style="margin-bottom: 24px;">
+      <div class="row" style="gap:16px">
+        <a href="./index.html" class="btn">← Powrót</a>
+        <div>
+          <h1 style="font-size: 24px; font-weight: 800; margin:0;">Zadania Pro</h1>
+          <div class="muted">Zarządzaj swoimi obowiązkami w jednym miejscu.</div>
+        </div>
+      </div>
+      <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
+    </header>
+
+    <div class="card" style="margin-top:16px;">
+      <h3 class="title" id="form-title" style="margin-bottom: 16px;">Nowe zadanie</h3>
+      <input type="hidden" id="task-id">
+      <div class="grid" style="grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px;">
+        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Tytuł zadania</label><input type="text" id="task-title" placeholder="Np. Przygotować raport kwartalny"></div>
+        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Notatki</label><textarea id="task-notes" placeholder="Szczegóły, linki, wymagania..."></textarea></div>
+      </div>
+      <div class="grid g-3">
+        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Kategoria</label>
+          <div id="task-category-selector" class="segmented-control">
+              <div class="segment active" data-value="work">Praca</div>
+              <div class="segment" data-value="private">Prywatne</div>
+          </div>
+        </div>
+        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Priorytet</label><select id="task-priority"><option value="low">Niski</option><option value="medium">Średni</option><option value="high">Wysoki</option></select></div>
+        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Termin</label><input type="date" id="task-due-date"></div>
+        <div style="grid-column: 1 / -1;"><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Tagi (oddzielone przecinkiem)</label><input type="text" id="task-tags" placeholder="np. praca, pilne, projekt-x"></div>
+        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Powtarzalność</label><select id="task-recurrence"><option value="none">Nigdy</option><option value="daily">Codziennie</option><option value="weekly">Co tydzień</option><option value="monthly">Co miesiąc</option></select></div>
+        <div style="grid-column: 2 / -1;">
+             <label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Podzadania</label>
+             <div style="display:flex; gap: 8px;">
+                 <input type="text" id="subtask-input" placeholder="Dodaj krok do wykonania...">
+                 <button id="add-subtask-btn" class="btn" style="white-space:nowrap;">Dodaj</button>
+             </div>
+             <ul id="subtask-list-form" style="list-style:none; padding: 0; margin: 8px 0 0 0; display:flex; flex-direction:column; gap: 4px;"></ul>
+        </div>
+      </div>
+       <div style="display:flex; gap: 8px; justify-content:flex-end; margin-top: 16px;">
+          <button id="cancel-edit-btn" class="btn" style="display:none;">Anuluj</button>
+          <button id="add-task-btn" class="btn primary"><span id="add-task-btn-text">Dodaj zadanie</span></button>
+       </div>
+    </div>
+    
+    <div class="tabs" style="margin-top: 24px;">
+        <div class="tab active" data-tab="list">Lista Zadań</div>
+        <div class="tab" data-tab="calendar">Kalendarz</div>
+        <div class="tab" data-tab="stats">Statystyki</div>
+    </div>
+
+    <div id="tab-content-list" class="card">
+        <div class="row" style="gap: 8px; padding-bottom: 12px;">
+            <div class="row" style="gap: 8px; flex-grow: 1;">
+              <select id="category-filter" style="width:auto;"></select>
+              <select id="date-filter" style="width:auto;"></select>
+              <select id="task-priority-filter" style="width:auto;"></select>
+              <input type="text" id="tag-filter" placeholder="Filtruj po tagach..." style="width: 150px; flex-grow: 1;">
+            </div>
+            <div class="row" style="gap: 8px;">
+              <select id="sort-by" style="width:auto;"></select>
+              <button id="sort-direction" class="btn" style="padding: 10px;">↑</button>
+              <label style="display:flex; align-items:center; gap: 6px; font-size: 11px; white-space: nowrap;"><input type="checkbox" id="hide-completed-filter" checked style="width: 16px; height: 16px;"> Ukryj wykonane</label>
+            </div>
+        </div>
+        <table class="task-table">
+            <thead>
+                <tr>
+                    <th style="width: 40px;"></th><th>Zadanie</th><th>Kategoria</th><th>Priorytet</th><th>Tagi</th><th>Termin</th><th>Postęp</th><th style="width: 120px;">Akcje</th>
+                </tr>
+            </thead>
+            <tbody id="task-table-body"></tbody>
+        </table>
+    </div>
+
+    <div id="tab-content-calendar" class="card" style="display:none;">
+        <div class="row">
+            <h3 class="title" id="calendar-title">Kalendarz</h3>
+            <div>
+                <button id="cal-prev" class="btn">←</button>
+                <button id="cal-next" class="btn">→</button>
+            </div>
+        </div>
+        <div id="calendar-container" style="margin-top: 16px;"></div>
+    </div>
+    <div id="tab-content-stats" class="card" style="display:none;">
+        <h3 class="title">Statystyki Produktywności</h3>
+        <div id="stats-grid" class="stats-grid">
+            <div class="chart-container"><canvas id="completed-tasks-chart"></canvas></div>
+            <div class="chart-container"><canvas id="tasks-by-prio-chart"></canvas></div>
+            <div class="chart-container"><canvas id="tasks-by-tag-chart"></canvas></div>
+        </div>
+    </div>
+  </div>
+
+<div id="modal-overlay" class="modal-overlay" style="display: none;">
+  <div class="modal-card"><p id="modal-text"></p><div id="modal-actions" class="modal-actions"></div></div>
+</div>
+
+<script>
+// --- KONFIGURACJA ---
+const TASKS_STORAGE_KEY = 'lifeos_tasks_pro_v2';
+let state = { tasks: [] };
+let charts = {};
+let tempSubtasks = [];
+let currentCalendarDate = new Date();
+let expandedTasks = new Set(); // Przechowuje ID rozwiniętych zadań
+
+// --- STAN APLIKACJI ---
+function loadState() {
+    const proDataRaw = localStorage.getItem(TASKS_STORAGE_KEY);
+    state = proDataRaw ? JSON.parse(proDataRaw) : { tasks: [] };
+}
+function saveState() { localStorage.setItem(TASKS_STORAGE_KEY, JSON.stringify(state)); }
+
+// --- ELEMENTY DOM ---
+const getEl = (id) => document.getElementById(id);
+const taskIdInput = getEl('task-id'), taskTitleInput = getEl('task-title'), taskNotesInput = getEl('task-notes');
+const taskDueDateInput = getEl('task-due-date'), taskPriorityInput = getEl('task-priority');
+const taskCategorySelector = getEl('task-category-selector');
+const taskRecurrenceInput = getEl('task-recurrence'), taskTagsInput = getEl('task-tags');
+const addTaskBtn = getEl('add-task-btn'), cancelEditBtn = getEl('cancel-edit-btn'), clearAllBtn = getEl('clear-all-btn');
+const taskTableBody = getEl('task-table-body');
+const subtaskInput = getEl('subtask-input'), subtaskListForm = getEl('subtask-list-form'), addSubtaskBtn = getEl('add-subtask-btn');
+const hideCompletedFilter = getEl('hide-completed-filter'), tagFilterInput = getEl('tag-filter');
+const priorityFilter = getEl('task-priority-filter'), categoryFilter = getEl('category-filter'), dateFilter = getEl('date-filter');
+const sortBySelect = getEl('sort-by'), sortDirectionBtn = getEl('sort-direction');
+const modalOverlay = getEl('modal-overlay'), modalText = getEl('modal-text'), modalActions = getEl('modal-actions');
+
+// --- GŁÓWNE FUNKCJE ---
+function render() { renderTaskList(); }
+
+function parseDate(dateString) {
+    if (!dateString) return null;
+    const parts = dateString.split('-').map(Number);
+    return new Date(Date.UTC(parts[0], parts[1] - 1, parts[2]));
+}
+
+function toYYYYMMDD(date) {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function renderTaskList() {
+    const catFilterVal = categoryFilter.value;
+    const dateFilterVal = dateFilter.value;
+    const prioFilterVal = priorityFilter.value;
+    const tagFilterVal = tagFilterInput.value.toLowerCase().trim();
+    const hideCompleted = hideCompletedFilter.checked;
+    const sortBy = sortBySelect.value;
+    const sortAsc = sortDirectionBtn.textContent === '↑';
+
+    let filteredTasks = state.tasks;
+
+    // Apply text/select filters first
+    if (catFilterVal !== 'all') filteredTasks = filteredTasks.filter(t => t.category === catFilterVal);
+    if (prioFilterVal !== 'all') filteredTasks = filteredTasks.filter(t => t.priority === prioFilterVal);
+    if (tagFilterVal) filteredTasks = filteredTasks.filter(t => t.tags.some(tag => tag.toLowerCase().includes(tagFilterVal)));
+
+    // Apply date range filter (only for active tasks view)
+    if (dateFilterVal !== 'all') {
+        const now = new Date();
+        const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+        let startDate, endDate;
+        if (dateFilterVal === 'this_week') {
+            const dayOfWeek = now.getUTCDay() === 0 ? 6 : now.getUTCDay() - 1;
+            startDate = new Date(today);
+            startDate.setUTCDate(startDate.getUTCDate() - dayOfWeek);
+            endDate = new Date(startDate);
+            endDate.setUTCDate(endDate.getUTCDate() + 6);
+        } else if (dateFilterVal === 'next_week') {
+            const dayOfWeek = now.getUTCDay() === 0 ? 6 : now.getUTCDay() - 1;
+            startDate = new Date(today);
+            startDate.setUTCDate(startDate.getUTCDate() - dayOfWeek + 7);
+            endDate = new Date(startDate);
+            endDate.setUTCDate(endDate.getUTCDate() + 6);
+        }
+        if (startDate && endDate) {
+            filteredTasks = filteredTasks.filter(t => {
+                if (t.status === 'done') return true; // Keep all completed tasks regardless of date filter
+                if (!t.dueDate) return false;
+                const dueDate = parseDate(t.dueDate);
+                return dueDate >= startDate && dueDate <= endDate;
+            });
+        }
+    }
+
+    taskTableBody.innerHTML = '';
+    
+    const today = new Date(); 
+    today.setUTCHours(0, 0, 0, 0);
+
+    // Create groups
+    const overdue = [];
+    const todayTasks = [];
+    const upcoming = [];
+    const completedOverdue = [];
+
+    for (const task of filteredTasks) {
+        const dueDate = parseDate(task.dueDate);
+        const isOverdue = dueDate && dueDate < today;
+
+        if (task.status === 'done') {
+            if (hideCompleted) {
+                continue; // Skip if we hide completed
+            }
+            if (isOverdue) {
+                completedOverdue.push(task);
+            } else {
+                if (dueDate && dueDate.getTime() === today.getTime()) {
+                    todayTasks.push(task);
+                } else { 
+                    upcoming.push(task);
+                }
+            }
+        } else { // Task is active
+            if (isOverdue) {
+                overdue.push(task);
+            } else if (dueDate && dueDate.getTime() === today.getTime()) {
+                todayTasks.push(task);
+            } else {
+                upcoming.push(task);
+            }
+        }
+    }
+
+    // Sorting function
+    const priorityOrder = { 'high': 1, 'medium': 2, 'low': 3 };
+    const sortFn = (a, b) => {
+        let comparison = 0;
+        switch(sortBy) {
+            case 'dueDate':
+                if (a.dueDate && b.dueDate) comparison = parseDate(a.dueDate) - parseDate(b.dueDate);
+                else if (a.dueDate) comparison = -1; else if (b.dueDate) comparison = 1;
+                break;
+            case 'priority':
+                comparison = priorityOrder[a.priority] - priorityOrder[b.priority];
+                break;
+            case 'category':
+                comparison = a.category.localeCompare(b.category);
+                break;
+        }
+        return sortAsc ? comparison : -comparison;
+    };
+    
+    // Sort each group
+    overdue.sort(sortFn);
+    todayTasks.sort(sortFn).sort((a,b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
+    upcoming.sort(sortFn).sort((a,b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
+    completedOverdue.sort((a, b) => (parseDate(b.dueDate) || 0) - (parseDate(a.dueDate) || 0));
+
+    if ([overdue, todayTasks, upcoming, completedOverdue].every(g => g.length === 0)) {
+         taskTableBody.innerHTML = `<tr><td colspan="8" class="muted" style="text-align:center; padding: 40px 0;">Brak zadań pasujących do filtrów.</td></tr>`;
+         return;
+    }
+
+    const createHeaderRow = (title, className = '') => `<tr class="task-group-header ${className}"><td colspan="8">${title}</td></tr>`;
+    
+    if (overdue.length > 0) {
+        taskTableBody.innerHTML += createHeaderRow('Zaległe', 'overdue-header');
+        overdue.forEach(t => appendTaskRow(t));
+    }
+    if (todayTasks.length > 0) {
+         taskTableBody.innerHTML += createHeaderRow('Dzisiaj');
+         todayTasks.forEach(t => appendTaskRow(t));
+    }
+    if (upcoming.length > 0) {
+        taskTableBody.innerHTML += createHeaderRow('Nadchodzące');
+        upcoming.forEach(t => appendTaskRow(t));
+    }
+    if (completedOverdue.length > 0) {
+        taskTableBody.innerHTML += createHeaderRow('Ukończone (Zaległe)', 'completed-header');
+        completedOverdue.forEach(t => appendTaskRow(t));
+    }
+    
+    addEventListenersToRows();
+}
+
+
+function addEventListenersToRows() {
+    taskTableBody.querySelectorAll('[data-id]').forEach(el => el.addEventListener('change', handleTaskStatusChange));
+    taskTableBody.querySelectorAll('[data-del-id]').forEach(el => el.addEventListener('click', (e) => deleteTask(e.currentTarget.dataset.delId)));
+    taskTableBody.querySelectorAll('[data-edit-id]').forEach(el => el.addEventListener('click', (e) => startEdit(e.currentTarget.dataset.editId)));
+    taskTableBody.querySelectorAll('.task-title-cell').forEach(el => el.addEventListener('click', (e) => {
+        const taskId = e.currentTarget.closest('tr').querySelector('[data-id]').dataset.id;
+        const subtaskRow = e.currentTarget.closest('tr').nextElementSibling;
+        if (subtaskRow) {
+            const isVisible = subtaskRow.style.display === 'table-row';
+            subtaskRow.style.display = isVisible ? 'none' : 'table-row';
+            if (isVisible) expandedTasks.delete(taskId); else expandedTasks.add(taskId);
+        }
+    }));
+    taskTableBody.querySelectorAll('.subtask-checkbox').forEach(el => el.addEventListener('change', (e) => {
+        const [taskId, subtaskId] = e.target.dataset.subtask.split(':');
+        toggleSubtask(taskId, subtaskId, e.target.checked);
+    }));
+}
+
+function appendTaskRow(task) {
+    const today = new Date(); today.setUTCHours(0, 0, 0, 0);
+    const dueDate = parseDate(task.dueDate);
+    const daysDiff = dueDate ? Math.ceil((dueDate - today) / (1000 * 60 * 60 * 24)) : null;
+    let dueDateInfo = 'Brak terminu';
+    if (daysDiff !== null) {
+        if (daysDiff < 0) dueDateInfo = `<span style="color:var(--red); font-weight: 600;">Po terminie ${Math.abs(daysDiff)} dni</span>`;
+        else if (daysDiff === 0) dueDateInfo = `<span style="color: var(--orange); font-weight: 600;">Termin dzisiaj</span>`;
+        else dueDateInfo = `Zostało ${daysDiff} dni`;
+    }
+
+    const subtasksDone = task.subtasks.filter(st => st.done).length;
+    const progress = task.subtasks.length > 0 ? (subtasksDone / task.subtasks.length) * 100 : 0;
+    const tagsHtml = task.tags.length > 0 ? `<div class="tags-container">${task.tags.map(tag => `<span class="tag-pill">${tag}</span>`).join('')}</div>` : '—';
+
+    const row = document.createElement('tr');
+    row.className = 'task-enter';
+    row.innerHTML = `
+        <td><input type="checkbox" data-id="${task.id}" ${task.status === 'done' ? 'checked' : ''}/></td>
+        <td class="task-title-cell">
+            <span class="task-title ${task.status === 'done' ? 'task-done' : ''}">${task.title}</span>
+        </td>
+        <td><span class="pill cat-${task.category}">${task.category === 'work' ? 'Praca' : 'Prywatne'}</span></td>
+        <td><span class="pill prio-${task.priority}">${task.priority === 'high' ? 'Wysoki' : (task.priority === 'medium' ? 'Średni' : 'Niski')}</span></td>
+        <td>${tagsHtml}</td>
+        <td>${task.dueDate ? `${task.dueDate} <br><span class="muted" style="font-size:10px">${dueDateInfo}</span>` : '—'}</td>
+        <td>
+            <div class="progress-bar-container" title="${subtasksDone}/${task.subtasks.length} ukończono">
+                <div class="progress-bar" style="width: ${progress}%;"></div>
+            </div>
+        </td>
+        <td class="task-actions">
+            <button class="btn" data-edit-id="${task.id}" title="Edytuj">✏️</button>
+            <button class="btn danger" data-del-id="${task.id}" title="Usuń">🗑️</button>
+        </td>
+    `;
+    const subtaskRow = document.createElement('tr');
+    subtaskRow.className = 'subtasks-row';
+    if (expandedTasks.has(task.id)) subtaskRow.style.display = 'table-row';
+    subtaskRow.innerHTML = `<td colspan="8" class="subtasks-content">
+        <p class="muted" style="font-weight: 600; margin: 0 0 8px 0;">Podzadania:</p>
+        ${task.subtasks.length > 0 ? `
+            <ul class="subtask-list">
+                ${task.subtasks.map(st => `
+                    <li class="subtask-item ${st.done ? 'done' : ''}">
+                       <input type="checkbox" class="subtask-checkbox" data-subtask="${task.id}:${st.id}" ${st.done ? 'checked' : ''}>
+                       <span>${st.text}</span>
+                    </li>
+                `).join('')}
+            </ul>` : '<span class="muted" style="font-size:11px;">Brak podzadań.</span>'}
+    </td>`;
+    taskTableBody.appendChild(row);
+    taskTableBody.appendChild(subtaskRow);
+}
+
+// --- ZARZĄDZANIE ZADANIAMI ---
+function getTask(id) { return state.tasks.find(t => t.id === id); }
+function getTaskIndex(id) { return state.tasks.findIndex(t => t.id === id); }
+
+function handleTaskStatusChange(e) {
+    const taskId = e.target.dataset.id, isChecked = e.target.checked;
+    const task = getTask(taskId);
+    if (!task) return;
+    task.status = isChecked ? 'done' : 'todo';
+    if (isChecked && task.recurrence !== 'none' && task.dueDate) {
+        const d = parseDate(task.dueDate);
+        if (task.recurrence === 'daily') d.setUTCDate(d.getUTCDate() + 1);
+        if (task.recurrence === 'weekly') d.setUTCDate(d.getUTCDate() + 7);
+        if (task.recurrence === 'monthly') d.setUTCMonth(d.getUTCMonth() + 1);
+        state.tasks.push({...task, id: `task_${Date.now()}`, dueDate: toYYYYMMDD(d), status: 'todo', subtasks: task.subtasks.map(st => ({ ...st, done: false })) });
+    }
+    saveState();
+    render();
+}
+
+function startEdit(id) {
+    const task = getTask(id);
+    if (!task) return;
+    taskIdInput.value = task.id;
+    taskTitleInput.value = task.title;
+    taskNotesInput.value = task.notes;
+    taskDueDateInput.value = task.dueDate;
+    taskPriorityInput.value = task.priority;
+    taskRecurrenceInput.value = task.recurrence;
+    taskTagsInput.value = task.tags.join(', ');
+    taskCategorySelector.querySelectorAll('.segment').forEach(s => s.classList.toggle('active', s.dataset.value === task.category));
+    tempSubtasks = [...task.subtasks];
+    renderSubtaskListForm();
+    getEl('add-task-btn-text').textContent = "Zapisz zmiany";
+    cancelEditBtn.style.display = 'inline-flex';
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function deleteTask(id) {
+    showConfirm('Na pewno usunąć to zadanie?', () => {
+        expandedTasks.delete(id);
+        const row = taskTableBody.querySelector(`[data-id="${id}"]`).closest('tr');
+        if (row) {
+            row.classList.add('task-exit');
+            row.nextElementSibling?.classList.add('task-exit');
+            setTimeout(() => {
+                state.tasks = state.tasks.filter(t => t.id !== id);
+                saveState();
+                render();
+            }, 300);
+        }
+    });
+}
+
+function resetForm() {
+    [taskIdInput, taskTitleInput, taskNotesInput, taskDueDateInput, taskTagsInput].forEach(el => el.value = '');
+    [taskPriorityInput, taskRecurrenceInput].forEach(el => el.value = el.options[0].value);
+    taskCategorySelector.querySelectorAll('.segment').forEach((s, i) => s.classList.toggle('active', i === 0));
+    tempSubtasks = [];
+    renderSubtaskListForm();
+    getEl('add-task-btn-text').textContent = "Dodaj zadanie";
+    cancelEditBtn.style.display = 'none';
+}
+
+// --- PODZADANIA ---
+function renderSubtaskListForm() {
+    subtaskListForm.innerHTML = tempSubtasks.map((st, index) => `
+        <li class="subtask-item"><span>${st.text}</span><button class="btn danger" style="padding: 4px; margin-left: auto;" data-index="${index}" onclick="removeTempSubtask(event)">🗑️</button></li>
+    `).join('');
+}
+function addTempSubtask() {
+    const text = subtaskInput.value.trim();
+    if (text) {
+        tempSubtasks.push({ id: `st_${Date.now()}`, text, done: false });
+        subtaskInput.value = '';
+        renderSubtaskListForm();
+    }
+}
+function removeTempSubtask(e) { e.preventDefault(); tempSubtasks.splice(e.currentTarget.dataset.index, 1); renderSubtaskListForm(); }
+function toggleSubtask(taskId, subtaskId, isDone) {
+    const task = getTask(taskId);
+    const subtask = task?.subtasks.find(st => st.id === subtaskId);
+    if (subtask) { subtask.done = isDone; saveState(); render(); }
+}
+
+// --- KALENDARZ ---
+function renderCalendar() {
+    const year = currentCalendarDate.getFullYear(), month = currentCalendarDate.getMonth();
+    getEl('calendar-title').textContent = currentCalendarDate.toLocaleString('pl-PL', { month: 'long', year: 'numeric' });
+    const firstDay = new Date(year, month, 1).getDay(), daysInMonth = new Date(year, month + 1, 0).getDate();
+    const dayOfWeek = (firstDay === 0) ? 6 : firstDay - 1;
+    let html = `<div class="calendar-grid">`;
+    ['Pon', 'Wt', 'Śr', 'Czw', 'Pt', 'Sob', 'Ndz'].forEach(day => html += `<div class="calendar-header">${day}</div>`);
+    for (let i = 0; i < dayOfWeek; i++) html += `<div class="calendar-day"></div>`;
+    for (let day = 1; day <= daysInMonth; day++) {
+        const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+        const tasksForDay = state.tasks.filter(t => t.dueDate === dateStr);
+        tasksForDay.sort((a,b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
+        
+        let tasksHtml = tasksForDay.map(t => `<div class="calendar-task-pill ${t.category} prio-${t.priority || 'low'} ${t.status === 'done' ? 'task-done' : ''}" title="${t.title}">${t.title}</div>`).join('');
+        
+        html += `<div class="calendar-day"><div class="day-number">${day}</div><div class="calendar-tasks">${tasksHtml}</div></div>`;
+    }
+    getEl('calendar-container').innerHTML = html + `</div>`;
+}
+
+// --- STATYSTYKI ---
+function renderStats() {
+    Object.values(charts).forEach(chart => chart.destroy());
+    const last7Days = Array(7).fill(0).map((_, i) => { const d = new Date(); d.setDate(d.getDate() - i); return toYYYYMMDD(d); }).reverse();
+    const completedCounts = last7Days.map(day => state.tasks.filter(t => t.status === 'done' && t.dueDate === day).length);
+    charts.completed = new Chart(getEl('completed-tasks-chart'), { type: 'bar', data: { labels: last7Days.map(d => d.slice(5)), datasets: [{ label: 'Ukończone zadania', data: completedCounts, backgroundColor: 'var(--accent-weak)', borderColor: 'var(--accent)', borderWidth: 1 }] }, options: { responsive: true, plugins: { legend: { display: false }, title: { display: true, text: 'Aktywność w ostatnim tygodniu' } } } });
+    const activeTasks = state.tasks.filter(t => t.status !== 'done');
+    const prioCounts = { high: 0, medium: 0, low: 0 };
+    activeTasks.forEach(t => prioCounts[t.priority]++);
+    charts.prio = new Chart(getEl('tasks-by-prio-chart'), { type: 'doughnut', data: { labels: ['Wysoki', 'Średni', 'Niski'], datasets: [{ data: Object.values(prioCounts), backgroundColor: ['#b91c1c', '#c2410c', '#475569'] }] }, options: { responsive: true, plugins: { title: { display: true, text: 'Aktywne zadania wg priorytetu' } } } });
+    const tagCounts = {};
+    activeTasks.forEach(t => t.tags.forEach(tag => tagCounts[tag] = (tagCounts[tag] || 0) + 1));
+    charts.tags = new Chart(getEl('tasks-by-tag-chart'), { type: 'pie', data: { labels: Object.keys(tagCounts), datasets: [{ data: Object.values(tagCounts), backgroundColor: ['#3b82f6', '#84cc16', '#f97316', '#a855f7', '#ec4899', '#10b981', '#f59e0b'] }] }, options: { responsive: true, plugins: { title: { display: true, text: 'Aktywne zadania wg tagów' } } } });
+}
+
+// --- MODALE ---
+function showModal(text, buttons) {
+    modalText.textContent = text;
+    modalActions.innerHTML = '';
+    buttons.forEach(btnConfig => { const button = document.createElement('button'); button.textContent = btnConfig.text; button.className = btnConfig.class; button.onclick = () => { modalOverlay.style.display = 'none'; if (btnConfig.onClick) btnConfig.onClick(); }; modalActions.appendChild(button); });
+    modalOverlay.style.display = 'flex';
+}
+function showAlert(message) { showModal(message, [{ text: 'OK', class: 'btn primary' }]); }
+function showConfirm(message, onConfirm) { showModal(message, [{ text: 'Anuluj', class: 'btn' }, { text: 'Potwierdź', class: 'btn danger', onClick: onConfirm }]); }
+
+// --- INICJALIZACJA I EVENT LISTENERS ---
+function init() {
+    categoryFilter.innerHTML = `<option value="all">Wszystkie kategorie</option><option value="work">Praca</option><option value="private">Prywatne</option>`;
+    dateFilter.innerHTML = `<option value="all">Wszystkie terminy</option><option value="this_week">Bieżący tydzień</option><option value="next_week">Kolejny tydzień</option>`;
+    priorityFilter.innerHTML = `<option value="all">Wszystkie priorytety</option><option value="high">Wysoki</option><option value="medium">Średni</option><option value="low">Niski</option>`;
+    sortBySelect.innerHTML = `<option value="dueDate">Sortuj wg Terminu</option><option value="priority">Sortuj wg Priorytetu</option><option value="category">Sortuj wg Kategorii</option>`;
+
+    addTaskBtn.addEventListener('click', () => {
+        const title = taskTitleInput.value.trim();
+        if (!title) { showAlert('Tytuł zadania jest wymagany.'); return; }
+        const taskData = { title, notes: taskNotesInput.value.trim(), dueDate: taskDueDateInput.value, priority: taskPriorityInput.value, category: taskCategorySelector.querySelector('.segment.active').dataset.value, recurrence: taskRecurrenceInput.value, tags: taskTagsInput.value.split(',').map(t => t.trim()).filter(Boolean), subtasks: [...tempSubtasks] };
+        const id = taskIdInput.value;
+        if (id) { const index = getTaskIndex(id); if (index > -1) state.tasks[index] = { ...state.tasks[index], ...taskData }; } 
+        else { state.tasks.push({ ...taskData, id: `task_${Date.now()}`, status: 'todo', createdAt: new Date().toISOString() }); }
+        saveState(); resetForm(); render();
+    });
+
+    taskCategorySelector.addEventListener('click', (e) => {
+        if (e.target.classList.contains('segment')) {
+            taskCategorySelector.querySelectorAll('.segment').forEach(s => s.classList.remove('active'));
+            e.target.classList.add('active');
+        }
+    });
+    
+    [categoryFilter, dateFilter, priorityFilter, tagFilterInput, hideCompletedFilter, sortBySelect].forEach(el => el.addEventListener('change', renderTaskList));
+    tagFilterInput.addEventListener('keyup', renderTaskList);
+    sortDirectionBtn.addEventListener('click', () => { sortDirectionBtn.textContent = sortDirectionBtn.textContent === '↑' ? '↓' : '↑'; renderTaskList(); });
+    addSubtaskBtn.addEventListener('click', addTempSubtask);
+    subtaskInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); addTempSubtask(); }});
+    cancelEditBtn.addEventListener('click', resetForm);
+    clearAllBtn.addEventListener('click', () => showConfirm('Na pewno usunąć WSZYSTKIE zadania?', () => { state.tasks = []; saveState(); render(); showAlert('Wszystkie zadania zostały usunięte.'); }));
+    document.querySelectorAll('.tab').forEach(tab => tab.addEventListener('click', (e) => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        e.target.classList.add('active');
+        const tabName = e.target.dataset.tab;
+        ['list', 'calendar', 'stats'].forEach(t => getEl(`tab-content-${t}`).style.display = t === tabName ? 'block' : 'none');
+        if (tabName === 'stats') renderStats();
+        if (tabName === 'calendar') renderCalendar();
+    }));
+    getEl('cal-prev').addEventListener('click', () => { currentCalendarDate.setMonth(currentCalendarDate.getMonth() - 1); renderCalendar(); });
+    getEl('cal-next').addEventListener('click', () => { currentCalendarDate.setMonth(currentCalendarDate.getMonth() + 1); renderCalendar(); });
+
+    loadState();
+    render();
+}
+
+init();
+</script>
+</body>
+</html>

--- a/trainings.html
+++ b/trainings.html
@@ -31,6 +31,12 @@
   --run-color: #047857;
   --read-color: #1d4ed8;
   --extra-color: #0ea5e9;
+  --day-empty: #fff1f2;
+  --day-empty-border: rgba(248, 113, 113, 0.5);
+  --day-planned: #fff7ed;
+  --day-planned-border: rgba(251, 191, 36, 0.45);
+  --day-completed: #ecfdf5;
+  --day-completed-border: rgba(34, 197, 94, 0.45);
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -209,7 +215,7 @@ a { color: inherit; text-decoration: none; }
 }
 
 .calendar-day {
-  background: var(--bg-alt);
+  background: #fff;
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.3);
   padding: 10px 12px;
@@ -223,9 +229,12 @@ a { color: inherit; text-decoration: none; }
 }
 
 .calendar-day:hover { border-color: var(--primary); box-shadow: var(--shadow-sm); transform: translateY(-2px); }
-.calendar-day--other-month { opacity: 0.55; background: rgba(248, 250, 252, 0.6); }
-.calendar-day--selected { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.16); background: #fff; }
+.calendar-day--other-month { opacity: 0.55; }
+.calendar-day--selected { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.12); }
 .calendar-day--today { border-color: var(--success); }
+.calendar-day--empty { background: var(--day-empty); border-color: var(--day-empty-border); }
+.calendar-day--planned { background: var(--day-planned); border-color: var(--day-planned-border); }
+.calendar-day--completed { background: var(--day-completed); border-color: var(--day-completed-border); }
 
 .calendar-day-header { display: flex; justify-content: space-between; align-items: center; }
 .calendar-date-number { font-weight: 700; font-size: 14px; }
@@ -240,18 +249,75 @@ a { color: inherit; text-decoration: none; }
   color: var(--muted);
 }
 
-.calendar-day-dots { display: flex; flex-wrap: wrap; gap: 4px; min-height: 20px; }
-.activity-dot, .legend-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
-.activity-dot.gym, .legend-dot.gym { background: var(--gym-color); }
-.activity-dot.running, .legend-dot.running { background: var(--run-color); }
-.activity-dot.reading, .legend-dot.reading { background: var(--read-color); }
-.activity-dot.extra, .legend-dot.extra { background: var(--extra-color); }
+.calendar-day-tags { display: flex; flex-wrap: wrap; gap: 4px; min-height: 32px; }
+.activity-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--ink);
+  border: 1px solid transparent;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.activity-tag.gym { background: rgba(91, 33, 182, 0.12); color: var(--gym-color); border-color: rgba(91, 33, 182, 0.16); }
+.activity-tag.running { background: rgba(4, 120, 87, 0.12); color: var(--run-color); border-color: rgba(4, 120, 87, 0.18); }
+.activity-tag.reading { background: rgba(29, 78, 216, 0.12); color: var(--read-color); border-color: rgba(29, 78, 216, 0.18); }
+.activity-tag.extra { background: rgba(14, 165, 233, 0.12); color: var(--extra-color); border-color: rgba(14, 165, 233, 0.18); }
+.activity-tag.more { background: rgba(148, 163, 184, 0.14); color: var(--muted); border-style: dashed; }
 
 .calendar-day-footer { margin-top: auto; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; align-items: center; }
-.calendar-footer-label { font-weight: 600; color: var(--success); }
+.calendar-footer-label { font-weight: 600; color: var(--muted); }
+.calendar-day--empty .calendar-footer-label { color: var(--danger); }
+.calendar-day--planned .calendar-footer-label { color: var(--warning); }
+.calendar-day--completed .calendar-footer-label { color: var(--success); }
 
-.calendar-legend { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; font-size: 11px; color: var(--muted); }
+.calendar-legend { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; font-size: 11px; color: var(--muted); }
 .calendar-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.legend-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--muted);
+}
+.legend-tag.gym { background: rgba(91, 33, 182, 0.12); color: var(--gym-color); }
+.legend-tag.running { background: rgba(4, 120, 87, 0.12); color: var(--run-color); }
+.legend-tag.reading { background: rgba(29, 78, 216, 0.12); color: var(--read-color); }
+.legend-tag.extra { background: rgba(14, 165, 233, 0.12); color: var(--extra-color); }
+
+.planning-banner {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 14px;
+  padding: 10px 12px;
+}
+
+.planning-banner.active { display: flex; }
+.planning-banner-info { display: flex; align-items: center; gap: 10px; }
+.planning-banner-info strong { display: block; font-size: 12px; font-weight: 700; color: var(--ink); }
+.planning-banner-info span { display: block; font-size: 11px; color: var(--muted); }
+.planning-banner .icon { color: var(--primary); }
+
+.btn.small { padding: 6px 12px; font-size: 11px; border-radius: 10px; }
+
+.calendar-card--planning { border-color: var(--primary); box-shadow: var(--shadow-sm); }
+.calendar-grid.is-planning .calendar-day { cursor: crosshair; }
 
 .upcoming-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
 .upcoming-item { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(248, 250, 252, 0.7); }
@@ -333,16 +399,16 @@ a { color: inherit; text-decoration: none; }
 .goal-progress-bar span { display: block; height: 100%; border-radius: 999px; transition: width .3s ease; }
 
 .heatmap-card { display: flex; flex-direction: column; gap: 16px; }
-.heatmap { display: flex; gap: 4px; overflow-x: auto; padding-bottom: 6px; }
-.heatmap-week { display: grid; grid-template-rows: repeat(7, 14px) auto; gap: 4px; align-items: center; }
-.heatmap-cell { width: 14px; height: 14px; border-radius: 3px; background: #e2e8f0; }
+.heatmap { display: flex; gap: 3px; overflow: hidden; padding-bottom: 8px; flex-wrap: nowrap; }
+.heatmap-week { display: grid; grid-template-rows: repeat(7, 11px) auto; gap: 3px; align-items: center; }
+.heatmap-cell { width: 11px; height: 11px; border-radius: 3px; background: #e2e8f0; }
 .heatmap-cell[data-level="0"] { background: #e2e8f0; }
 .heatmap-cell[data-level="1"] { background: #b7f3d0; }
 .heatmap-cell[data-level="2"] { background: #6ee7b7; }
 .heatmap-cell[data-level="3"] { background: #34d399; }
 .heatmap-cell[data-level="4"] { background: #059669; }
 .heatmap-cell--empty { background: transparent; }
-.heatmap-month-label { font-size: 9px; text-transform: uppercase; color: var(--muted); text-align: center; letter-spacing: 0.08em; }
+.heatmap-month-label { font-size: 9px; text-transform: uppercase; color: var(--muted); text-align: center; letter-spacing: 0.08em; margin-top: 1px; }
 .heatmap-legend { display: flex; align-items: center; justify-content: flex-end; gap: 10px; font-size: 11px; color: var(--muted); }
 .heatmap-legend-scale { display: inline-flex; align-items: center; gap: 4px; }
 .heatmap-legend-scale span { width: 14px; height: 14px; border-radius: 3px; background: #e2e8f0; }
@@ -478,14 +544,24 @@ a { color: inherit; text-decoration: none; }
             <p class="muted tiny">Planowanie i realizacja celów bez przewijania</p>
           </div>
           <div class="calendar-legend">
-            <span><span class="legend-dot gym"></span>Siłownia</span>
-            <span><span class="legend-dot running"></span>Bieganie</span>
-            <span><span class="legend-dot reading"></span>Czytanie</span>
-            <span><span class="legend-dot extra"></span>Dodatkowe</span>
+            <span class="legend-tag gym">Siłownia</span>
+            <span class="legend-tag running">Bieganie</span>
+            <span class="legend-tag reading">Czytanie</span>
+            <span class="legend-tag extra">Dodatkowe</span>
           </div>
         </div>
         <div class="calendar-weekdays">
           <span>Pon</span><span>Wt</span><span>Śr</span><span>Czw</span><span>Pt</span><span>Sob</span><span>Niedz</span>
+        </div>
+        <div id="planning-banner" class="planning-banner" aria-live="polite">
+          <div class="planning-banner-info">
+            <i data-lucide="mouse-pointer" class="icon"></i>
+            <div>
+              <strong id="planning-banner-title">Tryb planowania</strong>
+              <span id="planning-banner-meta">Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.</span>
+            </div>
+          </div>
+          <button id="stop-planning-btn" class="btn soft small"><i data-lucide="check" class="icon"></i>Zakończ</button>
         </div>
         <div id="calendar-grid" class="calendar-grid"></div>
       </div>
@@ -529,7 +605,7 @@ a { color: inherit; text-decoration: none; }
         </div>
 
         <div class="detail-actions">
-          <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj trening</button>
+          <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj treningi</button>
           <button id="add-extra-btn" class="btn ghost"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
         </div>
       </div>
@@ -622,10 +698,15 @@ const PRIORITY_IMPACT_LABELS = PRIORITY_IMPACT_OPTIONS.reduce((acc, opt) => {
   return acc;
 }, {});
 const MAX_PRIORITIES = 3;
+const ACTIVITY_TAG_SHORT = { gym: 'Siła', running: 'Bieg', reading: 'Czyt.' };
+const ACTIVITY_UNIT_SHORT = { running: 'km', reading: 'str.' };
+const MAX_CALENDAR_TAGS = 4;
+const DEFAULT_PLANNING_META = 'Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.';
 
 let state = { activities: {}, extras: {}, priorities: {} };
 let currentMonth = startOfMonth(new Date());
 let selectedDate = toYYYYMMDD(new Date());
+let planningMode = null;
 let saveTimeout;
 
 function startOfMonth(date) {
@@ -654,6 +735,53 @@ function formatRange(start, end) {
 
 function formatDateWithDay(date) {
   return date.toLocaleDateString('pl-PL', { weekday: 'short', day: '2-digit', month: 'short' });
+}
+
+function formatPlanningSummary(type, plannedValue) {
+  const def = GOAL_DEFINITIONS[type];
+  if (!def) return 'Nowy trening';
+  if (type === 'gym') return def.label;
+  const numeric = Number(plannedValue);
+  if (!Number.isFinite(numeric) || numeric <= 0) return def.label;
+  const valueLabel = `${numeric.toLocaleString('pl-PL')} ${def.unit}`;
+  return `${def.label} · ${valueLabel}`;
+}
+
+function getActivityTagText(activity) {
+  if (!activity || !activity.type) return 'Trening';
+  const short = ACTIVITY_TAG_SHORT[activity.type] || 'Plan';
+  if (activity.type === 'gym') return short;
+  const numeric = Number(activity.plannedValue || activity.loggedValue);
+  if (!Number.isFinite(numeric) || numeric <= 0) return short;
+  const unit = ACTIVITY_UNIT_SHORT[activity.type] || '';
+  const value = numeric.toLocaleString('pl-PL');
+  return unit ? `${short} ${value} ${unit}` : `${short} ${value}`;
+}
+
+function getExtraTagText(extra) {
+  if (!extra) return 'Aktywność';
+  const base = (extra.title || '').trim() || EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność';
+  if (base.length <= 14) return base;
+  return `${base.slice(0, 13)}…`;
+}
+
+function isPlanningActive() {
+  return Boolean(planningMode && planningMode.active);
+}
+
+function startPlanningMode(type, plannedValue) {
+  planningMode = {
+    active: true,
+    type,
+    plannedValue: type === 'gym' ? 1 : Number(plannedValue) || 0
+  };
+  setTimeout(() => render(), 0);
+}
+
+function stopPlanningMode() {
+  if (!isPlanningActive()) return;
+  planningMode = null;
+  setTimeout(() => render(), 0);
 }
 
 function addDays(date, days) {
@@ -699,6 +827,7 @@ function getISOWeekStart(year, week) {
 
 function loadState() {
   state = { activities: {}, extras: {}, priorities: {} };
+  planningMode = null;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
@@ -979,6 +1108,7 @@ function render() {
   renderPriorities();
   renderGoalProgress(weekStats.goalPercents);
   renderHeatmap();
+  renderPlanningIndicator();
   lucide.createIcons();
 }
 
@@ -1025,6 +1155,9 @@ function renderCalendar() {
     if (date.getMonth() !== currentMonth.getMonth()) cell.classList.add('calendar-day--other-month');
     if (dateString === selectedDate) cell.classList.add('calendar-day--selected');
     if (normalizeDate(date).getTime() === today.getTime()) cell.classList.add('calendar-day--today');
+    if (plannedCount === 0) cell.classList.add('calendar-day--empty');
+    else if (completedCount === 0) cell.classList.add('calendar-day--planned');
+    else cell.classList.add('calendar-day--completed');
 
     const header = document.createElement('div');
     header.className = 'calendar-day-header';
@@ -1043,23 +1176,44 @@ function renderCalendar() {
     header.appendChild(badges);
     cell.appendChild(header);
 
-    const dots = document.createElement('div');
-    dots.className = 'calendar-day-dots';
-    const dotTypes = [];
-    activities.forEach(activity => dotTypes.push(activity.type));
-    extras.forEach(() => dotTypes.push('extra'));
-    dotTypes.slice(0, 8).forEach(type => {
-      const dot = document.createElement('span');
-      dot.className = `activity-dot ${type}`;
-      dots.appendChild(dot);
+    const tags = document.createElement('div');
+    tags.className = 'calendar-day-tags';
+    const tagItems = [];
+    activities.forEach(activity => {
+      tagItems.push({
+        type: activity.type,
+        text: getActivityTagText(activity),
+        tooltip: formatPlanningSummary(activity.type, activity.plannedValue || activity.loggedValue)
+      });
     });
-    cell.appendChild(dots);
+    extras.forEach(extra => {
+      tagItems.push({
+        type: 'extra',
+        text: getExtraTagText(extra),
+        tooltip: (extra.title || '').trim() || EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność dodatkowa'
+      });
+    });
+    tagItems.slice(0, MAX_CALENDAR_TAGS).forEach(tag => {
+      const pill = document.createElement('span');
+      pill.className = `activity-tag ${tag.type}`;
+      pill.textContent = tag.text;
+      pill.title = tag.tooltip || tag.text;
+      tags.appendChild(pill);
+    });
+    if (tagItems.length > MAX_CALENDAR_TAGS) {
+      const more = document.createElement('span');
+      more.className = 'activity-tag more';
+      more.textContent = `+${tagItems.length - MAX_CALENDAR_TAGS}`;
+      more.title = 'Więcej zaplanowanych aktywności';
+      tags.appendChild(more);
+    }
+    cell.appendChild(tags);
 
     const footer = document.createElement('div');
     footer.className = 'calendar-day-footer';
     const done = document.createElement('span');
     done.className = 'calendar-footer-label';
-    done.textContent = completedCount > 0 ? `${completedCount} ukończ.` : 'Brak';
+    done.textContent = `${completedCount} ukończ.`;
     const remaining = document.createElement('span');
     const openCount = Math.max(0, plannedCount - completedCount);
     remaining.textContent = openCount > 0 ? `${openCount} otwarte` : '';
@@ -1069,14 +1223,47 @@ function renderCalendar() {
 
     cell.addEventListener('click', () => {
       selectedDate = dateString;
-      if (date.getMonth() !== currentMonth.getMonth()) {
+      if (!sameMonth(date, currentMonth)) {
         currentMonth = startOfMonth(date);
+      }
+      if (isPlanningActive()) {
+        addTraining(dateString, planningMode.type, planningMode.plannedValue);
+        return;
       }
       render();
     });
 
     grid.appendChild(cell);
   });
+}
+
+function renderPlanningIndicator() {
+  const banner = document.getElementById('planning-banner');
+  const title = document.getElementById('planning-banner-title');
+  const meta = document.getElementById('planning-banner-meta');
+  const calendarCard = document.querySelector('.calendar-card');
+  const grid = document.getElementById('calendar-grid');
+  const addBtn = document.getElementById('add-training-btn');
+  if (!banner || !title || !meta || !calendarCard || !grid || !addBtn) return;
+
+  if (isPlanningActive()) {
+    const summary = formatPlanningSummary(planningMode.type, planningMode.plannedValue);
+    banner.classList.add('active');
+    title.textContent = summary;
+    meta.textContent = 'Klikaj dni w kalendarzu, aby dodać ten trening. Zakończ, gdy skończysz planować.';
+    calendarCard.classList.add('calendar-card--planning');
+    grid.classList.add('is-planning');
+    addBtn.innerHTML = '<i data-lucide="x" class="icon"></i>Zakończ planowanie';
+    addBtn.classList.add('ghost');
+  } else {
+    banner.classList.remove('active');
+    title.textContent = 'Tryb planowania';
+    meta.textContent = DEFAULT_PLANNING_META;
+    calendarCard.classList.remove('calendar-card--planning');
+    grid.classList.remove('is-planning');
+    addBtn.innerHTML = '<i data-lucide="plus" class="icon"></i>Zaplanuj treningi';
+    addBtn.classList.remove('ghost');
+  }
 }
 
 function renderDayDetail() {
@@ -1463,6 +1650,16 @@ function showAddTrainingModal() {
     ],
     buttons: [
       { text: 'Anuluj', class: 'btn soft', action: 'close' },
+      { text: 'Planowanie wielu dni', class: 'btn ghost', action: (value, selected) => {
+          const type = selected || 'gym';
+          if (type !== 'gym') {
+            const numeric = Number(value);
+            if (!numeric || numeric <= 0) return false;
+            startPlanningMode(type, numeric);
+          } else {
+            startPlanningMode(type, 1);
+          }
+        } },
       { text: 'Dodaj', class: 'btn', action: (value, selected) => {
           const type = selected || 'gym';
           if (type !== 'gym') {
@@ -1622,7 +1819,14 @@ function setupEventListeners() {
     selectedDate = toYYYYMMDD(today);
     render();
   });
-  document.getElementById('add-training-btn').addEventListener('click', showAddTrainingModal);
+  document.getElementById('add-training-btn').addEventListener('click', () => {
+    if (isPlanningActive()) {
+      stopPlanningMode();
+    } else {
+      showAddTrainingModal();
+    }
+  });
+  document.getElementById('stop-planning-btn').addEventListener('click', () => stopPlanningMode());
   document.getElementById('add-extra-btn').addEventListener('click', showAddExtraModal);
   document.getElementById('priority-add-btn').addEventListener('click', showPriorityModal);
 

--- a/trainings.html
+++ b/trainings.html
@@ -60,42 +60,46 @@
     .row { display: flex; justify-content: space-between; align-items: center; }
 
     /* Header */
-    .page-header { display: grid; gap: 20px; margin-bottom: 32px; }
-    .page-header-main { display: flex; flex-direction: row; gap: 24px; align-items: center; padding: 28px; border-radius: 24px; background: linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, rgba(14, 165, 233, 0.05) 100%); border: 1px solid rgba(148, 163, 184, 0.25); position: relative; overflow: hidden; box-shadow: var(--shadow); }
+    .page-header { display: grid; gap: 24px; margin-bottom: 40px; }
+    .page-header-main { display: flex; flex-direction: column; gap: 24px; padding: 32px; border-radius: 28px; background: linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, rgba(14, 165, 233, 0.05) 100%); border: 1px solid rgba(148, 163, 184, 0.25); position: relative; overflow: hidden; box-shadow: var(--shadow); }
     .page-header-main::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at top right, rgba(59,130,246,0.16), transparent 55%); pointer-events: none; }
     .page-header-main > * { position: relative; z-index: 1; }
-    .back-btn { height: fit-content; align-self: flex-start; }
-    .page-header-copy { display: flex; flex-direction: column; gap: 12px; }
-    .page-header-copy h1 { font-size: 32px; margin: 0; font-weight: 800; letter-spacing: -0.5px; }
-    .header-subtitle { max-width: 520px; }
+    .header-top { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+    .page-header-copy { display: flex; flex-direction: column; gap: 16px; }
+    .page-header-copy h1 { font-size: 34px; margin: 0; font-weight: 800; letter-spacing: -0.5px; }
+    .header-subtitle { max-width: 580px; font-size: 15px; }
     .eyebrow { text-transform: uppercase; letter-spacing: 0.12em; font-size: 11px; font-weight: 600; color: var(--blue); }
-    .header-tags { display: flex; flex-wrap: wrap; gap: 8px; }
-    .chip { display: inline-flex; align-items: center; gap: 6px; font-weight: 600; font-size: 12px; padding: 6px 12px; border-radius: 999px; background: rgba(37, 99, 235, 0.12); color: var(--blue); }
-    .chip-outline { background: transparent; border: 1px solid rgba(148, 163, 184, 0.35); color: var(--muted); }
-    .header-kpis { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); padding: 20px; }
+    .header-insights { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
+    .insight-card { background: rgba(255, 255, 255, 0.7); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 18px; padding: 16px; box-shadow: var(--shadow); backdrop-filter: blur(8px); display: flex; flex-direction: column; gap: 6px; }
+    .insight-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); font-weight: 600; }
+    .insight-value { font-size: 22px; font-weight: 700; color: var(--ink); }
+    .insight-sub { font-size: 12px; color: var(--muted); }
+    .header-kpis { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); padding: 24px; }
     .kpi-item { text-align: left; display: flex; flex-direction: column; gap: 4px; }
     .kpi-value { font-size: 26px; font-weight: 800; line-height: 1.1; }
     .kpi-note { margin: 0; color: var(--muted); }
-    .goal-card { padding: 20px; box-shadow: none; transition: var(--transition-fast); border: 1px solid rgba(148, 163, 184, 0.2); }
-    .goal-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
-    .goal-card .title { font-size: 15px; margin-bottom: 6px; }
-    .goal-card .kpi-value { font-size: 22px; font-weight: 700; }
-    .goal-card .btn { width: 100%; margin-top: 16px; padding: 8px 12px; font-size: 13px; }
-    .goal-meta { font-size: 12px; color: var(--muted); margin-top: 6px; }
-    .weekly-overview-card { position: relative; overflow: visible; }
-    .overview-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .weekly-overview-card { position: relative; overflow: visible; display: flex; flex-direction: column; gap: 20px; }
+    .overview-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
+    .overview-header h3 { margin-bottom: 0; }
     .button-group { display: flex; gap: 8px; flex-wrap: wrap; }
-    .overview-progress { margin-top: 18px; display: flex; flex-direction: column; gap: 8px; }
+    .overview-progress { display: flex; flex-direction: column; gap: 10px; }
     .progress-summary { display: flex; justify-content: space-between; align-items: center; }
-    .goal-grid .goal-card { box-shadow: none; }
-    .goal-grid { margin-top: 20px; }
+    .goal-grid { display: grid; gap: 16px; grid-template-columns: 1fr; }
+    .goal-card { padding: 22px; border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 18px; display: flex; flex-direction: column; gap: 12px; transition: var(--transition-fast); }
+    .goal-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+    .goal-card .title { font-size: 16px; margin-bottom: 0; }
+    .goal-card .kpi-value { font-size: 22px; font-weight: 700; }
+    .goal-card .goal-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .goal-card .btn { flex: 1; min-width: 140px; padding: 8px 12px; font-size: 13px; }
+    .goal-meta { font-size: 12px; color: var(--muted); margin-top: 4px; }
     .goal-card.goal-gym { background: var(--gym-soft); border-color: var(--gym-border); }
     .goal-card.goal-running { background: var(--run-soft); border-color: var(--run-border); }
     .goal-card.goal-reading { background: var(--read-soft); border-color: var(--read-border); }
-    .insights-grid { margin-top: 20px; }
+    .page-layout { display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); gap: 24px; align-items: flex-start; }
+    .layout-main, .layout-side { display: flex; flex-direction: column; gap: 24px; }
+    @media(max-width: 1100px) { .page-layout { grid-template-columns: 1fr; } }
+    .insights-grid { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
     .insights-grid .card { min-height: 220px; display: flex; flex-direction: column; gap: 12px; }
-    .focus-text { font-size: 14px; line-height: 1.6; }
-    .focus-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: auto; }
     .priority-list, .next-actions-list { list-style: none; padding: 0; margin: 12px 0; display: flex; flex-direction: column; gap: 12px; }
     .priority-item { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.35); background: rgba(248, 250, 252, 0.7); transition: var(--transition-fast); }
     .priority-item:hover { border-color: rgba(37, 99, 235, 0.35); box-shadow: var(--shadow-sm); }
@@ -116,18 +120,23 @@
     .next-action-date { font-size: 12px; color: var(--muted); }
     .next-action-badge { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); background: rgba(37, 99, 235, 0.12); border-radius: 999px; padding: 4px 8px; }
     @media(max-width: 640px) {
-      .page-header-main { flex-direction: column; align-items: flex-start; }
+      .header-top { width: 100%; justify-content: flex-start; }
       .back-btn { width: 100%; }
     }
 
-    /* Tabs */
-    .tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 24px; border-bottom: 1px solid var(--line); padding-bottom: 8px; }
-    .tab { padding: 8px 14px; border-radius: 8px; cursor: pointer; font-weight: 600; border: 1px solid transparent; color: var(--muted); transition: var(--transition-fast); display: flex; align-items: center; gap: 6px;}
-    .tab:hover { background: var(--bg); color: var(--ink); }
-    .tab.active { background: #fff; color: var(--ink); border-color: var(--line); box-shadow: var(--shadow-sm); }
-
     /* Planner */
-    .planner-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 12px; margin-top: 16px; }
+    .planner-card { padding: 28px; }
+    .planner-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
+    .planner-title { display: flex; flex-direction: column; gap: 4px; }
+    .planner-title .title { margin: 0; font-size: 20px; }
+    .planner-range { font-size: 13px; color: var(--muted); }
+    .planner-controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+    .week-nav { display: flex; gap: 8px; }
+    .planner-meta { display: flex; justify-content: space-between; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 16px; }
+    .planner-status { font-weight: 600; font-size: 13px; }
+    .planner-instructions { display: none; margin: 0; margin-top: 12px; padding: 12px 16px; border-radius: 12px; background: var(--blue-soft); color: var(--blue); font-weight: 500; }
+    .btn.small { padding: 6px 12px; font-size: 12px; border-radius: 10px; }
+    .planner-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 12px; margin-top: 20px; }
     .day-column { position: relative; background: var(--bg); border-radius: 12px; padding: 12px; transition: var(--transition-fast); border: 2px solid transparent; }
     .day-header { font-weight: 600; text-align: center; font-size: 13px; padding-bottom: 8px; margin-bottom: 8px; border-bottom: 1px solid var(--line); }
     .day-header.today { color: var(--blue); }
@@ -175,7 +184,7 @@
     .add-extra-btn { align-self: flex-start; display: inline-flex; align-items: center; gap: 6px; border: 1px dashed rgba(148, 163, 184, 0.6); background: transparent; padding: 6px 10px; border-radius: 10px; font-size: 12px; color: var(--muted); cursor: pointer; transition: var(--transition-fast); }
     .add-extra-btn:hover { border-color: var(--blue); color: var(--blue); }
 
-    .empty-planner { text-align: center; padding: 40px; color: var(--muted); border: 2px dashed var(--line); border-radius: 12px; margin-top: 16px; }
+    .empty-planner { text-align: center; padding: 40px; color: var(--muted); border: 2px dashed var(--line); border-radius: 16px; margin-top: 24px; background: rgba(255, 255, 255, 0.7); }
 
     /* Modal */
     .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(15, 23, 42, 0.6); display: flex; justify-content: center; align-items: center; z-index: 1000; backdrop-filter: blur(4px); opacity: 0; pointer-events: none; transition: opacity .2s ease-out; }
@@ -214,16 +223,29 @@
   <div class="wrap">
     <header class="page-header">
       <div class="page-header-main">
-        <a href="./index.html" class="btn soft back-btn"><i data-lucide="arrow-left" class="icon"></i> Powrót</a>
+        <div class="header-top">
+          <a href="./index.html" class="btn soft back-btn"><i data-lucide="arrow-left" class="icon"></i> Powrót</a>
+        </div>
         <div class="page-header-copy">
-          <span class="eyebrow">Twoje centrum dowodzenia celami</span>
-          <h1>Plany i Progres</h1>
-          <p class="muted header-subtitle">Planuj, rób miejsce na dodatkowe aktywności i pilnuj tygodniowego rytmu.</p>
-          <div class="header-tags">
-            <span id="header-focus-chip" class="chip chip-outline">Brak zdefiniowanego fokusu</span>
-            <span class="chip">
-              Postęp tygodnia: <span id="header-week-progress">0%</span>
-            </span>
+          <span class="eyebrow">Strategiczne zarządzanie rozwojem</span>
+          <h1>Panel treningów</h1>
+          <p class="muted header-subtitle">Planowanie, realizacja i analiza Twoich kluczowych celów w jednym miejscu. Profesjonalny rytm tygodnia zaczyna się tutaj.</p>
+          <div class="header-insights">
+            <div class="insight-card">
+              <span class="insight-label">Aktualny tydzień</span>
+              <span class="insight-value" id="header-week-label">Tydzień --</span>
+              <span class="insight-sub" id="header-week-range">--</span>
+            </div>
+            <div class="insight-card">
+              <span class="insight-label">Realizacja celów</span>
+              <span class="insight-value" id="header-week-progress">0%</span>
+              <span class="insight-sub">Średni postęp celów głównych</span>
+            </div>
+            <div class="insight-card">
+              <span class="insight-label">Aktywności tygodnia</span>
+              <span class="insight-value" id="header-planned-activities">0/0</span>
+              <span class="insight-sub">ukończone / zaplanowane</span>
+            </div>
           </div>
         </div>
       </div>
@@ -246,15 +268,66 @@
       </div>
     </header>
 
-      <div class="card weekly-overview-card">
-          <div class="overview-header">
-              <h3 class="title"><i data-lucide="calendar-check" class="icon"></i><span id="week-title">Cele na ten tydzień</span></h3>
-              <div class="button-group">
-                  <button id="copy-plan-btn" class="btn soft" style="display: none;"><i data-lucide="copy" class="icon"></i>Kopiuj plan</button>
-                  <button id="prev-week-btn" class="btn soft"><i data-lucide="chevron-left" class="icon"></i>Poprzedni</button>
-                  <button id="today-week-btn" class="btn soft" style="display: none;">Dziś</button>
-                  <button id="next-week-btn" class="btn soft">Następny<i data-lucide="chevron-right" class="icon"></i></button>
+    <div class="page-layout">
+      <section class="layout-main">
+        <div id="planner-shell" class="card planner-card">
+          <div class="planner-header">
+            <div class="planner-title">
+              <h3 class="title"><i data-lucide="layout-grid" class="icon"></i>Planer tygodniowy</h3>
+              <span class="planner-range" id="planner-week-range">--</span>
+            </div>
+            <div class="planner-controls">
+              <button id="copy-plan-btn" class="btn ghost" style="display: none;"><i data-lucide="copy" class="icon"></i>Kopiuj plan</button>
+              <div class="week-nav">
+                <button id="prev-week-btn" class="btn soft"><i data-lucide="chevron-left" class="icon"></i>Poprzedni</button>
+                <button id="today-week-btn" class="btn soft" style="display: none;">Bieżący</button>
+                <button id="next-week-btn" class="btn soft">Następny<i data-lucide="chevron-right" class="icon"></i></button>
               </div>
+            </div>
+          </div>
+          <div class="planner-meta">
+            <span id="planning-status" class="planner-status muted"></span>
+            <button id="cancel-planning-btn" class="btn soft small" style="display: none;">Zakończ planowanie</button>
+          </div>
+          <p id="planning-instructions" class="planner-instructions"></p>
+          <div class="planner-grid"></div>
+          <div id="empty-planner-placeholder" class="empty-planner" style="display: none;">
+            <h4 style="margin: 0 0 4px 0;">Brak zaplanowanych działań</h4>
+            <p class="muted" style="margin: 0;">Dodaj cele z panelu obok lub użyj szybkich przycisków w kalendarzu.</p>
+          </div>
+        </div>
+
+        <div class="insights-grid">
+          <div class="card next-actions-card">
+              <h3 class="title"><i data-lucide="alarm-clock" class="icon"></i>Najbliższe kroki</h3>
+              <p class="muted tiny" style="margin-top:-4px;">Automatyczne podpowiedzi z planera i aktywności dodatkowych.</p>
+              <ul id="next-actions-list" class="next-actions-list"></ul>
+              <p id="next-actions-empty" class="empty-priority">Brak zaplanowanych aktywności na horyzoncie.</p>
+          </div>
+          <div class="card stats-card">
+              <h3 class="title"><i data-lucide="flame" class="icon"></i>Aktywność w czasie</h3>
+              <p class="muted tiny" style="margin-top:-8px; margin-bottom: 12px;">Każdy kwadrat to jeden dzień roku. Im ciemniejszy odcień, tym więcej ukończonych działań.</p>
+              <div class="heatmap-container"></div>
+              <div class="heatmap-legend">
+                  <span class="muted tiny">Mniej</span>
+                  <div class="heatmap-cell" style="background: var(--line)"></div>
+                  <div class="heatmap-cell" data-level="1"></div>
+                  <div class="heatmap-cell" data-level="2"></div>
+                  <div class="heatmap-cell" data-level="3"></div>
+                  <div class="heatmap-cell" data-level="4"></div>
+                  <span class="muted tiny">Więcej</span>
+              </div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="layout-side">
+        <div class="card weekly-overview-card">
+          <div class="overview-header">
+            <div>
+              <h3 class="title"><i data-lucide="calendar-check" class="icon"></i><span id="week-title">Cele tygodniowe</span></h3>
+              <p class="muted tiny" style="margin-top:-4px;">Monitoruj realizację kluczowych wskaźników.</p>
+            </div>
           </div>
           <div class="overview-progress">
               <div class="progress-summary">
@@ -262,87 +335,45 @@
               </div>
               <div class="progress-bar"><div id="overall-progress-bar" style="width:0%; background: var(--blue);"></div></div>
           </div>
-          <div class="grid g-3 goal-grid">
-              <div class="card goal-card goal-gym">
+          <div class="goal-grid">
+              <div class="goal-card goal-gym">
                   <h4 class="title">💪 Trening siłowy</h4>
                   <div id="goal-gym-progress" class="kpi-value">0/3 sesje</div>
                   <div class="progress-bar"><div id="goal-gym-bar" style="width:0%; background: var(--gym-color);"></div></div>
                   <p class="goal-meta" id="goal-gym-remaining">Pozostało: 3 sesje</p>
-                  <button class="btn soft" data-activity-type="gym" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Zaplanuj</button>
+                  <div class="goal-actions">
+                    <button class="btn soft" data-activity-type="gym" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
+                  </div>
               </div>
-              <div class="card goal-card goal-running">
+              <div class="goal-card goal-running">
                   <h4 class="title">🏃 Bieg</h4>
                   <div id="goal-running-progress" class="kpi-value">0/5 km</div>
                   <div class="progress-bar"><div id="goal-running-bar" style="width:0%; background: var(--run-color);"></div></div>
                   <p class="goal-meta" id="goal-running-remaining">Pozostało: 5 km</p>
-                  <button class="btn soft" data-activity-type="running" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Zaplanuj</button>
+                  <div class="goal-actions">
+                    <button class="btn soft" data-activity-type="running" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
+                  </div>
               </div>
-              <div class="card goal-card goal-reading">
+              <div class="goal-card goal-reading">
                   <h4 class="title">📚 Czytanie</h4>
                   <div id="goal-reading-progress" class="kpi-value">0/100 stron</div>
                   <div class="progress-bar"><div id="goal-reading-bar" style="width:0%; background: var(--read-color);"></div></div>
                   <p class="goal-meta" id="goal-reading-remaining">Pozostało: 100 stron</p>
-                  <button class="btn soft" data-activity-type="reading" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Zaplanuj</button>
+                  <div class="goal-actions">
+                    <button class="btn soft" data-activity-type="reading" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
+                  </div>
               </div>
           </div>
-      </div>
+        </div>
 
-      <div class="grid g-3 insights-grid">
-          <div class="card focus-card">
-              <h3 class="title"><i data-lucide="target" class="icon"></i>Fokus tygodnia</h3>
-              <p id="focus-text" class="muted focus-text">Zdefiniuj główny kierunek działań, aby codziennie wiedzieć na czym się skupić.</p>
-              <div class="focus-actions">
-                  <button id="edit-focus-btn" class="btn soft"><i data-lucide="compass"></i>Ustal fokus</button>
-                  <button id="clear-focus-btn" class="btn ghost" style="display: none;"><i data-lucide="x"></i>Wyczyść</button>
-              </div>
-          </div>
-          <div class="card priorities-card">
+        <div class="card priorities-card">
               <h3 class="title"><i data-lucide="star" class="icon"></i>Priorytety tygodnia</h3>
-              <p class="muted tiny" style="margin-top:-4px;">Wybierz do trzech najważniejszych kroków z wysokim wpływem.</p>
+              <p class="muted tiny" style="margin-top:-4px;">Skup się na maksymalnie trzech działaniach o największym wpływie.</p>
               <ul id="priority-list" class="priority-list"></ul>
               <p id="priority-empty" class="empty-priority">Dodaj pierwszy priorytet, by mieć jasność działań.</p>
               <button id="add-priority-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
-          </div>
-          <div class="card next-actions-card">
-              <h3 class="title"><i data-lucide="alarm-clock" class="icon"></i>Najbliższe kroki</h3>
-              <p class="muted tiny" style="margin-top:-4px;">Automatyczne podpowiedzi z planera i aktywności dodatkowych.</p>
-              <ul id="next-actions-list" class="next-actions-list"></ul>
-              <p id="next-actions-empty" class="empty-priority">Brak zaplanowanych aktywności na horyzoncie.</p>
-          </div>
-      </div>
-    
-    <div class="tabs">
-        <div class="tab active" data-tab="planner"><i data-lucide="calendar-days" class="icon"></i>Planer</div>
-        <div class="tab" data-tab="stats"><i data-lucide="trending-up" class="icon"></i>Statystyki</div>
-    </div>
-
-    <div id="tab-content-planner" class="card">
-        <div class="row">
-            <h3 class="title"><i data-lucide="layout-grid" class="icon"></i>Planer tygodniowy</h3>
-            <p id="planning-status" class="muted tiny" style="font-weight: 500;"></p>
-            <button id="cancel-planning-btn" class="btn soft" style="display: none;">Zakończ planowanie</button>
         </div>
-        <p id="planning-instructions" class="muted" style="display: none; text-align: center; margin-top: 16px; padding: 12px; background: var(--blue-soft); border-radius: 12px;"></p>
-        <div class="planner-grid"></div>
-        <div id="empty-planner-placeholder" class="empty-planner" style="display: none;">
-            <h4 style="margin: 0 0 4px 0;">Tydzień jest pusty</h4>
-            <p style="margin: 0;">Zaplanuj swoje aktywności używając przycisków powyżej lub skopiuj plan z poprzedniego tygodnia.</p>
-        </div>
-    </div>
-
-    <div id="tab-content-stats" class="card" style="display:none;">
-         <h3 class="title"><i data-lucide="flame" class="icon"></i>Kalendarz Aktywności</h3>
-         <p class="muted tiny" style="margin-top:-8px; margin-bottom: 12px;">Każdy kwadrat to jeden dzień roku. Im ciemniejszy odcień zieleni, tym więcej aktywności ukończono.</p>
-         <div class="heatmap-container"></div>
-         <div class="heatmap-legend">
-             <span class="muted tiny">Mniej</span>
-             <div class="heatmap-cell" style="background: var(--line)"></div>
-             <div class="heatmap-cell" data-level="1"></div>
-             <div class="heatmap-cell" data-level="2"></div>
-             <div class="heatmap-cell" data-level="3"></div>
-             <div class="heatmap-cell" data-level="4"></div>
-             <span class="muted tiny">Więcej</span>
-         </div>
+      </aside>
     </div>
   </div>
 
@@ -406,7 +437,6 @@ function ensureWeekDataShape(weekData) {
     if (!weekData.progress) weekData.progress = { gym: 0, running: 0, reading: 0 };
     if (!weekData.extras) weekData.extras = createEmptyDayMapping();
     if (!Array.isArray(weekData.priorities)) weekData.priorities = [];
-    if (typeof weekData.focus !== 'string') weekData.focus = '';
 }
 
 function getCurrentWeekContext() {
@@ -418,6 +448,15 @@ function getCurrentWeekContext() {
 function formatDateWithDay(date) {
     const dayLabel = DAY_NAMES[date.getDay()] || '';
     return `${dayLabel} · ${date.toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit' })}`;
+}
+
+function formatWeekRange(startDate) {
+    const endDate = new Date(startDate);
+    endDate.setDate(startDate.getDate() + 6);
+    const options = { day: '2-digit', month: 'short' };
+    const startLabel = startDate.toLocaleDateString('pl-PL', options);
+    const endLabel = endDate.toLocaleDateString('pl-PL', options);
+    return `${startLabel} – ${endLabel}`;
 }
 
 // --- STAN APLIKACJI ---
@@ -455,7 +494,6 @@ function initializeWeekData(year, week) {
             plan: createEmptyDayMapping(),
             extras: createEmptyDayMapping(),
             priorities: [],
-            focus: '',
             isComplete: false,
             summaryShown: false
         };
@@ -617,7 +655,6 @@ function copyPreviousWeek(copyProgress = false) {
     }
     state[currentYear][currentWeek].extras = newExtras;
 
-    state[currentYear][currentWeek].focus = copyProgress ? (prevWeekData.focus || '') : '';
     state[currentYear][currentWeek].priorities = copyProgress && Array.isArray(prevWeekData.priorities)
         ? prevWeekData.priorities.map(priority => ({
             ...priority,
@@ -641,21 +678,33 @@ function render() {
     const weekData = state[year][week];
     const startOfWeek = getStartOfWeek(year, week);
     
-    document.getElementById('week-title').textContent = `Tydzień ${week} (${year})`;
-    
+    const weekTitleEl = document.getElementById('week-title');
+    if (weekTitleEl) weekTitleEl.textContent = `Cele tygodniowe · ${week}/${year}`;
+
+    const weekRangeLabel = formatWeekRange(startOfWeek);
+    const headerWeekLabel = document.getElementById('header-week-label');
+    if (headerWeekLabel) headerWeekLabel.textContent = `Tydzień ${week} (${year})`;
+    const headerWeekRange = document.getElementById('header-week-range');
+    if (headerWeekRange) headerWeekRange.textContent = weekRangeLabel;
+    const plannerRangeEl = document.getElementById('planner-week-range');
+    if (plannerRangeEl) plannerRangeEl.textContent = weekRangeLabel;
+
     const todayBtn = document.getElementById('today-week-btn');
     const [currentYear, currentWeek] = getWeekNumber(new Date());
-    todayBtn.style.display = (year === currentYear && week === currentWeek) ? 'none' : 'inline-flex';
+    if (todayBtn) {
+        todayBtn.style.display = (year === currentYear && week === currentWeek) ? 'none' : 'inline-flex';
+    }
 
     renderCopyPlanButton();
     renderGoals(weekData.progress);
-    renderWeekFocus(weekData);
     renderPriorities(weekData.priorities);
     const upcoming = renderNextActions(weekData, startOfWeek);
     renderPlanner(weekData, startOfWeek);
     renderHeaderKPIs(year, upcoming[0]);
     renderPlanningStatus(weekData.plan);
     renderOverallProgress(weekData.progress);
+    updateHeaderActivitiesOverview(weekData);
+    renderStats();
     lucide.createIcons();
 }
 
@@ -883,6 +932,7 @@ function renderHeaderKPIs(year, nextUpcoming) {
 
 function renderPlanningStatus(plan) {
     const statusEl = document.getElementById('planning-status');
+    if (!statusEl) return;
     const plannedTotals = { gym: 0, running: 0, reading: 0 };
     Object.values(plan).flat().forEach(activity => {
         plannedTotals[activity.type] += activity.completed ? activity.loggedValue : (activity.plannedValue || 0);
@@ -891,10 +941,10 @@ function renderPlanningStatus(plan) {
     const allGoalsPlanned = Object.keys(GOAL_DEFINITIONS).every(type => plannedTotals[type] >= GOAL_DEFINITIONS[type].target);
 
     if (allGoalsPlanned) {
-        statusEl.textContent = '✅ Cele tygodnia zaplanowane!';
+        statusEl.textContent = '✅ Wszystkie cele mają zaplanowane działania.';
         statusEl.style.color = 'var(--green)';
     } else {
-        statusEl.textContent = '⚠️ Nie wszystkie cele są w pełni zaplanowane.';
+        statusEl.textContent = '🧭 Zaplanuj brakujące działania, aby domknąć tydzień.';
         statusEl.style.color = 'var(--orange)';
     }
 }
@@ -913,6 +963,16 @@ function renderOverallProgress(progress) {
     }
 }
 
+function updateHeaderActivitiesOverview(weekData) {
+    const headerActivities = document.getElementById('header-planned-activities');
+    if (!headerActivities) return;
+    const planned = Object.values(weekData.plan || {}).flat();
+    const extras = Object.values(weekData.extras || {}).flat();
+    const total = planned.length + extras.length;
+    const completed = planned.filter(a => a.completed).length + extras.filter(a => a.completed).length;
+    headerActivities.textContent = total > 0 ? `${completed}/${total}` : '0/0';
+}
+
 function renderCopyPlanButton() {
     let prevWeekDate = new Date(currentDate);
     prevWeekDate.setDate(prevWeekDate.getDate() - 7);
@@ -924,29 +984,9 @@ function renderCopyPlanButton() {
         Object.values(prevWeekData.extras || {}).some(day => day.length > 0)
     );
 
-    document.getElementById('copy-plan-btn').style.display = hasPreviousPlan ? 'inline-flex' : 'none';
-}
-
-function renderWeekFocus(weekData) {
-    const focusTextEl = document.getElementById('focus-text');
-    const clearBtn = document.getElementById('clear-focus-btn');
-    const headerChip = document.getElementById('header-focus-chip');
-    const focusValue = (weekData.focus || '').trim();
-
-    if (focusTextEl) {
-        focusTextEl.textContent = focusValue || 'Zdefiniuj główny kierunek działań, aby codziennie wiedzieć na czym się skupić.';
-    }
-    if (clearBtn) {
-        clearBtn.style.display = focusValue ? 'inline-flex' : 'none';
-    }
-    if (headerChip) {
-        if (focusValue) {
-            headerChip.textContent = `Fokus: ${focusValue}`;
-            headerChip.classList.remove('chip-outline');
-        } else {
-            headerChip.textContent = 'Brak zdefiniowanego fokusu';
-            if (!headerChip.classList.contains('chip-outline')) headerChip.classList.add('chip-outline');
-        }
+    const copyBtn = document.getElementById('copy-plan-btn');
+    if (copyBtn) {
+        copyBtn.style.display = hasPreviousPlan ? 'inline-flex' : 'none';
     }
 }
 
@@ -1210,19 +1250,6 @@ function showExtraActivityModal(dayIndex) {
     });
 }
 
-function showFocusModal() {
-    const { weekData } = getCurrentWeekContext();
-    showModal({
-        title: 'Ustal fokus tygodnia',
-        text: 'Jedno zdanie, które przypomni Ci, co jest najważniejsze.',
-        textarea: { placeholder: 'np. Codziennie dbam o ruch i spokojny sen', value: weekData.focus || '', rows: 4 },
-        buttons: [
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            { text: 'Zapisz fokus', class: 'btn', action: (value) => setWeekFocus(value || '') }
-        ]
-    });
-}
-
 function showPriorityModal() {
     const { weekData } = getCurrentWeekContext();
     if (weekData.priorities.length >= MAX_PRIORITIES) return;
@@ -1320,22 +1347,6 @@ function showWeeklySummary() {
     }
 }
 
-function setWeekFocus(value) {
-    const { weekData } = getCurrentWeekContext();
-    const normalized = (value || '')
-        .split('\n')
-        .map(part => part.trim())
-        .filter(Boolean)
-        .join(' ');
-    weekData.focus = normalized;
-    saveState();
-    render();
-}
-
-function clearWeekFocus() {
-    setWeekFocus('');
-}
-
 function addPriority(title, impact = 'high') {
     const trimmed = (title || '').trim();
     if (!trimmed) return;
@@ -1415,8 +1426,6 @@ function setupEventListeners() {
         btn.addEventListener('click', (e) => startPlanning(e.currentTarget.dataset.activityType));
     });
 
-    document.getElementById('edit-focus-btn').addEventListener('click', showFocusModal);
-    document.getElementById('clear-focus-btn').addEventListener('click', clearWeekFocus);
     document.getElementById('add-priority-btn').addEventListener('click', showPriorityModal);
     document.getElementById('priority-list').addEventListener('click', (e) => {
         const toggleBtn = e.target.closest('.priority-toggle');
@@ -1495,18 +1504,6 @@ function setupEventListeners() {
         }
     });
 
-    document.querySelectorAll('.tab').forEach(tab => {
-        tab.addEventListener('click', (e) => {
-            const tabEl = e.currentTarget;
-            document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-            tabEl.classList.add('active');
-            const tabName = tabEl.dataset.tab;
-            document.getElementById('tab-content-planner').style.display = tabName === 'planner' ? 'block' : 'none';
-            document.getElementById('tab-content-stats').style.display = tabName === 'stats' ? 'block' : 'none';
-            if (tabName === 'stats') renderStats();
-        });
-    });
-
     document.getElementById('cancel-planning-btn').addEventListener('click', stopPlanning);
 }
 
@@ -1525,6 +1522,7 @@ function renderStats() {
     const year = getWeekNumber(currentDate)[0];
     const yearData = state[year] || {};
     const heatmapContainer = document.querySelector('.heatmap-container');
+    if (!heatmapContainer) return;
     heatmapContainer.innerHTML = '';
 
     const activitiesByDay = {};
@@ -1576,17 +1574,19 @@ function renderStats() {
 // --- TRYB PLANOWANIA ---
 function startPlanning(type) {
     planningState = { isPlanning: true, activityType: type };
-    document.getElementById('tab-content-planner').classList.add('planning-mode');
-    document.getElementById('planning-instructions').style.display = 'block';
-    document.getElementById('planning-instructions').textContent = `Kliknij w wybrany dzień, aby dodać: ${GOAL_DEFINITIONS[type].label}`;
+    document.getElementById('planner-shell').classList.add('planning-mode');
+    const instructions = document.getElementById('planning-instructions');
+    instructions.style.display = 'block';
+    instructions.textContent = `Kliknij w kalendarzu, aby dodać: ${GOAL_DEFINITIONS[type].label}`;
     document.getElementById('cancel-planning-btn').style.display = 'inline-flex';
     document.querySelectorAll('[data-action="plan"]').forEach(b => b.style.display = 'none');
 }
 
 function stopPlanning() {
     planningState = { isPlanning: false, activityType: null };
-    document.getElementById('tab-content-planner').classList.remove('planning-mode');
-    document.getElementById('planning-instructions').style.display = 'none';
+    document.getElementById('planner-shell').classList.remove('planning-mode');
+    const instructions = document.getElementById('planning-instructions');
+    instructions.style.display = 'none';
     document.getElementById('cancel-planning-btn').style.display = 'none';
     document.querySelectorAll('[data-action="plan"]').forEach(b => b.style.display = 'inline-flex');
 }

--- a/trainings.html
+++ b/trainings.html
@@ -97,7 +97,7 @@ a { color: inherit; text-decoration: none; }
 
 .metrics-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
   gap: 12px;
 }
 
@@ -166,11 +166,6 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 18px;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(12px);
 }
 
 .page-header-top {
@@ -262,9 +257,109 @@ a { color: inherit; text-decoration: none; }
   background: linear-gradient(160deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.05));
 }
 
+.metric-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-card--donut,
+.metric-card--visual {
+  flex-direction: row;
+  align-items: center;
+  gap: 14px;
+}
+
+.metric-card--donut .metric-text,
+.metric-card--visual .metric-text {
+  flex: 1;
+}
+
 .metric-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); font-weight: 600; }
 .metric-value { font-size: 22px; font-weight: 700; }
 .metric-sub { font-size: 11px; color: var(--muted); }
+
+.metric-donut {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+}
+
+.metric-donut svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.metric-donut circle {
+  fill: none;
+  stroke-width: 3.6;
+}
+
+.metric-donut .donut-bg {
+  stroke: rgba(148, 163, 184, 0.28);
+}
+
+.metric-donut .donut-value {
+  stroke: var(--primary);
+  stroke-linecap: round;
+  stroke-dasharray: 0 100;
+  transition: stroke-dasharray 0.4s ease;
+}
+
+.metric-donut span {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.metric-visual {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  flex-shrink: 0;
+  transition: var(--transition);
+}
+
+.metric-visual .icon {
+  width: 24px;
+  height: 24px;
+}
+
+.metric-card--visual[data-activity-type="gym"] .metric-visual {
+  background: rgba(91, 33, 182, 0.12);
+  color: var(--gym-color);
+}
+
+.metric-card--visual[data-activity-type="running"] .metric-visual {
+  background: rgba(4, 120, 87, 0.12);
+  color: var(--run-color);
+}
+
+.metric-card--visual[data-activity-type="reading"] .metric-visual {
+  background: rgba(29, 78, 216, 0.12);
+  color: var(--read-color);
+}
+
+.metric-card--visual[data-activity-type="extra"] .metric-visual {
+  background: rgba(14, 165, 233, 0.14);
+  color: var(--extra-color);
+}
+
+.metric-card--visual[data-activity-type="none"] .metric-visual {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+}
 
 
 .card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
@@ -550,6 +645,8 @@ a { color: inherit; text-decoration: none; }
 .modal-card h3 { font-size: 18px; font-weight: 700; }
 .modal-actions { display: flex; justify-content: flex-end; gap: 10px; }
 .modal-card input, .modal-card textarea, .modal-card select { width: 100%; border: 1px solid var(--line); border-radius: 12px; padding: 12px; font-family: inherit; font-size: 13px; }
+.modal-field { display: flex; flex-direction: column; gap: 6px; }
+.modal-field-label { font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
 .modal-options { display: flex; flex-direction: column; gap: 10px; }
 .option-label { border: 1px solid var(--line); border-radius: 12px; padding: 10px 12px; display: flex; align-items: center; gap: 10px; cursor: pointer; transition: var(--transition); }
 .option-label:hover { border-color: var(--primary); background: var(--primary-soft); }
@@ -631,24 +728,47 @@ a { color: inherit; text-decoration: none; }
         </div>
         <div class="metrics-grid">
           <div class="metric-card">
-            <span class="metric-label">Realizacja celów</span>
-            <span class="metric-value" id="metric-goal-progress">0%</span>
-            <span class="metric-sub" id="metric-goal-progress-sub">Cele tygodniowe</span>
+            <div class="metric-text">
+              <span class="metric-label">Realizacja celów</span>
+              <span class="metric-value" id="metric-goal-progress">0%</span>
+              <span class="metric-sub" id="metric-goal-progress-sub">Cele tygodniowe</span>
+            </div>
+          </div>
+          <div class="metric-card metric-card--donut">
+            <div class="metric-donut">
+              <svg viewBox="0 0 36 36" aria-hidden="true">
+                <circle class="donut-bg" cx="18" cy="18" r="16"></circle>
+                <circle class="donut-value" id="metric-weekly-complete-circle" cx="18" cy="18" r="16" stroke-dasharray="0 100"></circle>
+              </svg>
+              <span id="metric-weekly-complete-percent">0%</span>
+            </div>
+            <div class="metric-text">
+              <span class="metric-label">Zaliczone tygodnie</span>
+              <span class="metric-value" id="metric-weekly-complete-count">0/0</span>
+              <span class="metric-sub" id="metric-weekly-complete-sub">Rok --</span>
+            </div>
           </div>
           <div class="metric-card">
-            <span class="metric-label">Zamknięte działania</span>
-            <span class="metric-value" id="metric-plan-completion">0/0</span>
-            <span class="metric-sub">Ukończone vs zaplanowane</span>
+            <div class="metric-text">
+              <span class="metric-label">Zamknięte działania</span>
+              <span class="metric-value" id="metric-plan-completion">0/0</span>
+              <span class="metric-sub">Ukończone vs zaplanowane</span>
+            </div>
           </div>
           <div class="metric-card">
-            <span class="metric-label">Aktywne dni</span>
-            <span class="metric-value" id="metric-active-days">0/0</span>
-            <span class="metric-sub">Dni z planem w miesiącu</span>
+            <div class="metric-text">
+              <span class="metric-label">Aktywne dni</span>
+              <span class="metric-value" id="metric-active-days">0/0</span>
+              <span class="metric-sub">Dni z planem w miesiącu</span>
+            </div>
           </div>
-          <div class="metric-card">
-            <span class="metric-label">Najbliższa aktywność</span>
-            <span class="metric-value" id="metric-next-activity">Brak</span>
-            <span class="metric-sub" id="metric-next-activity-date">--</span>
+          <div class="metric-card metric-card--visual" id="metric-next-activity-card" data-activity-type="none">
+            <div class="metric-visual" id="metric-next-activity-visual"><i data-lucide="calendar" class="icon"></i></div>
+            <div class="metric-text">
+              <span class="metric-label">Najbliższa aktywność</span>
+              <span class="metric-value" id="metric-next-activity">Brak</span>
+              <span class="metric-sub" id="metric-next-activity-date">--</span>
+            </div>
           </div>
         </div>
       </section>
@@ -705,6 +825,7 @@ a { color: inherit; text-decoration: none; }
         <div class="detail-actions">
           <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj treningi</button>
           <button id="add-extra-btn" class="btn ghost"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
+          <button id="plan-vacation-range-btn" class="btn ghost"><i data-lucide="calendar-range" class="icon"></i>Zaplanuj urlop</button>
         </div>
       </section>
     </div>
@@ -824,6 +945,7 @@ const ACTIVITY_UNIT_SHORT = { running: 'km', reading: 'str.' };
 const MAX_CALENDAR_TAGS = 4;
 const DEFAULT_PLANNING_META = 'Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.';
 const DAY_MS = 24 * 60 * 60 * 1000;
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * 16;
 
 let state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
 let currentMonth = startOfMonth(new Date());
@@ -944,6 +1066,27 @@ function toggleVacationDay(dateString) {
   render();
 }
 
+function planVacationRange(startDateString, endDateString) {
+  if (!startDateString || !endDateString) return;
+  const start = parseDate(startDateString);
+  const end = parseDate(endDateString);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return;
+  const normalizedStart = normalizeDate(start);
+  const normalizedEnd = normalizeDate(end);
+  if (normalizedEnd < normalizedStart) return;
+  if (!state.vacations) state.vacations = {};
+  const cursor = new Date(normalizedStart);
+  let guard = 0;
+  while (cursor.getTime() <= normalizedEnd.getTime() && guard < 370) {
+    const key = toYYYYMMDD(cursor);
+    state.vacations[key] = true;
+    cursor.setDate(cursor.getDate() + 1);
+    guard += 1;
+  }
+  saveState();
+  render();
+}
+
 let dragPayload = null;
 
 function enableDrag(element, payload) {
@@ -1028,6 +1171,18 @@ function getISOWeekStart(year, week) {
   const diff = (day === 0 ? -6 : 1) - day;
   simple.setUTCDate(simple.getUTCDate() + diff);
   return new Date(simple.getUTCFullYear(), simple.getUTCMonth(), simple.getUTCDate());
+}
+
+function getISOWeekInfo(date) {
+  const target = new Date(date);
+  target.setHours(0, 0, 0, 0);
+  const dayNumber = (target.getDay() + 6) % 7;
+  target.setDate(target.getDate() - dayNumber + 3);
+  const isoYear = target.getFullYear();
+  const firstWeekStart = getISOWeekStart(isoYear, 1);
+  const diffDays = Math.round((target.getTime() - firstWeekStart.getTime()) / DAY_MS);
+  const week = 1 + Math.floor(diffDays / 7);
+  return { year: isoYear, week: Math.max(1, week) };
 }
 
 function loadState() {
@@ -1200,12 +1355,13 @@ function calculateMonthlyStats(monthDate) {
   Object.entries(state.activities).forEach(([dateString, activities]) => {
     const date = parseDate(dateString);
     if (!sameMonth(date, monthDate)) return;
+    const normalized = normalizeDate(date);
     if (activities.length) activeDays.add(dateString);
     totals.planned += activities.length;
     activities.forEach(activity => {
       if (activity.completed) {
         totals.completed += 1;
-      } else if (normalizeDate(date) >= today) {
+      } else if (normalized >= today) {
         const goal = GOAL_DEFINITIONS[activity.type];
         if (!goal) return;
         let label = goal.label;
@@ -1217,8 +1373,9 @@ function calculateMonthlyStats(monthDate) {
           label,
           badge: 'Trening',
           icon: goal.icon || 'activity',
-          date,
-          dateLabel: formatDateWithDay(date)
+          date: normalized,
+          dateLabel: formatDateWithDay(normalized),
+          relative: getRelativeLabel(normalized, today)
         });
       }
     });
@@ -1227,19 +1384,21 @@ function calculateMonthlyStats(monthDate) {
   Object.entries(state.extras).forEach(([dateString, extras]) => {
     const date = parseDate(dateString);
     if (!sameMonth(date, monthDate)) return;
+    const normalized = normalizeDate(date);
     if (extras.length) activeDays.add(dateString);
     totals.planned += extras.length;
     extras.forEach(extra => {
       if (extra.completed) {
         totals.completed += 1;
-      } else if (normalizeDate(date) >= today) {
+      } else if (normalized >= today) {
         upcoming.push({
           type: 'extra',
           label: extra.title,
           badge: EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność',
           icon: 'sparkles',
-          date,
-          dateLabel: formatDateWithDay(date)
+          date: normalized,
+          dateLabel: formatDateWithDay(normalized),
+          relative: getRelativeLabel(normalized, today)
         });
       }
     });
@@ -1256,7 +1415,7 @@ function calculateMonthlyStats(monthDate) {
     completedCount: totals.completed,
     activeDays: activeDays.size,
     totalDays,
-    nextActivity: upcoming.length ? { label: upcoming[0].label, dateLabel: upcoming[0].dateLabel } : null,
+    nextActivity: upcoming.length ? upcoming[0] : null,
     upcoming,
     range: { start: firstDay, end: lastDay }
   };
@@ -1301,6 +1460,25 @@ function calculateWeeklyGoalStats(referenceDate) {
   ) || 0;
 
   return { goalPercents, averageGoalPercent, range: { start: weekStart, end: weekEnd } };
+}
+
+function calculateWeekCompletionToDate() {
+  const today = normalizeDate(new Date());
+  const info = getISOWeekInfo(today);
+  const totalWeeks = Math.max(0, info.week - 1);
+  let completedWeeks = 0;
+
+  for (let week = 1; week < info.week; week++) {
+    const weekStart = getISOWeekStart(info.year, week);
+    const stats = calculateWeeklyGoalStats(weekStart);
+    const goals = Object.values(stats.goalPercents || {});
+    if (goals.length && goals.every(goal => Number(goal.percent || 0) >= 100)) {
+      completedWeeks += 1;
+    }
+  }
+
+  const percent = totalWeeks > 0 ? Math.round((completedWeeks / totalWeeks) * 100) : 0;
+  return { completedWeeks, totalWeeks, percent, currentWeek: info.week, isoYear: info.year };
 }
 
 function getRelativeLabel(targetDate, today) {
@@ -1375,7 +1553,8 @@ function render() {
   const monthStats = calculateMonthlyStats(currentMonth);
   const weekStats = calculateWeeklyGoalStats(parseDate(selectedDate));
   const upcomingWindow = calculateUpcomingWindow();
-  renderHeader(monthStats, weekStats, upcomingWindow);
+  const yearStats = calculateWeekCompletionToDate();
+  renderHeader(monthStats, weekStats, upcomingWindow, yearStats);
   renderCalendar();
   renderDayDetail();
   renderUpcoming(upcomingWindow);
@@ -1386,7 +1565,7 @@ function render() {
   lucide.createIcons();
 }
 
-function renderHeader(monthStats, weekStats, upcomingWindow) {
+function renderHeader(monthStats, weekStats, upcomingWindow, yearStats) {
   const monthLabel = formatMonth(currentMonth);
   document.getElementById('header-month-chip').textContent = monthLabel;
   document.getElementById('current-month-label').textContent = monthLabel;
@@ -1401,13 +1580,45 @@ function renderHeader(monthStats, weekStats, upcomingWindow) {
   }
   document.getElementById('metric-plan-completion').textContent = `${monthStats.completedCount}/${monthStats.plannedCount}`;
   document.getElementById('metric-active-days').textContent = `${monthStats.activeDays}/${monthStats.totalDays}`;
+  if (yearStats) {
+    const countEl = document.getElementById('metric-weekly-complete-count');
+    if (countEl) {
+      const completedLabel = `${yearStats.completedWeeks.toLocaleString('pl-PL')}/${yearStats.totalWeeks.toLocaleString('pl-PL')}`;
+      countEl.textContent = completedLabel;
+    }
+    const subEl = document.getElementById('metric-weekly-complete-sub');
+    if (subEl) {
+      if (yearStats.totalWeeks > 0) {
+        const uptoWeek = Math.max(0, yearStats.currentWeek - 1);
+        subEl.textContent = `Rok ${yearStats.isoYear} · Do tygodnia ${uptoWeek.toLocaleString('pl-PL')}`;
+      } else {
+        subEl.textContent = `Rok ${yearStats.isoYear} · Start sezonu`;
+      }
+    }
+    const percentEl = document.getElementById('metric-weekly-complete-percent');
+    if (percentEl) percentEl.textContent = `${yearStats.percent.toLocaleString('pl-PL')}%`;
+    const circle = document.getElementById('metric-weekly-complete-circle');
+    if (circle) {
+      const safePercent = Math.max(0, Math.min(100, yearStats.percent));
+      const dash = (safePercent / 100) * DONUT_CIRCUMFERENCE;
+      circle.setAttribute('stroke-dasharray', `${dash} ${DONUT_CIRCUMFERENCE - dash}`);
+    }
+  }
   const metricNext = upcomingWindow && upcomingWindow.length ? upcomingWindow[0] : monthStats.nextActivity;
+  const nextCard = document.getElementById('metric-next-activity-card');
+  const nextVisual = document.getElementById('metric-next-activity-visual');
+  const nextLabel = document.getElementById('metric-next-activity');
+  const nextDate = document.getElementById('metric-next-activity-date');
   if (metricNext) {
-    document.getElementById('metric-next-activity').textContent = metricNext.label;
-    document.getElementById('metric-next-activity-date').textContent = metricNext.relative || metricNext.dateLabel;
+    if (nextLabel) nextLabel.textContent = metricNext.label;
+    if (nextDate) nextDate.textContent = metricNext.relative || metricNext.dateLabel || '--';
+    if (nextCard) nextCard.dataset.activityType = metricNext.type || 'none';
+    if (nextVisual) nextVisual.innerHTML = `<i data-lucide="${metricNext.icon || 'calendar'}" class="icon"></i>`;
   } else {
-    document.getElementById('metric-next-activity').textContent = 'Brak';
-    document.getElementById('metric-next-activity-date').textContent = '--';
+    if (nextLabel) nextLabel.textContent = 'Brak';
+    if (nextDate) nextDate.textContent = '--';
+    if (nextCard) nextCard.dataset.activityType = 'none';
+    if (nextVisual) nextVisual.innerHTML = '<i data-lucide="calendar-x" class="icon"></i>';
   }
   document.getElementById('priority-month-label').textContent = monthLabel;
 }
@@ -2053,6 +2264,42 @@ function showAddExtraModal() {
   });
 }
 
+function showVacationRangeModal() {
+  showModal({
+    title: 'Plan urlopu',
+    text: 'Oznacz cały zakres dat jako urlop, aby kalendarz uwzględnił przerwę.',
+    inputs: [
+      { type: 'date', value: selectedDate, label: 'Początek urlopu', key: 'start' },
+      { type: 'date', value: selectedDate, label: 'Koniec urlopu', key: 'end' }
+    ],
+    buttons: [
+      { text: 'Anuluj', class: 'btn soft', action: 'close' },
+      { text: 'Zapisz', class: 'btn', action: (value) => {
+          if (!value || !value.start || !value.end) return false;
+          if (value.end < value.start) return false;
+          planVacationRange(value.start, value.end);
+        } }
+    ],
+    onShow: ({ inputs }) => {
+      if (!inputs || inputs.length < 2) return;
+      const [startField, endField] = inputs;
+      if (!startField || !endField) return;
+      endField.min = startField.value;
+      endField.addEventListener('change', () => {
+        if (endField.value < startField.value) {
+          endField.value = startField.value;
+        }
+      });
+      startField.addEventListener('change', () => {
+        if (endField.value < startField.value) {
+          endField.value = startField.value;
+        }
+        endField.min = startField.value;
+      });
+    }
+  });
+}
+
 function showPriorityModal() {
   const monthKey = getMonthKey(currentMonth);
   ensurePriorityMonth(monthKey);
@@ -2084,26 +2331,54 @@ function showModal(config) {
   optionsContainer.innerHTML = '';
   actions.innerHTML = '';
 
-  if (config.input) {
+  const inputConfigs = [];
+  if (Array.isArray(config.inputs)) inputConfigs.push(...config.inputs);
+  if (config.input) inputConfigs.push(config.input);
+
+  inputConfigs.forEach(inputConfig => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'modal-field';
+    if (inputConfig.label) {
+      const label = document.createElement('span');
+      label.className = 'modal-field-label';
+      label.textContent = inputConfig.label;
+      wrapper.appendChild(label);
+    }
     const input = document.createElement('input');
-    input.type = config.input.type || 'text';
-    if (config.input.placeholder) input.placeholder = config.input.placeholder;
-    if (config.input.value !== undefined) input.value = config.input.value;
-    if (config.input.min !== undefined) input.min = config.input.min;
-    if (config.input.step !== undefined) input.step = config.input.step;
-    if (config.input.disabled) input.disabled = true;
+    input.type = inputConfig.type || 'text';
+    if (inputConfig.placeholder) input.placeholder = inputConfig.placeholder;
+    if (inputConfig.value !== undefined) input.value = inputConfig.value;
+    if (inputConfig.min !== undefined) input.min = inputConfig.min;
+    if (inputConfig.max !== undefined) input.max = inputConfig.max;
+    if (inputConfig.step !== undefined) input.step = inputConfig.step;
+    if (inputConfig.disabled) input.disabled = true;
+    if (inputConfig.required) input.required = true;
     input.autocomplete = 'off';
     input.dataset.modalInput = 'true';
-    inputContainer.appendChild(input);
-  }
+    if (inputConfig.key) input.dataset.modalKey = inputConfig.key;
+    if (inputConfig.name) input.name = inputConfig.name;
+    wrapper.appendChild(input);
+    inputContainer.appendChild(wrapper);
+  });
 
   if (config.textarea) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'modal-field';
+    if (config.textarea.label) {
+      const label = document.createElement('span');
+      label.className = 'modal-field-label';
+      label.textContent = config.textarea.label;
+      wrapper.appendChild(label);
+    }
     const textarea = document.createElement('textarea');
     textarea.placeholder = config.textarea.placeholder || '';
     textarea.value = config.textarea.value || '';
     textarea.rows = config.textarea.rows || 4;
+    textarea.autocomplete = 'off';
     textarea.dataset.modalInput = 'true';
-    inputContainer.appendChild(textarea);
+    if (config.textarea.key) textarea.dataset.modalKey = config.textarea.key;
+    wrapper.appendChild(textarea);
+    inputContainer.appendChild(wrapper);
   }
 
   if (config.options) {
@@ -2127,9 +2402,18 @@ function showModal(config) {
         overlay.classList.remove('visible');
         return;
       }
-      const field = inputContainer.querySelector('[data-modal-input]');
+      const fields = Array.from(inputContainer.querySelectorAll('[data-modal-input]'));
       const selectedOption = optionsContainer.querySelector('input[name="modal-option"]:checked')?.value;
-      const value = field ? field.value : '';
+      let value = '';
+      if (fields.length === 1) {
+        value = fields[0].value;
+      } else if (fields.length > 1) {
+        value = {};
+        fields.forEach((field, index) => {
+          const key = field.dataset.modalKey || field.name || `field${index + 1}`;
+          value[key] = field.value;
+        });
+      }
       const result = btn.action(value, selectedOption);
       if (result === false) return;
       overlay.classList.remove('visible');
@@ -2139,7 +2423,8 @@ function showModal(config) {
 
   overlay.classList.add('visible');
   if (typeof config.onShow === 'function') {
-    config.onShow({ overlay, input: inputContainer.querySelector('[data-modal-input]'), optionsContainer });
+    const inputs = Array.from(inputContainer.querySelectorAll('[data-modal-input]'));
+    config.onShow({ overlay, input: inputs[0] || null, inputs, optionsContainer, inputContainer });
   }
   const focusTarget = inputContainer.querySelector('[data-modal-input]');
   if (focusTarget && !focusTarget.disabled) focusTarget.focus();
@@ -2169,6 +2454,7 @@ function setupEventListeners() {
   });
   document.getElementById('stop-planning-btn').addEventListener('click', () => stopPlanningMode());
   document.getElementById('add-extra-btn').addEventListener('click', showAddExtraModal);
+  document.getElementById('plan-vacation-range-btn').addEventListener('click', showVacationRangeModal);
   document.getElementById('toggle-vacation-btn').addEventListener('click', () => toggleVacationDay(selectedDate));
   document.getElementById('priority-add-btn').addEventListener('click', showPriorityModal);
 

--- a/trainings.html
+++ b/trainings.html
@@ -449,7 +449,7 @@ a { color: inherit; text-decoration: none; }
       <div class="metric-card">
         <span class="metric-label">Realizacja celów</span>
         <span class="metric-value" id="metric-goal-progress">0%</span>
-        <span class="metric-sub">Średni postęp głównych celów</span>
+        <span class="metric-sub" id="metric-goal-progress-sub">Cele tygodniowe</span>
       </div>
       <div class="metric-card">
         <span class="metric-label">Zamknięte działania</span>
@@ -550,7 +550,7 @@ a { color: inherit; text-decoration: none; }
         <div class="card-header">
           <div>
             <h3>Postęp celów</h3>
-            <p class="muted tiny">Porównanie z planem miesięcznym</p>
+            <p class="muted tiny">Porównanie z celami tygodniowymi</p>
           </div>
         </div>
         <div id="goal-progress-list" class="goal-progress-list"></div>
@@ -594,10 +594,12 @@ a { color: inherit; text-decoration: none; }
 
 <script>
 const STORAGE_KEY = 'lifeos_trainings_month_v1';
+const LEGACY_STORAGE_KEY = 'lifeos_trainings_v1';
+const MIGRATION_FLAG_KEY = 'lifeos_trainings_migrated_to_month_v1';
 const GOAL_DEFINITIONS = {
-  gym: { target: 10, unit: 'sesji', label: 'Trening siłowy', icon: 'dumbbell', color: 'var(--gym-color)' },
-  running: { target: 60, unit: 'km', label: 'Bieganie', icon: 'activity', color: 'var(--run-color)' },
-  reading: { target: 300, unit: 'stron', label: 'Czytanie', icon: 'book-open', color: 'var(--read-color)' }
+  gym: { target: 3, unit: 'sesje', label: 'Trening siłowy', icon: 'dumbbell', color: 'var(--gym-color)' },
+  running: { target: 5, unit: 'km', label: 'Bieganie', icon: 'activity', color: 'var(--run-color)' },
+  reading: { target: 100, unit: 'stron', label: 'Czytanie', icon: 'book-open', color: 'var(--read-color)' }
 };
 const EXTRA_ACTIVITY_CATEGORIES = [
   { value: 'training', label: 'Trening / ruch' },
@@ -660,6 +662,14 @@ function addDays(date, days) {
   return copy;
 }
 
+function startOfWeek(date) {
+  const copy = new Date(date);
+  const offset = (copy.getDay() + 6) % 7;
+  copy.setDate(copy.getDate() - offset);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
 function ensureDay(dateString) {
   if (!state.activities[dateString]) state.activities[dateString] = [];
   if (!state.extras[dateString]) state.extras[dateString] = [];
@@ -679,18 +689,30 @@ function normalizeDate(date) {
   return normalized;
 }
 
+function getISOWeekStart(year, week) {
+  const simple = new Date(Date.UTC(year, 0, 1 + (week - 1) * 7));
+  const day = simple.getUTCDay();
+  const diff = (day === 0 ? -6 : 1) - day;
+  simple.setUTCDate(simple.getUTCDate() + diff);
+  return new Date(simple.getUTCFullYear(), simple.getUTCMonth(), simple.getUTCDate());
+}
+
 function loadState() {
+  state = { activities: {}, extras: {}, priorities: {} };
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const parsed = JSON.parse(raw);
-      state.activities = parsed.activities || {};
-      state.extras = parsed.extras || {};
-      state.priorities = parsed.priorities || {};
+      if (parsed && typeof parsed === 'object') {
+        state.activities = parsed.activities && typeof parsed.activities === 'object' ? parsed.activities : {};
+        state.extras = parsed.extras && typeof parsed.extras === 'object' ? parsed.extras : {};
+        state.priorities = parsed.priorities && typeof parsed.priorities === 'object' ? parsed.priorities : {};
+      }
     }
   } catch (error) {
     state = { activities: {}, extras: {}, priorities: {} };
   }
+  migrateLegacyState();
 }
 
 function saveState() {
@@ -699,6 +721,112 @@ function saveState() {
   status.classList.add('visible');
   clearTimeout(saveTimeout);
   saveTimeout = setTimeout(() => status.classList.remove('visible'), 1600);
+}
+
+function migrateLegacyState() {
+  try {
+    if (localStorage.getItem(MIGRATION_FLAG_KEY)) return;
+    const legacyRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (!legacyRaw) return;
+    const legacyState = JSON.parse(legacyRaw);
+    if (!legacyState || typeof legacyState !== 'object') {
+      localStorage.setItem(MIGRATION_FLAG_KEY, 'done');
+      return;
+    }
+    let imported = false;
+    Object.keys(legacyState).forEach(yearKey => {
+      const weeks = legacyState[yearKey];
+      if (!weeks || typeof weeks !== 'object') return;
+      Object.keys(weeks).forEach(weekKey => {
+        const weekData = weeks[weekKey];
+        if (!weekData || typeof weekData !== 'object') return;
+        const year = Number(yearKey);
+        const week = Number(weekKey);
+        if (!Number.isFinite(year) || !Number.isFinite(week)) return;
+        const weekStart = getISOWeekStart(year, week);
+        if (Number.isNaN(weekStart.getTime())) return;
+
+        const mapDayToDate = (dayIndex) => {
+          const base = new Date(weekStart);
+          const offset = dayIndex === 0 ? 6 : dayIndex - 1;
+          base.setDate(weekStart.getDate() + offset);
+          base.setHours(0, 0, 0, 0);
+          return base;
+        };
+
+        const plan = weekData.plan && typeof weekData.plan === 'object' ? weekData.plan : {};
+        Object.keys(plan).forEach(dayKey => {
+          const dayIndex = Number(dayKey);
+          if (!Number.isFinite(dayIndex)) return;
+          const date = mapDayToDate(dayIndex);
+          const dateString = toYYYYMMDD(date);
+          ensureDay(dateString);
+          const activities = Array.isArray(plan[dayKey]) ? plan[dayKey] : [];
+          activities.forEach(activity => {
+            if (!activity || !activity.type || !GOAL_DEFINITIONS[activity.type]) return;
+            if (state.activities[dateString].some(item => item.id === activity.id)) return;
+            const plannedValue = activity.type === 'gym' ? 1 : Number(activity.plannedValue) || 0;
+            const loggedValue = activity.type === 'gym'
+              ? (activity.completed ? 1 : 0)
+              : Number(activity.loggedValue) || (activity.completed ? plannedValue : 0);
+            state.activities[dateString].push({
+              id: activity.id || `act_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+              type: activity.type,
+              plannedValue,
+              loggedValue,
+              completed: Boolean(activity.completed),
+              createdAt: activity.createdAt || Date.now()
+            });
+            imported = true;
+          });
+        });
+
+        const extras = weekData.extras && typeof weekData.extras === 'object' ? weekData.extras : {};
+        Object.keys(extras).forEach(dayKey => {
+          const dayIndex = Number(dayKey);
+          if (!Number.isFinite(dayIndex)) return;
+          const date = mapDayToDate(dayIndex);
+          const dateString = toYYYYMMDD(date);
+          ensureDay(dateString);
+          const list = Array.isArray(extras[dayKey]) ? extras[dayKey] : [];
+          list.forEach(extra => {
+            if (!extra || !extra.title) return;
+            if (state.extras[dateString].some(item => item.id === extra.id)) return;
+            state.extras[dateString].push({
+              id: extra.id || `extra_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+              title: extra.title,
+              category: extra.category || 'other',
+              completed: Boolean(extra.completed),
+              createdAt: extra.createdAt || Date.now()
+            });
+            imported = true;
+          });
+        });
+
+        const priorities = Array.isArray(weekData.priorities) ? weekData.priorities : [];
+        priorities.forEach(priority => {
+          if (!priority || !priority.title) return;
+          const monthKey = getMonthKey(mapDayToDate(1));
+          ensurePriorityMonth(monthKey);
+          if (state.priorities[monthKey].some(item => item.id === priority.id)) return;
+          state.priorities[monthKey].push({
+            id: priority.id || `prio_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+            title: priority.title,
+            impact: priority.impact || 'high',
+            completed: Boolean(priority.completed),
+            createdAt: priority.createdAt || Date.now()
+          });
+          imported = true;
+        });
+      });
+    });
+    if (imported) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    }
+    localStorage.setItem(MIGRATION_FLAG_KEY, 'done');
+  } catch (error) {
+    console.error('Legacy trainings migration failed', error);
+  }
 }
 
 function getMonthKey(date) {
@@ -730,7 +858,6 @@ function calculateMonthlyStats(monthDate) {
   const lastDay = new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0);
   const totalDays = lastDay.getDate();
   const totals = { planned: 0, completed: 0 };
-  const goalProgress = { gym: 0, running: 0, reading: 0 };
   const activeDays = new Set();
   const upcoming = [];
   const today = normalizeDate(new Date());
@@ -743,8 +870,6 @@ function calculateMonthlyStats(monthDate) {
     activities.forEach(activity => {
       if (activity.completed) {
         totals.completed += 1;
-        if (activity.type === 'gym') goalProgress.gym += 1;
-        else goalProgress[activity.type] += Number(activity.loggedValue) || Number(activity.plannedValue) || 0;
       } else if (normalizeDate(date) >= today) {
         const goal = GOAL_DEFINITIONS[activity.type];
         if (!goal) return;
@@ -791,60 +916,90 @@ function calculateMonthlyStats(monthDate) {
     return a.type.localeCompare(b.type);
   });
 
-  const goalPercents = {};
-  Object.keys(GOAL_DEFINITIONS).forEach(type => {
-    const progressValue = goalProgress[type] || 0;
-    const target = GOAL_DEFINITIONS[type].target;
-    const percent = target > 0 ? Math.min(100, Math.round((progressValue / target) * 100)) : 0;
-    goalPercents[type] = {
-      percent,
-      progress: progressValue,
-      target
-    };
-  });
-  const averageGoalPercent = Math.round(Object.values(goalPercents).reduce((acc, info) => acc + info.percent, 0) / Object.keys(GOAL_DEFINITIONS).length) || 0;
-
   return {
     plannedCount: totals.planned,
     completedCount: totals.completed,
     activeDays: activeDays.size,
     totalDays,
-    goalPercents,
-    averageGoalPercent,
     nextActivity: upcoming.length ? { label: upcoming[0].label, dateLabel: upcoming[0].dateLabel } : null,
     upcoming,
     range: { start: firstDay, end: lastDay }
   };
 }
 
+function calculateWeeklyGoalStats(referenceDate) {
+  const base = referenceDate ? new Date(referenceDate) : new Date();
+  const weekStart = startOfWeek(base);
+  const weekEnd = addDays(weekStart, 6);
+  const totals = { gym: 0, running: 0, reading: 0 };
+
+  Object.entries(state.activities).forEach(([dateString, activities]) => {
+    const date = parseDate(dateString);
+    const normalized = normalizeDate(date);
+    if (normalized < weekStart || normalized > weekEnd) return;
+    activities.forEach(activity => {
+      if (!activity || !GOAL_DEFINITIONS[activity.type] || !activity.completed) return;
+      if (activity.type === 'gym') {
+        totals.gym += 1;
+      } else {
+        const logged = Number(activity.loggedValue);
+        const planned = Number(activity.plannedValue);
+        const value = !Number.isNaN(logged) && logged > 0
+          ? logged
+          : (!Number.isNaN(planned) ? planned : 0);
+        totals[activity.type] += value;
+      }
+    });
+  });
+
+  const goalPercents = {};
+  Object.keys(GOAL_DEFINITIONS).forEach(type => {
+    const progress = totals[type] || 0;
+    const target = GOAL_DEFINITIONS[type].target;
+    const percent = target > 0 ? Math.min(100, Math.round((progress / target) * 100)) : 0;
+    goalPercents[type] = { percent, progress, target };
+  });
+
+  const averageGoalPercent = Math.round(
+    Object.values(goalPercents).reduce((acc, info) => acc + info.percent, 0) /
+    Object.keys(GOAL_DEFINITIONS).length
+  ) || 0;
+
+  return { goalPercents, averageGoalPercent, range: { start: weekStart, end: weekEnd } };
+}
+
 function render() {
   ensureSelectionInMonth();
-  const stats = calculateMonthlyStats(currentMonth);
-  renderHeader(stats);
+  const monthStats = calculateMonthlyStats(currentMonth);
+  const weekStats = calculateWeeklyGoalStats(parseDate(selectedDate));
+  renderHeader(monthStats, weekStats);
   renderCalendar();
   renderDayDetail();
-  renderUpcoming(stats.upcoming);
+  renderUpcoming(monthStats.upcoming);
   renderPriorities();
-  renderGoalProgress(stats.goalPercents);
+  renderGoalProgress(weekStats.goalPercents);
   renderHeatmap();
   lucide.createIcons();
 }
 
-function renderHeader(stats) {
+function renderHeader(monthStats, weekStats) {
   const monthLabel = formatMonth(currentMonth);
   document.getElementById('header-month-chip').textContent = monthLabel;
   document.getElementById('current-month-label').textContent = monthLabel;
-  document.getElementById('current-month-range').textContent = `${formatRange(stats.range.start, stats.range.end)} ${currentMonth.getFullYear()}`;
+  document.getElementById('current-month-range').textContent = `${formatRange(monthStats.range.start, monthStats.range.end)} ${currentMonth.getFullYear()}`;
   const todayButton = document.getElementById('today-month-btn');
   if (sameMonth(new Date(), currentMonth)) todayButton.style.display = 'none';
   else todayButton.style.display = 'inline-flex';
-
-  document.getElementById('metric-goal-progress').textContent = `${stats.averageGoalPercent}%`;
-  document.getElementById('metric-plan-completion').textContent = `${stats.completedCount}/${stats.plannedCount}`;
-  document.getElementById('metric-active-days').textContent = `${stats.activeDays}/${stats.totalDays}`;
-  if (stats.nextActivity) {
-    document.getElementById('metric-next-activity').textContent = stats.nextActivity.label;
-    document.getElementById('metric-next-activity-date').textContent = stats.nextActivity.dateLabel;
+  document.getElementById('metric-goal-progress').textContent = `${weekStats.averageGoalPercent}%`;
+  const goalProgressSub = document.getElementById('metric-goal-progress-sub');
+  if (goalProgressSub && weekStats && weekStats.range) {
+    goalProgressSub.textContent = `Cele tygodniowe · ${formatRange(weekStats.range.start, weekStats.range.end)}`;
+  }
+  document.getElementById('metric-plan-completion').textContent = `${monthStats.completedCount}/${monthStats.plannedCount}`;
+  document.getElementById('metric-active-days').textContent = `${monthStats.activeDays}/${monthStats.totalDays}`;
+  if (monthStats.nextActivity) {
+    document.getElementById('metric-next-activity').textContent = monthStats.nextActivity.label;
+    document.getElementById('metric-next-activity-date').textContent = monthStats.nextActivity.dateLabel;
   } else {
     document.getElementById('metric-next-activity').textContent = 'Brak';
     document.getElementById('metric-next-activity-date').textContent = '--';
@@ -1080,6 +1235,7 @@ function renderPriorities() {
 function renderGoalProgress(goalPercents) {
   const container = document.getElementById('goal-progress-list');
   container.innerHTML = '';
+  if (!goalPercents) return;
   Object.entries(goalPercents).forEach(([type, info]) => {
     const def = GOAL_DEFINITIONS[type];
     const item = document.createElement('div');

--- a/trainings.html
+++ b/trainings.html
@@ -29,7 +29,7 @@
     }
     *, *::before, *::after { box-sizing: border-box; }
     body { margin: 0; min-height: 100vh; background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 20%, #f8fafc 100%); color: var(--ink); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto; font-size: 14px; line-height: 1.5; -webkit-font-smoothing: antialiased; }
-    .wrap { max-width: 1240px; margin: 0 auto; padding: 48px 24px 64px; }
+    .wrap { max-width: 1240px; margin: 0 auto; padding: 32px 24px 56px; }
     .grid { display: grid; gap: 16px; }
     .g-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .g-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -60,23 +60,28 @@
     .row { display: flex; justify-content: space-between; align-items: center; }
 
     /* Header */
-    .page-header { display: grid; gap: 24px; margin-bottom: 40px; }
-    .page-header-main { display: flex; flex-direction: column; gap: 24px; padding: 32px; border-radius: 28px; background: linear-gradient(135deg, rgba(59, 130, 246, 0.08) 0%, rgba(14, 165, 233, 0.05) 100%); border: 1px solid rgba(148, 163, 184, 0.25); position: relative; overflow: hidden; box-shadow: var(--shadow); }
-    .page-header-main::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at top right, rgba(59,130,246,0.16), transparent 55%); pointer-events: none; }
+    .page-header { display: grid; grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr); gap: 24px; margin-bottom: 32px; align-items: stretch; }
+    @media(max-width: 1100px) { .page-header { grid-template-columns: 1fr; } }
+    .page-header-main { display: flex; flex-direction: column; gap: 18px; padding: 24px; border-radius: 22px; background: linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, rgba(14, 165, 233, 0.03) 100%); border: 1px solid rgba(148, 163, 184, 0.2); position: relative; overflow: hidden; box-shadow: var(--shadow-sm); }
+    .page-header-main::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at top right, rgba(59,130,246,0.14), transparent 60%); pointer-events: none; }
     .page-header-main > * { position: relative; z-index: 1; }
-    .header-top { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
-    .page-header-copy { display: flex; flex-direction: column; gap: 16px; }
-    .page-header-copy h1 { font-size: 34px; margin: 0; font-weight: 800; letter-spacing: -0.5px; }
-    .header-subtitle { max-width: 580px; font-size: 15px; }
+    .header-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+    .header-title-block { display: flex; flex-direction: column; gap: 6px; }
+    .header-title-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .header-title-row h1 { margin: 0; font-size: 28px; font-weight: 800; letter-spacing: -0.3px; }
+    .header-subtitle { max-width: 600px; font-size: 14px; margin: 0; }
+    .header-week-range { font-size: 13px; color: var(--muted); }
+    .week-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--blue-soft); color: var(--blue); font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; }
+    .header-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .eyebrow { text-transform: uppercase; letter-spacing: 0.12em; font-size: 11px; font-weight: 600; color: var(--blue); }
-    .header-insights { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
-    .insight-card { background: rgba(255, 255, 255, 0.7); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 18px; padding: 16px; box-shadow: var(--shadow); backdrop-filter: blur(8px); display: flex; flex-direction: column; gap: 6px; }
+    .header-insights { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+    .insight-card { background: rgba(255, 255, 255, 0.8); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 16px; padding: 14px; box-shadow: var(--shadow-sm); display: flex; flex-direction: column; gap: 6px; }
     .insight-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); font-weight: 600; }
-    .insight-value { font-size: 22px; font-weight: 700; color: var(--ink); }
+    .insight-value { font-size: 20px; font-weight: 700; color: var(--ink); }
     .insight-sub { font-size: 12px; color: var(--muted); }
-    .header-kpis { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); padding: 24px; }
-    .kpi-item { text-align: left; display: flex; flex-direction: column; gap: 4px; }
-    .kpi-value { font-size: 26px; font-weight: 800; line-height: 1.1; }
+    .header-kpis { display: flex; flex-direction: column; gap: 18px; padding: 24px; }
+    .kpi-item { text-align: left; display: flex; flex-direction: column; gap: 6px; }
+    .kpi-value { font-size: 24px; font-weight: 800; line-height: 1.1; }
     .kpi-note { margin: 0; color: var(--muted); }
     .weekly-overview-card { position: relative; overflow: visible; display: flex; flex-direction: column; gap: 20px; }
     .overview-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
@@ -95,7 +100,7 @@
     .goal-card.goal-gym { background: var(--gym-soft); border-color: var(--gym-border); }
     .goal-card.goal-running { background: var(--run-soft); border-color: var(--run-border); }
     .goal-card.goal-reading { background: var(--read-soft); border-color: var(--read-border); }
-    .page-layout { display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); gap: 24px; align-items: flex-start; }
+    .page-layout { display: grid; grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr); gap: 24px; align-items: flex-start; }
     .layout-main, .layout-side { display: flex; flex-direction: column; gap: 24px; }
     @media(max-width: 1100px) { .page-layout { grid-template-columns: 1fr; } }
     .insights-grid { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
@@ -120,24 +125,26 @@
     .next-action-date { font-size: 12px; color: var(--muted); }
     .next-action-badge { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); background: rgba(37, 99, 235, 0.12); border-radius: 999px; padding: 4px 8px; }
     @media(max-width: 640px) {
-      .header-top { width: 100%; justify-content: flex-start; }
+      .header-top { width: 100%; flex-direction: column; align-items: flex-start; }
+      .header-actions { width: 100%; justify-content: flex-start; }
       .back-btn { width: 100%; }
     }
 
     /* Planner */
-    .planner-card { padding: 28px; }
+    .planner-card { padding: 24px; overflow: visible; }
     .planner-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
     .planner-title { display: flex; flex-direction: column; gap: 4px; }
     .planner-title .title { margin: 0; font-size: 20px; }
     .planner-range { font-size: 13px; color: var(--muted); }
     .planner-controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
     .week-nav { display: flex; gap: 8px; }
-    .planner-meta { display: flex; justify-content: space-between; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 16px; }
+    .planner-meta { display: flex; justify-content: space-between; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 12px; }
     .planner-status { font-weight: 600; font-size: 13px; }
     .planner-instructions { display: none; margin: 0; margin-top: 12px; padding: 12px 16px; border-radius: 12px; background: var(--blue-soft); color: var(--blue); font-weight: 500; }
     .btn.small { padding: 6px 12px; font-size: 12px; border-radius: 10px; }
-    .planner-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 12px; margin-top: 20px; }
-    .day-column { position: relative; background: var(--bg); border-radius: 12px; padding: 12px; transition: var(--transition-fast); border: 2px solid transparent; }
+    .planner-grid-wrapper { margin-top: 20px; overflow-x: auto; padding-bottom: 12px; }
+    .planner-grid { display: grid; grid-template-columns: repeat(7, minmax(160px, 1fr)); gap: 16px; min-width: 1120px; }
+    .day-column { position: relative; background: var(--bg); border-radius: 12px; padding: 12px; transition: var(--transition-fast); border: 2px solid transparent; min-width: 160px; }
     .day-header { font-weight: 600; text-align: center; font-size: 13px; padding-bottom: 8px; margin-bottom: 8px; border-bottom: 1px solid var(--line); }
     .day-header.today { color: var(--blue); }
     .activities-container { min-height: 120px; display: flex; flex-direction: column; gap: 8px; }
@@ -203,8 +210,10 @@
     .planning-mode .day-column:hover { border-color: var(--blue); background: var(--blue-soft); }
 
     /* Stats */
-    .heatmap-container { margin-top: 16px; overflow-x: auto; padding-bottom: 10px; }
-    .heatmap { display: grid; grid-template-rows: repeat(7, 1fr); grid-auto-flow: column; gap: 4px; }
+    .heatmap-container { margin-top: 16px; overflow-x: auto; padding-bottom: 12px; }
+    .heatmap { display: flex; gap: 4px; min-width: max-content; align-items: flex-start; }
+    .heatmap-week { display: flex; flex-direction: column; gap: 4px; align-items: center; }
+    .heatmap-week-label { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap; }
     .heatmap-cell { width: 15px; height: 15px; background: var(--line); border-radius: 3px; position: relative; }
     .heatmap-cell[data-level="1"] { background: #9be9a8; }
     .heatmap-cell[data-level="2"] { background: #40c463; }
@@ -224,28 +233,34 @@
     <header class="page-header">
       <div class="page-header-main">
         <div class="header-top">
-          <a href="./index.html" class="btn soft back-btn"><i data-lucide="arrow-left" class="icon"></i> Powrót</a>
+          <div class="header-title-block">
+            <span class="eyebrow">Strategiczne zarządzanie rozwojem</span>
+            <div class="header-title-row">
+              <h1>Panel treningów</h1>
+              <span class="week-chip" id="header-week-label">Tydzień --</span>
+            </div>
+            <span class="header-week-range" id="header-week-range">--</span>
+          </div>
+          <div class="header-actions">
+            <a href="./index.html" class="btn soft back-btn"><i data-lucide="arrow-left" class="icon"></i> Powrót</a>
+          </div>
         </div>
-        <div class="page-header-copy">
-          <span class="eyebrow">Strategiczne zarządzanie rozwojem</span>
-          <h1>Panel treningów</h1>
-          <p class="muted header-subtitle">Planowanie, realizacja i analiza Twoich kluczowych celów w jednym miejscu. Profesjonalny rytm tygodnia zaczyna się tutaj.</p>
-          <div class="header-insights">
-            <div class="insight-card">
-              <span class="insight-label">Aktualny tydzień</span>
-              <span class="insight-value" id="header-week-label">Tydzień --</span>
-              <span class="insight-sub" id="header-week-range">--</span>
-            </div>
-            <div class="insight-card">
-              <span class="insight-label">Realizacja celów</span>
-              <span class="insight-value" id="header-week-progress">0%</span>
-              <span class="insight-sub">Średni postęp celów głównych</span>
-            </div>
-            <div class="insight-card">
-              <span class="insight-label">Aktywności tygodnia</span>
-              <span class="insight-value" id="header-planned-activities">0/0</span>
-              <span class="insight-sub">ukończone / zaplanowane</span>
-            </div>
+        <p class="muted header-subtitle">Planowanie, realizacja i analiza Twoich kluczowych celów w jednym miejscu.</p>
+        <div class="header-insights">
+          <div class="insight-card">
+            <span class="insight-label">Realizacja celów</span>
+            <span class="insight-value" id="header-week-progress">0%</span>
+            <span class="insight-sub">Średni postęp celów głównych</span>
+          </div>
+          <div class="insight-card">
+            <span class="insight-label">Aktywności tygodnia</span>
+            <span class="insight-value" id="header-planned-activities">0/0</span>
+            <span class="insight-sub">ukończone / zaplanowane</span>
+          </div>
+          <div class="insight-card">
+            <span class="insight-label">Status planu</span>
+            <span class="insight-value" id="header-plan-status">W trakcie</span>
+            <span class="insight-sub" id="header-plan-status-hint">Uzupełnij plan, aby zamknąć cele tygodnia.</span>
           </div>
         </div>
       </div>
@@ -290,7 +305,9 @@
             <button id="cancel-planning-btn" class="btn soft small" style="display: none;">Zakończ planowanie</button>
           </div>
           <p id="planning-instructions" class="planner-instructions"></p>
-          <div class="planner-grid"></div>
+          <div class="planner-grid-wrapper">
+            <div class="planner-grid"></div>
+          </div>
           <div id="empty-planner-placeholder" class="empty-planner" style="display: none;">
             <h4 style="margin: 0 0 4px 0;">Brak zaplanowanych działań</h4>
             <p class="muted" style="margin: 0;">Dodaj cele z panelu obok lub użyj szybkich przycisków w kalendarzu.</p>
@@ -683,9 +700,9 @@ function render() {
 
     const weekRangeLabel = formatWeekRange(startOfWeek);
     const headerWeekLabel = document.getElementById('header-week-label');
-    if (headerWeekLabel) headerWeekLabel.textContent = `Tydzień ${week} (${year})`;
+    if (headerWeekLabel) headerWeekLabel.textContent = `Tydzień ${week}`;
     const headerWeekRange = document.getElementById('header-week-range');
-    if (headerWeekRange) headerWeekRange.textContent = weekRangeLabel;
+    if (headerWeekRange) headerWeekRange.textContent = `${weekRangeLabel} · ${year}`;
     const plannerRangeEl = document.getElementById('planner-week-range');
     if (plannerRangeEl) plannerRangeEl.textContent = weekRangeLabel;
 
@@ -932,7 +949,8 @@ function renderHeaderKPIs(year, nextUpcoming) {
 
 function renderPlanningStatus(plan) {
     const statusEl = document.getElementById('planning-status');
-    if (!statusEl) return;
+    const headerPlanStatus = document.getElementById('header-plan-status');
+    const headerPlanHint = document.getElementById('header-plan-status-hint');
     const plannedTotals = { gym: 0, running: 0, reading: 0 };
     Object.values(plan).flat().forEach(activity => {
         plannedTotals[activity.type] += activity.completed ? activity.loggedValue : (activity.plannedValue || 0);
@@ -940,12 +958,26 @@ function renderPlanningStatus(plan) {
 
     const allGoalsPlanned = Object.keys(GOAL_DEFINITIONS).every(type => plannedTotals[type] >= GOAL_DEFINITIONS[type].target);
 
-    if (allGoalsPlanned) {
-        statusEl.textContent = '✅ Wszystkie cele mają zaplanowane działania.';
-        statusEl.style.color = 'var(--green)';
-    } else {
-        statusEl.textContent = '🧭 Zaplanuj brakujące działania, aby domknąć tydzień.';
-        statusEl.style.color = 'var(--orange)';
+    if (statusEl) {
+        if (allGoalsPlanned) {
+            statusEl.textContent = '✅ Wszystkie cele mają zaplanowane działania.';
+            statusEl.style.color = 'var(--green)';
+        } else {
+            statusEl.textContent = '🧭 Zaplanuj brakujące działania, aby domknąć tydzień.';
+            statusEl.style.color = 'var(--orange)';
+        }
+    }
+
+    if (headerPlanStatus && headerPlanHint) {
+        if (allGoalsPlanned) {
+            headerPlanStatus.textContent = 'Gotowy';
+            headerPlanStatus.style.color = 'var(--green)';
+            headerPlanHint.textContent = 'Cele mają pełny plan działania.';
+        } else {
+            headerPlanStatus.textContent = 'W trakcie';
+            headerPlanStatus.style.color = 'var(--orange)';
+            headerPlanHint.textContent = 'Uzupełnij plan, aby zamknąć cele tygodnia.';
+        }
     }
 }
 
@@ -1548,26 +1580,47 @@ function renderStats() {
     const heatmap = document.createElement('div');
     heatmap.className = 'heatmap';
 
-    for(let i=0; i < 53 * 7; i++) { // Renderuj pełne 53 kolumny dla spójności
-        const dateString = toYYYYMMDD(currentDay);
-        const cell = document.createElement('div');
-        cell.className = 'heatmap-cell';
-        
-        if (currentDay.getFullYear() === year) {
-            const count = activitiesByDay[dateString] || 0;
-            let level = 0;
-            if(count > 0) level = 1;
-            if(count > 1) level = 2;
-            if(count > 2) level = 3;
-            if(count > 3) level = 4;
-            cell.dataset.level = level;
-            cell.title = `${dateString}: ${count} ukończone aktywności`;
-        } else {
-             cell.style.background = 'transparent'; // Dni spoza roku są puste
+    const totalWeeks = 53;
+    for (let weekIndex = 0; weekIndex < totalWeeks; weekIndex++) {
+        const weekColumn = document.createElement('div');
+        weekColumn.className = 'heatmap-week';
+        const weekStart = new Date(currentDay);
+
+        for (let day = 0; day < 7; day++) {
+            const dateString = toYYYYMMDD(currentDay);
+            const cell = document.createElement('div');
+            cell.className = 'heatmap-cell';
+
+            if (currentDay.getFullYear() === year) {
+                const count = activitiesByDay[dateString] || 0;
+                let level = 0;
+                if(count > 0) level = 1;
+                if(count > 1) level = 2;
+                if(count > 2) level = 3;
+                if(count > 3) level = 4;
+                cell.dataset.level = level;
+                cell.title = `${dateString}: ${count} ukończone aktywności`;
+            } else {
+                 cell.style.background = 'transparent';
+            }
+
+            weekColumn.appendChild(cell);
+            currentDay.setDate(currentDay.getDate() + 1);
         }
-        heatmap.appendChild(cell);
-        currentDay.setDate(currentDay.getDate() + 1);
+
+        const label = document.createElement('span');
+        label.className = 'heatmap-week-label';
+        if (weekStart.getFullYear() === year) {
+            const monthLabel = weekStart.toLocaleDateString('pl-PL', { month: 'short' }).replace('.', '').toUpperCase();
+            label.textContent = monthLabel;
+            label.title = `${formatWeekRange(weekStart)} ${weekStart.getFullYear()}`;
+        } else {
+            label.textContent = ' ';
+        }
+        weekColumn.appendChild(label);
+        heatmap.appendChild(weekColumn);
     }
+
     heatmapContainer.appendChild(heatmap);
 }
 

--- a/trainings.html
+++ b/trainings.html
@@ -55,12 +55,12 @@ h1, h2, h3, h4, h5 { margin: 0; color: var(--ink); }
 p { margin: 0; }
 
 .wrap {
-  max-width: 1280px;
+  max-width: 1360px;
   margin: 0 auto;
   padding: 28px 32px 40px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
 }
 
 a { color: inherit; text-decoration: none; }
@@ -71,6 +71,95 @@ a { color: inherit; text-decoration: none; }
   border: 1px solid rgba(148, 163, 184, 0.25);
   padding: 20px 24px;
   box-shadow: var(--shadow-sm);
+}
+
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.top-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(520px, 2fr);
+  gap: 20px;
+  align-items: stretch;
+}
+
+.metrics-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.metrics-header h3 { font-size: 16px; font-weight: 700; }
+.metrics-header p { margin-top: 4px; }
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.focus-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.focus-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.focus-title h3 { font-size: 20px; font-weight: 700; }
+
+.focus-meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.focus-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  align-items: start;
+}
+
+.focus-column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.vacation-note {
+  display: none;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 12px;
+  padding: 8px 12px;
+}
+
+.focus-goals {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(37, 99, 235, 0.06);
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 16px;
+  padding: 14px 16px;
+}
+
+.bottom-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
+  gap: 20px;
+  align-items: stretch;
 }
 
 .page-header {
@@ -128,6 +217,7 @@ a { color: inherit; text-decoration: none; }
 .btn.soft:hover { border-color: var(--primary); color: var(--primary); }
 .btn.ghost { background: rgba(148, 163, 184, 0.16); color: var(--ink); }
 .btn.ghost:hover { background: rgba(148, 163, 184, 0.3); }
+.btn.ghost.active { background: rgba(148, 163, 184, 0.28); border-color: rgba(148, 163, 184, 0.5); }
 .btn:disabled { opacity: 0.6; cursor: not-allowed; transform: none; box-shadow: none; }
 
 .icon-btn {
@@ -176,14 +266,6 @@ a { color: inherit; text-decoration: none; }
 .metric-value { font-size: 22px; font-weight: 700; }
 .metric-sub { font-size: 11px; color: var(--muted); }
 
-.layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
-  gap: 20px;
-  align-items: start;
-}
-
-.calendar-column, .sidebar { display: flex; flex-direction: column; gap: 20px; }
 
 .card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
 .card-header p { margin-top: 4px; }
@@ -211,7 +293,7 @@ a { color: inherit; text-decoration: none; }
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 8px;
+  gap: 12px;
 }
 
 .calendar-day {
@@ -219,7 +301,7 @@ a { color: inherit; text-decoration: none; }
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.3);
   padding: 10px 12px;
-  min-height: 116px;
+  min-height: 104px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -235,6 +317,15 @@ a { color: inherit; text-decoration: none; }
 .calendar-day--empty { background: var(--day-empty); border-color: var(--day-empty-border); }
 .calendar-day--planned { background: var(--day-planned); border-color: var(--day-planned-border); }
 .calendar-day--completed { background: var(--day-completed); border-color: var(--day-completed-border); }
+.calendar-day--vacation {
+  background: #f1f5f9;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--muted);
+}
+.calendar-day--drag-over {
+  outline: 2px dashed var(--primary);
+  outline-offset: 3px;
+}
 
 .calendar-day-header { display: flex; justify-content: space-between; align-items: center; }
 .calendar-date-number { font-weight: 700; font-size: 14px; }
@@ -267,10 +358,13 @@ a { color: inherit; text-decoration: none; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.activity-tag[draggable="true"] { cursor: grab; }
+.activity-tag.dragging { opacity: 0.6; cursor: grabbing; }
 .activity-tag.gym { background: rgba(91, 33, 182, 0.12); color: var(--gym-color); border-color: rgba(91, 33, 182, 0.16); }
 .activity-tag.running { background: rgba(4, 120, 87, 0.12); color: var(--run-color); border-color: rgba(4, 120, 87, 0.18); }
 .activity-tag.reading { background: rgba(29, 78, 216, 0.12); color: var(--read-color); border-color: rgba(29, 78, 216, 0.18); }
 .activity-tag.extra { background: rgba(14, 165, 233, 0.12); color: var(--extra-color); border-color: rgba(14, 165, 233, 0.18); }
+.activity-tag.vacation { background: rgba(148, 163, 184, 0.22); color: var(--muted); border-color: rgba(148, 163, 184, 0.32); font-weight: 700; }
 .activity-tag.more { background: rgba(148, 163, 184, 0.14); color: var(--muted); border-style: dashed; }
 
 .calendar-day-footer { margin-top: auto; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; align-items: center; }
@@ -296,20 +390,26 @@ a { color: inherit; text-decoration: none; }
 .legend-tag.running { background: rgba(4, 120, 87, 0.12); color: var(--run-color); }
 .legend-tag.reading { background: rgba(29, 78, 216, 0.12); color: var(--read-color); }
 .legend-tag.extra { background: rgba(14, 165, 233, 0.12); color: var(--extra-color); }
+.legend-tag.vacation { background: rgba(148, 163, 184, 0.22); color: var(--muted); }
 
 .planning-banner {
-  display: none;
-  align-items: center;
-  justify-content: space-between;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   gap: 12px;
-  background: rgba(37, 99, 235, 0.08);
-  border: 1px solid rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.05);
+  border: 1px dashed rgba(37, 99, 235, 0.25);
   border-radius: 14px;
-  padding: 10px 12px;
+  padding: 12px 14px;
 }
 
-.planning-banner.active { display: flex; }
-.planning-banner-info { display: flex; align-items: center; gap: 10px; }
+.planning-banner.active {
+  border-style: solid;
+  background: rgba(37, 99, 235, 0.1);
+  box-shadow: var(--shadow-sm);
+}
+.planning-banner:not(.active) #stop-planning-btn { display: none; }
+.planning-banner-info { display: flex; align-items: flex-start; gap: 10px; }
 .planning-banner-info strong { display: block; font-size: 12px; font-weight: 700; color: var(--ink); }
 .planning-banner-info span { display: block; font-size: 11px; color: var(--muted); }
 .planning-banner .icon { color: var(--primary); }
@@ -320,9 +420,11 @@ a { color: inherit; text-decoration: none; }
 .calendar-grid.is-planning .calendar-day { cursor: crosshair; }
 
 .upcoming-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
-.upcoming-item { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(248, 250, 252, 0.7); }
+.upcoming-item { display: flex; align-items: flex-start; gap: 14px; padding: 14px 16px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(248, 250, 252, 0.7); }
+.upcoming-body { display: flex; flex-direction: column; gap: 6px; }
+.upcoming-when { font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--primary); }
 .upcoming-item strong { display: block; font-size: 13px; }
-.upcoming-item .meta { display: flex; gap: 8px; font-size: 11px; color: var(--muted); }
+.upcoming-item .meta { display: flex; gap: 8px; font-size: 11px; color: var(--muted); flex-wrap: wrap; }
 .upcoming-item .badge { background: rgba(37, 99, 235, 0.12); color: var(--primary); border-radius: 999px; padding: 2px 8px; font-weight: 600; }
 
 .empty-state {
@@ -348,6 +450,8 @@ a { color: inherit; text-decoration: none; }
   background: rgba(248, 250, 252, 0.8);
   transition: var(--transition);
 }
+.detail-item[draggable="true"] { cursor: grab; }
+.detail-item.dragging { opacity: 0.6; cursor: grabbing; }
 .detail-item:hover { border-color: var(--primary-border); box-shadow: var(--shadow-sm); background: #fff; }
 .detail-item.completed { background: var(--success-soft); border-color: var(--success-border); }
 .detail-info { display: flex; gap: 12px; }
@@ -471,7 +575,9 @@ a { color: inherit; text-decoration: none; }
 #save-status.visible { opacity: 1; transform: translateX(-50%) translateY(0); }
 
 @media (max-width: 1080px) {
-  .layout { grid-template-columns: 1fr; }
+  .top-grid { grid-template-columns: 1fr; }
+  .focus-columns { grid-template-columns: 1fr; }
+  .bottom-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 720px) {
@@ -479,7 +585,10 @@ a { color: inherit; text-decoration: none; }
   .page-header-top { flex-direction: column; align-items: flex-start; }
   .page-header-actions { width: 100%; }
   .page-header-actions .btn { flex: 1; justify-content: center; }
-  .metrics-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .metrics-grid { grid-template-columns: 1fr; }
+  .focus-meta { flex-direction: column; align-items: flex-start; }
+  .detail-actions { flex-direction: column; }
+  .bottom-grid { grid-template-columns: 1fr; }
   .calendar-weekdays { display: none; }
   .calendar-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
@@ -511,106 +620,128 @@ a { color: inherit; text-decoration: none; }
         <button id="next-month-btn" class="icon-btn" aria-label="Następny miesiąc"><i data-lucide="chevron-right" class="icon"></i></button>
       </div>
     </div>
-    <div class="metrics-row">
-      <div class="metric-card">
-        <span class="metric-label">Realizacja celów</span>
-        <span class="metric-value" id="metric-goal-progress">0%</span>
-        <span class="metric-sub" id="metric-goal-progress-sub">Cele tygodniowe</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-label">Zamknięte działania</span>
-        <span class="metric-value" id="metric-plan-completion">0/0</span>
-        <span class="metric-sub">Ukończone vs zaplanowane</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-label">Aktywne dni</span>
-        <span class="metric-value" id="metric-active-days">0/0</span>
-        <span class="metric-sub">Dni z planem w miesiącu</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-label">Najbliższa aktywność</span>
-        <span class="metric-value" id="metric-next-activity">Brak</span>
-        <span class="metric-sub" id="metric-next-activity-date">--</span>
-      </div>
-    </div>
   </header>
 
-  <main class="layout">
-    <section class="calendar-column">
-      <div class="card calendar-card">
-        <div class="card-header">
-          <div>
-            <h3>Harmonogram miesięczny</h3>
-            <p class="muted tiny">Planowanie i realizacja celów bez przewijania</p>
+  <main class="page-content">
+    <div class="top-grid">
+      <section class="card metrics-card">
+        <div class="metrics-header">
+          <h3>Wskaźniki</h3>
+          <p class="muted tiny">Szybki podgląd Twojego miesiąca</p>
+        </div>
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <span class="metric-label">Realizacja celów</span>
+            <span class="metric-value" id="metric-goal-progress">0%</span>
+            <span class="metric-sub" id="metric-goal-progress-sub">Cele tygodniowe</span>
           </div>
-          <div class="calendar-legend">
-            <span class="legend-tag gym">Siłownia</span>
-            <span class="legend-tag running">Bieganie</span>
-            <span class="legend-tag reading">Czytanie</span>
-            <span class="legend-tag extra">Dodatkowe</span>
+          <div class="metric-card">
+            <span class="metric-label">Zamknięte działania</span>
+            <span class="metric-value" id="metric-plan-completion">0/0</span>
+            <span class="metric-sub">Ukończone vs zaplanowane</span>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Aktywne dni</span>
+            <span class="metric-value" id="metric-active-days">0/0</span>
+            <span class="metric-sub">Dni z planem w miesiącu</span>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Najbliższa aktywność</span>
+            <span class="metric-value" id="metric-next-activity">Brak</span>
+            <span class="metric-sub" id="metric-next-activity-date">--</span>
           </div>
         </div>
-        <div class="calendar-weekdays">
-          <span>Pon</span><span>Wt</span><span>Śr</span><span>Czw</span><span>Pt</span><span>Sob</span><span>Niedz</span>
+      </section>
+
+      <section class="card focus-card">
+        <div class="focus-header">
+          <div class="focus-title">
+            <span class="tiny muted">Plan na dziś</span>
+            <h3 id="selected-day-title">--</h3>
+          </div>
+          <div class="focus-meta">
+            <span class="month-chip" id="selected-day-chip">--</span>
+            <button id="toggle-vacation-btn" class="btn ghost small"><i data-lucide="plane" class="icon"></i>Urlop</button>
+          </div>
         </div>
-        <div id="planning-banner" class="planning-banner" aria-live="polite">
-          <div class="planning-banner-info">
-            <i data-lucide="mouse-pointer" class="icon"></i>
-            <div>
-              <strong id="planning-banner-title">Tryb planowania</strong>
-              <span id="planning-banner-meta">Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.</span>
+        <p class="muted tiny" id="selected-day-summary">Wybierz dzień z kalendarza, aby zarządzać planem.</p>
+        <div id="vacation-note" class="vacation-note">Dzień oznaczony jako urlop — bez oczekiwań treningowych.</div>
+        <div class="focus-columns">
+          <div class="focus-column">
+            <div class="detail-block">
+              <div class="detail-block-header">
+                <span>Plan treningowy</span>
+              </div>
+              <div id="day-plan-list" class="detail-list"></div>
+              <p id="day-plan-empty" class="empty-state">Brak zaplanowanych treningów na ten dzień.</p>
+            </div>
+            <div class="detail-block">
+              <div class="detail-block-header">
+                <span>Aktywności dodatkowe</span>
+              </div>
+              <div id="day-extra-list" class="detail-list"></div>
+              <p id="day-extra-empty" class="empty-state">Dodaj krótkie działania lub przypomnienia.</p>
             </div>
           </div>
-          <button id="stop-planning-btn" class="btn soft small"><i data-lucide="check" class="icon"></i>Zakończ</button>
-        </div>
-        <div id="calendar-grid" class="calendar-grid"></div>
-      </div>
-
-      <div class="card overview-card">
-        <div class="card-header">
-          <div>
-            <h3>Najbliższe działania</h3>
-            <p class="muted tiny">Lista priorytetów na obecny miesiąc</p>
+          <div class="focus-column">
+            <div class="planning-banner" id="planning-banner" aria-live="polite">
+              <div class="planning-banner-info">
+                <i data-lucide="mouse-pointer" class="icon"></i>
+                <div>
+                  <strong id="planning-banner-title">Tryb planowania</strong>
+                  <span id="planning-banner-meta">Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.</span>
+                </div>
+              </div>
+              <button id="stop-planning-btn" class="btn soft small"><i data-lucide="check" class="icon"></i>Zakończ</button>
+            </div>
+            <div class="focus-goals">
+              <div class="detail-block-header">
+                <span>Postęp tygodnia</span>
+              </div>
+              <div id="goal-progress-list" class="goal-progress-list"></div>
+            </div>
           </div>
         </div>
-        <ul id="upcoming-list" class="upcoming-list"></ul>
-        <p id="upcoming-empty" class="empty-state">Brak zaplanowanych aktywności w nadchodzących dniach.</p>
-      </div>
-    </section>
-
-    <aside class="sidebar">
-      <div class="card day-detail-card">
-        <div class="day-detail-header">
-          <div>
-            <h3 id="selected-day-title">--</h3>
-            <p class="muted tiny" id="selected-day-summary">Wybierz dzień z kalendarza, aby zarządzać planem.</p>
-          </div>
-          <span class="month-chip" id="selected-day-chip">--</span>
-        </div>
-
-        <div class="detail-block">
-          <div class="detail-block-header">
-            <span>Plan treningowy</span>
-          </div>
-          <div id="day-plan-list" class="detail-list"></div>
-          <p id="day-plan-empty" class="empty-state">Brak zaplanowanych treningów na ten dzień.</p>
-        </div>
-
-        <div class="detail-block">
-          <div class="detail-block-header">
-            <span>Aktywności dodatkowe</span>
-          </div>
-          <div id="day-extra-list" class="detail-list"></div>
-          <p id="day-extra-empty" class="empty-state">Dodaj krótkie działania lub przypomnienia.</p>
-        </div>
-
         <div class="detail-actions">
           <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj treningi</button>
           <button id="add-extra-btn" class="btn ghost"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
         </div>
-      </div>
+      </section>
+    </div>
 
-      <div class="card priorities-card">
+    <section class="card calendar-card">
+      <div class="card-header">
+        <div>
+          <h3>Harmonogram miesięczny</h3>
+          <p class="muted tiny">Pełny miesiąc w jednym widoku</p>
+        </div>
+        <div class="calendar-legend">
+          <span class="legend-tag gym">Siłownia</span>
+          <span class="legend-tag running">Bieganie</span>
+          <span class="legend-tag reading">Czytanie</span>
+          <span class="legend-tag extra">Dodatkowe</span>
+          <span class="legend-tag vacation">Urlop</span>
+        </div>
+      </div>
+      <div class="calendar-weekdays">
+        <span>Pon</span><span>Wt</span><span>Śr</span><span>Czw</span><span>Pt</span><span>Sob</span><span>Niedz</span>
+      </div>
+      <div id="calendar-grid" class="calendar-grid"></div>
+    </section>
+
+    <section class="card upcoming-card">
+      <div class="card-header">
+        <div>
+          <h3>Najbliższe działania</h3>
+          <p class="muted tiny">Plan na kolejne 7 dni</p>
+        </div>
+      </div>
+      <ul id="upcoming-list" class="upcoming-list"></ul>
+      <p id="upcoming-empty" class="empty-state">Brak zaplanowanych aktywności w nadchodzącym tygodniu.</p>
+    </section>
+
+    <div class="bottom-grid">
+      <section class="card priorities-card">
         <div class="card-header">
           <div>
             <h3>Priorytety miesiąca</h3>
@@ -620,41 +751,31 @@ a { color: inherit; text-decoration: none; }
         <ul id="priority-list" class="priority-list"></ul>
         <p id="priority-empty" class="empty-state">Ustal maksymalnie trzy kluczowe priorytety, które dociągniesz do końca miesiąca.</p>
         <button id="priority-add-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
-      </div>
+      </section>
 
-      <div class="card analytics-card">
+      <section class="card heatmap-card">
         <div class="card-header">
           <div>
-            <h3>Postęp celów</h3>
-            <p class="muted tiny">Porównanie z celami tygodniowymi</p>
+            <h3>Historia aktywności</h3>
+            <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
           </div>
+          <span class="month-chip" id="heatmap-year-label">--</span>
         </div>
-        <div id="goal-progress-list" class="goal-progress-list"></div>
-      </div>
-    </aside>
+        <div id="heatmap" class="heatmap"></div>
+        <div class="heatmap-legend">
+          <span>Brak</span>
+          <div class="heatmap-legend-scale">
+            <span data-level="0"></span>
+            <span data-level="1"></span>
+            <span data-level="2"></span>
+            <span data-level="3"></span>
+            <span data-level="4"></span>
+          </div>
+          <span>Intensywnie</span>
+        </div>
+      </section>
+    </div>
   </main>
-
-  <div class="card heatmap-card">
-    <div class="card-header">
-      <div>
-        <h3>Historia aktywności</h3>
-        <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
-      </div>
-      <span class="month-chip" id="heatmap-year-label">--</span>
-    </div>
-    <div id="heatmap" class="heatmap"></div>
-    <div class="heatmap-legend">
-      <span>Brak</span>
-      <div class="heatmap-legend-scale">
-        <span data-level="0"></span>
-        <span data-level="1"></span>
-        <span data-level="2"></span>
-        <span data-level="3"></span>
-        <span data-level="4"></span>
-      </div>
-      <span>Intensywnie</span>
-    </div>
-  </div>
 </div>
 
 <div id="modal-overlay" class="modal-overlay">
@@ -702,8 +823,9 @@ const ACTIVITY_TAG_SHORT = { gym: 'Siła', running: 'Bieg', reading: 'Czyt.' };
 const ACTIVITY_UNIT_SHORT = { running: 'km', reading: 'str.' };
 const MAX_CALENDAR_TAGS = 4;
 const DEFAULT_PLANNING_META = 'Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.';
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-let state = { activities: {}, extras: {}, priorities: {} };
+let state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
 let currentMonth = startOfMonth(new Date());
 let selectedDate = toYYYYMMDD(new Date());
 let planningMode = null;
@@ -807,6 +929,89 @@ function ensurePriorityMonth(monthKey) {
   if (!state.priorities[monthKey]) state.priorities[monthKey] = [];
 }
 
+function isVacationDay(dateString) {
+  return Boolean(state.vacations && state.vacations[dateString]);
+}
+
+function toggleVacationDay(dateString) {
+  if (!state.vacations) state.vacations = {};
+  if (isVacationDay(dateString)) {
+    delete state.vacations[dateString];
+  } else {
+    state.vacations[dateString] = true;
+  }
+  saveState();
+  render();
+}
+
+let dragPayload = null;
+
+function enableDrag(element, payload) {
+  if (!element) return;
+  element.setAttribute('draggable', 'true');
+  element.addEventListener('dragstart', event => {
+    dragPayload = payload;
+    element.classList.add('dragging');
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      try {
+        event.dataTransfer.setData('application/json', JSON.stringify(payload));
+      } catch (error) {
+        // ignore unsupported MIME
+      }
+    }
+  });
+  element.addEventListener('dragend', () => {
+    dragPayload = null;
+    element.classList.remove('dragging');
+  });
+}
+
+function resolveDragPayload(event) {
+  if (dragPayload) return dragPayload;
+  if (!event || !event.dataTransfer) return null;
+  try {
+    const data = event.dataTransfer.getData('application/json');
+    if (data) {
+      return JSON.parse(data);
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+function movePlannedItem(payload, targetDate) {
+  if (!payload || !targetDate || payload.sourceDate === targetDate) return;
+  ensureDay(payload.sourceDate);
+  ensureDay(targetDate);
+  let moved = false;
+  if (payload.itemType === 'activity') {
+    const sourceList = state.activities[payload.sourceDate] || [];
+    const index = sourceList.findIndex(item => item.id === payload.id);
+    if (index > -1) {
+      const [item] = sourceList.splice(index, 1);
+      state.activities[targetDate].push(item);
+      moved = true;
+    }
+  } else if (payload.itemType === 'extra') {
+    const sourceList = state.extras[payload.sourceDate] || [];
+    const index = sourceList.findIndex(item => item.id === payload.id);
+    if (index > -1) {
+      const [item] = sourceList.splice(index, 1);
+      state.extras[targetDate].push(item);
+      moved = true;
+    }
+  }
+  if (moved) {
+    if (state.vacations && state.vacations[targetDate] && (state.activities[targetDate].length > 0 || state.extras[targetDate].length > 0)) {
+      delete state.vacations[targetDate];
+    }
+    saveState();
+    render();
+  }
+}
+
 function sameMonth(date, reference) {
   return date.getFullYear() === reference.getFullYear() && date.getMonth() === reference.getMonth();
 }
@@ -826,7 +1031,7 @@ function getISOWeekStart(year, week) {
 }
 
 function loadState() {
-  state = { activities: {}, extras: {}, priorities: {} };
+  state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
   planningMode = null;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -836,10 +1041,11 @@ function loadState() {
         state.activities = parsed.activities && typeof parsed.activities === 'object' ? parsed.activities : {};
         state.extras = parsed.extras && typeof parsed.extras === 'object' ? parsed.extras : {};
         state.priorities = parsed.priorities && typeof parsed.priorities === 'object' ? parsed.priorities : {};
+        state.vacations = parsed.vacations && typeof parsed.vacations === 'object' ? parsed.vacations : {};
       }
     }
   } catch (error) {
-    state = { activities: {}, extras: {}, priorities: {} };
+    state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
   }
   migrateLegacyState();
 }
@@ -1097,14 +1303,82 @@ function calculateWeeklyGoalStats(referenceDate) {
   return { goalPercents, averageGoalPercent, range: { start: weekStart, end: weekEnd } };
 }
 
+function getRelativeLabel(targetDate, today) {
+  const diff = Math.round((targetDate.getTime() - today.getTime()) / DAY_MS);
+  if (diff === 0) return 'Dziś';
+  if (diff === 1) return 'Jutro';
+  if (diff === 2) return 'Pojutrze';
+  if (diff > 2 && diff < 7) return `Za ${diff} dni`;
+  if (diff === -1) return 'Wczoraj';
+  if (diff < -1 && diff > -7) return `${Math.abs(diff)} dni temu`;
+  return targetDate.toLocaleDateString('pl-PL', { weekday: 'short', day: '2-digit', month: 'short' });
+}
+
+function calculateUpcomingWindow() {
+  const today = normalizeDate(new Date());
+  const horizon = addDays(today, 6);
+  const items = [];
+
+  Object.entries(state.activities).forEach(([dateString, activities]) => {
+    const date = parseDate(dateString);
+    const normalized = normalizeDate(date);
+    if (normalized < today || normalized > horizon) return;
+    activities.forEach(activity => {
+      if (!activity || activity.completed) return;
+      const goal = GOAL_DEFINITIONS[activity.type];
+      if (!goal) return;
+      let label = goal.label;
+      if (activity.type !== 'gym' && activity.plannedValue) {
+        label += ` • ${Number(activity.plannedValue).toLocaleString('pl-PL')} ${goal.unit}`;
+      }
+      items.push({
+        type: activity.type,
+        label,
+        badge: 'Trening',
+        icon: goal.icon || 'activity',
+        date: normalized,
+        dateLabel: formatDateWithDay(normalized),
+        relative: getRelativeLabel(normalized, today)
+      });
+    });
+  });
+
+  Object.entries(state.extras).forEach(([dateString, extras]) => {
+    const date = parseDate(dateString);
+    const normalized = normalizeDate(date);
+    if (normalized < today || normalized > horizon) return;
+    extras.forEach(extra => {
+      if (!extra || extra.completed) return;
+      items.push({
+        type: 'extra',
+        label: extra.title,
+        badge: EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność',
+        icon: 'sparkles',
+        date: normalized,
+        dateLabel: formatDateWithDay(normalized),
+        relative: getRelativeLabel(normalized, today)
+      });
+    });
+  });
+
+  items.sort((a, b) => {
+    const diff = a.date - b.date;
+    if (diff !== 0) return diff;
+    return a.label.localeCompare(b.label);
+  });
+
+  return items;
+}
+
 function render() {
   ensureSelectionInMonth();
   const monthStats = calculateMonthlyStats(currentMonth);
   const weekStats = calculateWeeklyGoalStats(parseDate(selectedDate));
-  renderHeader(monthStats, weekStats);
+  const upcomingWindow = calculateUpcomingWindow();
+  renderHeader(monthStats, weekStats, upcomingWindow);
   renderCalendar();
   renderDayDetail();
-  renderUpcoming(monthStats.upcoming);
+  renderUpcoming(upcomingWindow);
   renderPriorities();
   renderGoalProgress(weekStats.goalPercents);
   renderHeatmap();
@@ -1112,7 +1386,7 @@ function render() {
   lucide.createIcons();
 }
 
-function renderHeader(monthStats, weekStats) {
+function renderHeader(monthStats, weekStats, upcomingWindow) {
   const monthLabel = formatMonth(currentMonth);
   document.getElementById('header-month-chip').textContent = monthLabel;
   document.getElementById('current-month-label').textContent = monthLabel;
@@ -1127,9 +1401,10 @@ function renderHeader(monthStats, weekStats) {
   }
   document.getElementById('metric-plan-completion').textContent = `${monthStats.completedCount}/${monthStats.plannedCount}`;
   document.getElementById('metric-active-days').textContent = `${monthStats.activeDays}/${monthStats.totalDays}`;
-  if (monthStats.nextActivity) {
-    document.getElementById('metric-next-activity').textContent = monthStats.nextActivity.label;
-    document.getElementById('metric-next-activity-date').textContent = monthStats.nextActivity.dateLabel;
+  const metricNext = upcomingWindow && upcomingWindow.length ? upcomingWindow[0] : monthStats.nextActivity;
+  if (metricNext) {
+    document.getElementById('metric-next-activity').textContent = metricNext.label;
+    document.getElementById('metric-next-activity-date').textContent = metricNext.relative || metricNext.dateLabel;
   } else {
     document.getElementById('metric-next-activity').textContent = 'Brak';
     document.getElementById('metric-next-activity-date').textContent = '--';
@@ -1147,6 +1422,7 @@ function renderCalendar() {
     ensureDay(dateString);
     const activities = state.activities[dateString] || [];
     const extras = state.extras[dateString] || [];
+    const vacationDay = isVacationDay(dateString);
     const plannedCount = activities.length + extras.length;
     const completedCount = activities.filter(a => a.completed).length + extras.filter(e => e.completed).length;
 
@@ -1155,9 +1431,10 @@ function renderCalendar() {
     if (date.getMonth() !== currentMonth.getMonth()) cell.classList.add('calendar-day--other-month');
     if (dateString === selectedDate) cell.classList.add('calendar-day--selected');
     if (normalizeDate(date).getTime() === today.getTime()) cell.classList.add('calendar-day--today');
-    if (plannedCount === 0) cell.classList.add('calendar-day--empty');
-    else if (completedCount === 0) cell.classList.add('calendar-day--planned');
-    else cell.classList.add('calendar-day--completed');
+    if (vacationDay) cell.classList.add('calendar-day--vacation');
+    if (!vacationDay && plannedCount === 0) cell.classList.add('calendar-day--empty');
+    else if (plannedCount > 0 && completedCount === 0) cell.classList.add('calendar-day--planned');
+    else if (plannedCount > 0) cell.classList.add('calendar-day--completed');
 
     const header = document.createElement('div');
     header.className = 'calendar-day-header';
@@ -1183,21 +1460,38 @@ function renderCalendar() {
       tagItems.push({
         type: activity.type,
         text: getActivityTagText(activity),
-        tooltip: formatPlanningSummary(activity.type, activity.plannedValue || activity.loggedValue)
+        tooltip: formatPlanningSummary(activity.type, activity.plannedValue || activity.loggedValue),
+        itemType: 'activity',
+        id: activity.id,
+        draggable: true
       });
     });
     extras.forEach(extra => {
       tagItems.push({
         type: 'extra',
         text: getExtraTagText(extra),
-        tooltip: (extra.title || '').trim() || EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność dodatkowa'
+        tooltip: (extra.title || '').trim() || EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność dodatkowa',
+        itemType: 'extra',
+        id: extra.id,
+        draggable: true
       });
     });
+    if (vacationDay) {
+      tagItems.unshift({
+        type: 'vacation',
+        text: 'Urlop',
+        tooltip: 'Dzień wolny od planów',
+        draggable: false
+      });
+    }
     tagItems.slice(0, MAX_CALENDAR_TAGS).forEach(tag => {
       const pill = document.createElement('span');
       pill.className = `activity-tag ${tag.type}`;
       pill.textContent = tag.text;
       pill.title = tag.tooltip || tag.text;
+      if (tag.draggable !== false && tag.itemType && tag.id) {
+        enableDrag(pill, { itemType: tag.itemType, id: tag.id, sourceDate: dateString });
+      }
       tags.appendChild(pill);
     });
     if (tagItems.length > MAX_CALENDAR_TAGS) {
@@ -1213,13 +1507,35 @@ function renderCalendar() {
     footer.className = 'calendar-day-footer';
     const done = document.createElement('span');
     done.className = 'calendar-footer-label';
-    done.textContent = `${completedCount} ukończ.`;
+    done.textContent = vacationDay && plannedCount === 0 ? 'Urlop' : `${completedCount} ukończ.`;
     const remaining = document.createElement('span');
     const openCount = Math.max(0, plannedCount - completedCount);
     remaining.textContent = openCount > 0 ? `${openCount} otwarte` : '';
     footer.appendChild(done);
     footer.appendChild(remaining);
     cell.appendChild(footer);
+
+    const handleDragTarget = (event) => {
+      const payload = resolveDragPayload(event);
+      if (!payload || payload.sourceDate === dateString) return;
+      event.preventDefault();
+      cell.classList.add('calendar-day--drag-over');
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+    };
+
+    cell.addEventListener('dragover', handleDragTarget);
+    cell.addEventListener('dragenter', handleDragTarget);
+    cell.addEventListener('dragleave', (event) => {
+      if (event.relatedTarget && cell.contains(event.relatedTarget)) return;
+      cell.classList.remove('calendar-day--drag-over');
+    });
+    cell.addEventListener('drop', (event) => {
+      event.preventDefault();
+      cell.classList.remove('calendar-day--drag-over');
+      const payload = resolveDragPayload(event);
+      if (!payload || payload.sourceDate === dateString) return;
+      movePlannedItem(payload, dateString);
+    });
 
     cell.addEventListener('click', () => {
       selectedDate = dateString;
@@ -1271,11 +1587,31 @@ function renderDayDetail() {
   const date = parseDate(selectedDate);
   const activities = state.activities[selectedDate] || [];
   const extras = state.extras[selectedDate] || [];
+  const vacationDay = isVacationDay(selectedDate);
   const completedCount = activities.filter(a => a.completed).length + extras.filter(e => e.completed).length;
   const total = activities.length + extras.length;
   document.getElementById('selected-day-title').textContent = date.toLocaleDateString('pl-PL', { weekday: 'long', day: 'numeric', month: 'long' });
-  document.getElementById('selected-day-summary').textContent = total > 0 ? `Zaplanowane: ${total} · Ukończone: ${completedCount}` : 'Brak zaplanowanych aktywności na ten dzień.';
+  const summary = vacationDay
+    ? (total > 0
+      ? `Urlop · Zaplanowane: ${total} · Ukończone: ${completedCount}`
+      : 'Dzień urlopowy. Nie planujesz aktywności.')
+    : (total > 0
+      ? `Zaplanowane: ${total} · Ukończone: ${completedCount}`
+      : 'Brak zaplanowanych aktywności na ten dzień.');
+  document.getElementById('selected-day-summary').textContent = summary;
   document.getElementById('selected-day-chip').textContent = date.toLocaleDateString('pl-PL', { day: '2-digit', month: 'short' }).replace('.', '').toUpperCase();
+  const vacationNote = document.getElementById('vacation-note');
+  if (vacationNote) vacationNote.style.display = vacationDay ? 'block' : 'none';
+  const vacationBtn = document.getElementById('toggle-vacation-btn');
+  if (vacationBtn) {
+    if (vacationDay) {
+      vacationBtn.classList.add('active');
+      vacationBtn.innerHTML = '<i data-lucide="sun" class="icon"></i>Usuń urlop';
+    } else {
+      vacationBtn.classList.remove('active');
+      vacationBtn.innerHTML = '<i data-lucide="plane" class="icon"></i>Oznacz urlop';
+    }
+  }
 
   renderDayActivities(activities);
   renderDayExtras(extras);
@@ -1317,6 +1653,7 @@ function renderDayActivities(activities) {
         <button class="action-btn danger" data-action="delete-activity" data-day="${selectedDate}" data-activity-id="${activity.id}">Usuń</button>
       </div>
     `;
+    enableDrag(item, { itemType: 'activity', id: activity.id, sourceDate: selectedDate });
     list.appendChild(item);
   });
 }
@@ -1347,6 +1684,7 @@ function renderDayExtras(extras) {
         <button class="action-btn danger" data-action="delete-extra" data-day="${selectedDate}" data-extra-id="${extra.id}">Usuń</button>
       </div>
     `;
+    enableDrag(item, { itemType: 'extra', id: extra.id, sourceDate: selectedDate });
     list.appendChild(item);
   });
 }
@@ -1355,18 +1693,19 @@ function renderUpcoming(upcoming) {
   const list = document.getElementById('upcoming-list');
   const empty = document.getElementById('upcoming-empty');
   list.innerHTML = '';
-  const limited = upcoming.slice(0, 6);
-  if (!limited.length) {
+  if (!upcoming.length) {
     empty.style.display = 'block';
     return;
   }
   empty.style.display = 'none';
-  limited.forEach(item => {
+  upcoming.forEach(item => {
     const li = document.createElement('li');
     li.className = 'upcoming-item';
+    const whenLabel = item.relative || item.dateLabel;
     li.innerHTML = `
       <div class="detail-icon ${item.type === 'extra' ? 'extra' : item.type}"><i data-lucide="${item.icon}" class="icon"></i></div>
-      <div>
+      <div class="upcoming-body">
+        <span class="upcoming-when">${whenLabel}</span>
         <strong>${item.label}</strong>
         <div class="meta">
           <span class="badge">${item.badge}</span>
@@ -1518,6 +1857,7 @@ function addTraining(dateString, type, plannedValue) {
     completed: false,
     createdAt: Date.now()
   });
+  if (state.vacations && state.vacations[dateString]) delete state.vacations[dateString];
   saveState();
   render();
 }
@@ -1531,6 +1871,7 @@ function addExtra(dateString, title, category) {
     completed: false,
     createdAt: Date.now()
   });
+  if (state.vacations && state.vacations[dateString]) delete state.vacations[dateString];
   saveState();
   render();
 }
@@ -1828,6 +2169,7 @@ function setupEventListeners() {
   });
   document.getElementById('stop-planning-btn').addEventListener('click', () => stopPlanningMode());
   document.getElementById('add-extra-btn').addEventListener('click', showAddExtraModal);
+  document.getElementById('toggle-vacation-btn').addEventListener('click', () => toggleVacationDay(selectedDate));
   document.getElementById('priority-add-btn').addEventListener('click', showPriorityModal);
 
   document.getElementById('day-plan-list').addEventListener('click', (event) => {

--- a/trainings.html
+++ b/trainings.html
@@ -155,13 +155,6 @@ a { color: inherit; text-decoration: none; }
   padding: 14px 16px;
 }
 
-.bottom-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
-  gap: 20px;
-  align-items: stretch;
-}
-
 .page-header {
   display: flex;
   flex-direction: column;
@@ -277,7 +270,9 @@ a { color: inherit; text-decoration: none; }
 
 .metric-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); font-weight: 600; }
 .metric-value { font-size: 22px; font-weight: 700; }
-.metric-sub { font-size: 11px; color: var(--muted); }
+.metric-sub { font-size: 11px; color: var(--muted); display: block; }
+.metric-sub--stacked { display: flex; flex-direction: column; gap: 2px; }
+.metric-subline { display: block; }
 
 .metric-donut {
   position: relative;
@@ -304,8 +299,9 @@ a { color: inherit; text-decoration: none; }
 .metric-donut .donut-value {
   stroke: var(--primary);
   stroke-linecap: round;
-  stroke-dasharray: 0 100;
-  transition: stroke-dasharray 0.4s ease;
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+  transition: stroke-dashoffset 0.4s ease;
 }
 
 .metric-donut span {
@@ -514,14 +510,6 @@ a { color: inherit; text-decoration: none; }
 .calendar-card--planning { border-color: var(--primary); box-shadow: var(--shadow-sm); }
 .calendar-grid.is-planning .calendar-day { cursor: crosshair; }
 
-.upcoming-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
-.upcoming-item { display: flex; align-items: flex-start; gap: 14px; padding: 14px 16px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(248, 250, 252, 0.7); }
-.upcoming-body { display: flex; flex-direction: column; gap: 6px; }
-.upcoming-when { font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--primary); }
-.upcoming-item strong { display: block; font-size: 13px; }
-.upcoming-item .meta { display: flex; gap: 8px; font-size: 11px; color: var(--muted); flex-wrap: wrap; }
-.upcoming-item .badge { background: rgba(37, 99, 235, 0.12); color: var(--primary); border-radius: 999px; padding: 2px 8px; font-weight: 600; }
-
 .empty-state {
   font-size: 12px;
   color: var(--muted);
@@ -578,17 +566,6 @@ a { color: inherit; text-decoration: none; }
 
 .detail-actions { display: flex; gap: 10px; margin-top: 18px; flex-wrap: wrap; }
 
-.priority-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
-.priority-item { display: flex; justify-content: space-between; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.3); background: rgba(248, 250, 252, 0.8); transition: var(--transition); }
-.priority-item.completed { background: var(--success-soft); border-color: var(--success-border); }
-.priority-body { display: flex; flex-direction: column; gap: 4px; }
-.priority-title { font-weight: 600; font-size: 13px; }
-.priority-meta { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
-.priority-item.completed .priority-title { text-decoration: line-through; }
-.priority-actions { display: flex; gap: 8px; }
-.priority-btn { border: none; background: rgba(148, 163, 184, 0.16); border-radius: 10px; padding: 6px 8px; cursor: pointer; color: var(--muted); display: inline-flex; align-items: center; justify-content: center; transition: var(--transition); }
-.priority-btn:hover { background: rgba(37, 99, 235, 0.15); color: var(--primary); }
-
 .goal-progress-list { display: flex; flex-direction: column; gap: 14px; }
 .goal-progress-item { display: flex; flex-direction: column; gap: 8px; }
 .goal-progress-label { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
@@ -598,7 +575,7 @@ a { color: inherit; text-decoration: none; }
 .goal-progress-bar span { display: block; height: 100%; border-radius: 999px; transition: width .3s ease; }
 
 .heatmap-card { display: flex; flex-direction: column; gap: 16px; }
-.heatmap { display: flex; gap: 3px; overflow: hidden; padding-bottom: 8px; flex-wrap: nowrap; }
+.heatmap { display: flex; gap: 3px; overflow-x: auto; padding-bottom: 8px; flex-wrap: nowrap; }
 .heatmap-week { display: grid; grid-template-rows: repeat(7, 11px) auto; gap: 3px; align-items: center; }
 .heatmap-cell { width: 11px; height: 11px; border-radius: 3px; background: #e2e8f0; }
 .heatmap-cell[data-level="0"] { background: #e2e8f0; }
@@ -731,21 +708,27 @@ a { color: inherit; text-decoration: none; }
             <div class="metric-text">
               <span class="metric-label">Realizacja celów</span>
               <span class="metric-value" id="metric-goal-progress">0%</span>
-              <span class="metric-sub" id="metric-goal-progress-sub">Cele tygodniowe</span>
+              <div class="metric-sub metric-sub--stacked" id="metric-goal-progress-sub">
+                <span class="metric-subline">Cele tygodniowe</span>
+                <span class="metric-subline">--</span>
+              </div>
             </div>
           </div>
           <div class="metric-card metric-card--donut">
             <div class="metric-donut">
               <svg viewBox="0 0 36 36" aria-hidden="true">
                 <circle class="donut-bg" cx="18" cy="18" r="16"></circle>
-                <circle class="donut-value" id="metric-weekly-complete-circle" cx="18" cy="18" r="16" stroke-dasharray="0 100"></circle>
+                <circle class="donut-value" id="metric-weekly-complete-circle" cx="18" cy="18" r="16"></circle>
               </svg>
               <span id="metric-weekly-complete-percent">0%</span>
             </div>
             <div class="metric-text">
               <span class="metric-label">Zaliczone tygodnie</span>
               <span class="metric-value" id="metric-weekly-complete-count">0/0</span>
-              <span class="metric-sub" id="metric-weekly-complete-sub">Rok --</span>
+              <div class="metric-sub metric-sub--stacked" id="metric-weekly-complete-sub">
+                <span class="metric-subline">Rok --</span>
+                <span class="metric-subline">--</span>
+              </div>
             </div>
           </div>
           <div class="metric-card">
@@ -766,8 +749,9 @@ a { color: inherit; text-decoration: none; }
             <div class="metric-visual" id="metric-next-activity-visual"><i data-lucide="calendar" class="icon"></i></div>
             <div class="metric-text">
               <span class="metric-label">Najbliższa aktywność</span>
-              <span class="metric-value" id="metric-next-activity">Brak</span>
-              <span class="metric-sub" id="metric-next-activity-date">--</span>
+              <div class="metric-sub metric-sub--stacked">
+                <span class="metric-subline" id="metric-next-activity-date">Brak terminu</span>
+              </div>
             </div>
           </div>
         </div>
@@ -850,52 +834,27 @@ a { color: inherit; text-decoration: none; }
       <div id="calendar-grid" class="calendar-grid"></div>
     </section>
 
-    <section class="card upcoming-card">
+    <section class="card heatmap-card">
       <div class="card-header">
         <div>
-          <h3>Najbliższe działania</h3>
-          <p class="muted tiny">Plan na kolejne 7 dni</p>
+          <h3>Historia aktywności</h3>
+          <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
         </div>
+        <span class="month-chip" id="heatmap-year-label">--</span>
       </div>
-      <ul id="upcoming-list" class="upcoming-list"></ul>
-      <p id="upcoming-empty" class="empty-state">Brak zaplanowanych aktywności w nadchodzącym tygodniu.</p>
+      <div id="heatmap" class="heatmap"></div>
+      <div class="heatmap-legend">
+        <span>Brak</span>
+        <div class="heatmap-legend-scale">
+          <span data-level="0"></span>
+          <span data-level="1"></span>
+          <span data-level="2"></span>
+          <span data-level="3"></span>
+          <span data-level="4"></span>
+        </div>
+        <span>Intensywnie</span>
+      </div>
     </section>
-
-    <div class="bottom-grid">
-      <section class="card priorities-card">
-        <div class="card-header">
-          <div>
-            <h3>Priorytety miesiąca</h3>
-            <p class="muted tiny" id="priority-month-label">--</p>
-          </div>
-        </div>
-        <ul id="priority-list" class="priority-list"></ul>
-        <p id="priority-empty" class="empty-state">Ustal maksymalnie trzy kluczowe priorytety, które dociągniesz do końca miesiąca.</p>
-        <button id="priority-add-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
-      </section>
-
-      <section class="card heatmap-card">
-        <div class="card-header">
-          <div>
-            <h3>Historia aktywności</h3>
-            <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
-          </div>
-          <span class="month-chip" id="heatmap-year-label">--</span>
-        </div>
-        <div id="heatmap" class="heatmap"></div>
-        <div class="heatmap-legend">
-          <span>Brak</span>
-          <div class="heatmap-legend-scale">
-            <span data-level="0"></span>
-            <span data-level="1"></span>
-            <span data-level="2"></span>
-            <span data-level="3"></span>
-            <span data-level="4"></span>
-          </div>
-          <span>Intensywnie</span>
-        </div>
-      </section>
-    </div>
   </main>
 </div>
 
@@ -930,16 +889,6 @@ const EXTRA_CATEGORY_LABELS = EXTRA_ACTIVITY_CATEGORIES.reduce((acc, item) => {
   acc[item.value] = item.label;
   return acc;
 }, {});
-const PRIORITY_IMPACT_OPTIONS = [
-  { value: 'high', label: 'Wysoki wpływ' },
-  { value: 'medium', label: 'Średni wpływ' },
-  { value: 'low', label: 'Lekki wpływ' }
-];
-const PRIORITY_IMPACT_LABELS = PRIORITY_IMPACT_OPTIONS.reduce((acc, opt) => {
-  acc[opt.value] = opt.label;
-  return acc;
-}, {});
-const MAX_PRIORITIES = 3;
 const ACTIVITY_TAG_SHORT = { gym: 'Siła', running: 'Bieg', reading: 'Czyt.' };
 const ACTIVITY_UNIT_SHORT = { running: 'km', reading: 'str.' };
 const MAX_CALENDAR_TAGS = 4;
@@ -947,7 +896,7 @@ const DEFAULT_PLANNING_META = 'Wybierz typ treningu, aby rozpocząć tryb planow
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DONUT_CIRCUMFERENCE = 2 * Math.PI * 16;
 
-let state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
+let state = { activities: {}, extras: {}, vacations: {} };
 let currentMonth = startOfMonth(new Date());
 let selectedDate = toYYYYMMDD(new Date());
 let planningMode = null;
@@ -1045,10 +994,6 @@ function startOfWeek(date) {
 function ensureDay(dateString) {
   if (!state.activities[dateString]) state.activities[dateString] = [];
   if (!state.extras[dateString]) state.extras[dateString] = [];
-}
-
-function ensurePriorityMonth(monthKey) {
-  if (!state.priorities[monthKey]) state.priorities[monthKey] = [];
 }
 
 function isVacationDay(dateString) {
@@ -1186,7 +1131,7 @@ function getISOWeekInfo(date) {
 }
 
 function loadState() {
-  state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
+  state = { activities: {}, extras: {}, vacations: {} };
   planningMode = null;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -1195,12 +1140,11 @@ function loadState() {
       if (parsed && typeof parsed === 'object') {
         state.activities = parsed.activities && typeof parsed.activities === 'object' ? parsed.activities : {};
         state.extras = parsed.extras && typeof parsed.extras === 'object' ? parsed.extras : {};
-        state.priorities = parsed.priorities && typeof parsed.priorities === 'object' ? parsed.priorities : {};
         state.vacations = parsed.vacations && typeof parsed.vacations === 'object' ? parsed.vacations : {};
       }
     }
   } catch (error) {
-    state = { activities: {}, extras: {}, priorities: {}, vacations: {} };
+    state = { activities: {}, extras: {}, vacations: {} };
   }
   migrateLegacyState();
 }
@@ -1293,21 +1237,6 @@ function migrateLegacyState() {
           });
         });
 
-        const priorities = Array.isArray(weekData.priorities) ? weekData.priorities : [];
-        priorities.forEach(priority => {
-          if (!priority || !priority.title) return;
-          const monthKey = getMonthKey(mapDayToDate(1));
-          ensurePriorityMonth(monthKey);
-          if (state.priorities[monthKey].some(item => item.id === priority.id)) return;
-          state.priorities[monthKey].push({
-            id: priority.id || `prio_${Date.now()}_${Math.random().toString(16).slice(2)}`,
-            title: priority.title,
-            impact: priority.impact || 'high',
-            completed: Boolean(priority.completed),
-            createdAt: priority.createdAt || Date.now()
-          });
-          imported = true;
-        });
       });
     });
     if (imported) {
@@ -1557,8 +1486,6 @@ function render() {
   renderHeader(monthStats, weekStats, upcomingWindow, yearStats);
   renderCalendar();
   renderDayDetail();
-  renderUpcoming(upcomingWindow);
-  renderPriorities();
   renderGoalProgress(weekStats.goalPercents);
   renderHeatmap();
   renderPlanningIndicator();
@@ -1575,52 +1502,59 @@ function renderHeader(monthStats, weekStats, upcomingWindow, yearStats) {
   else todayButton.style.display = 'inline-flex';
   document.getElementById('metric-goal-progress').textContent = `${weekStats.averageGoalPercent}%`;
   const goalProgressSub = document.getElementById('metric-goal-progress-sub');
-  if (goalProgressSub && weekStats && weekStats.range) {
-    goalProgressSub.textContent = `Cele tygodniowe · ${formatRange(weekStats.range.start, weekStats.range.end)}`;
+  if (goalProgressSub) {
+    if (weekStats && weekStats.range) {
+      goalProgressSub.innerHTML = `<span class="metric-subline">Cele tygodniowe</span><span class="metric-subline">${formatRange(weekStats.range.start, weekStats.range.end)}</span>`;
+    } else {
+      goalProgressSub.innerHTML = `<span class="metric-subline">Cele tygodniowe</span><span class="metric-subline">--</span>`;
+    }
   }
   document.getElementById('metric-plan-completion').textContent = `${monthStats.completedCount}/${monthStats.plannedCount}`;
   document.getElementById('metric-active-days').textContent = `${monthStats.activeDays}/${monthStats.totalDays}`;
-  if (yearStats) {
-    const countEl = document.getElementById('metric-weekly-complete-count');
-    if (countEl) {
-      const completedLabel = `${yearStats.completedWeeks.toLocaleString('pl-PL')}/${yearStats.totalWeeks.toLocaleString('pl-PL')}`;
-      countEl.textContent = completedLabel;
+  const countEl = document.getElementById('metric-weekly-complete-count');
+  if (countEl && yearStats) {
+    const completedLabel = `${yearStats.completedWeeks.toLocaleString('pl-PL')}/${yearStats.totalWeeks.toLocaleString('pl-PL')}`;
+    countEl.textContent = completedLabel;
+  } else if (countEl) {
+    countEl.textContent = '0/0';
+  }
+  const subEl = document.getElementById('metric-weekly-complete-sub');
+  if (subEl) {
+    if (yearStats && yearStats.totalWeeks > 0) {
+      const uptoWeek = Math.max(0, yearStats.currentWeek - 1);
+      subEl.innerHTML = `<span class="metric-subline">Rok ${yearStats.isoYear}</span><span class="metric-subline">Do tygodnia ${uptoWeek.toLocaleString('pl-PL')}</span>`;
+    } else if (yearStats) {
+      subEl.innerHTML = `<span class="metric-subline">Rok ${yearStats.isoYear}</span><span class="metric-subline">Start sezonu</span>`;
+    } else {
+      subEl.innerHTML = `<span class="metric-subline">Rok --</span><span class="metric-subline">--</span>`;
     }
-    const subEl = document.getElementById('metric-weekly-complete-sub');
-    if (subEl) {
-      if (yearStats.totalWeeks > 0) {
-        const uptoWeek = Math.max(0, yearStats.currentWeek - 1);
-        subEl.textContent = `Rok ${yearStats.isoYear} · Do tygodnia ${uptoWeek.toLocaleString('pl-PL')}`;
-      } else {
-        subEl.textContent = `Rok ${yearStats.isoYear} · Start sezonu`;
-      }
-    }
-    const percentEl = document.getElementById('metric-weekly-complete-percent');
-    if (percentEl) percentEl.textContent = `${yearStats.percent.toLocaleString('pl-PL')}%`;
-    const circle = document.getElementById('metric-weekly-complete-circle');
-    if (circle) {
-      const safePercent = Math.max(0, Math.min(100, yearStats.percent));
-      const dash = (safePercent / 100) * DONUT_CIRCUMFERENCE;
-      circle.setAttribute('stroke-dasharray', `${dash} ${DONUT_CIRCUMFERENCE - dash}`);
-    }
+  }
+  const percentEl = document.getElementById('metric-weekly-complete-percent');
+  if (percentEl) {
+    const value = yearStats ? yearStats.percent : 0;
+    const formatted = Number(value).toLocaleString('pl-PL', { maximumFractionDigits: 0 });
+    percentEl.textContent = `${formatted}%`;
+  }
+  const circle = document.getElementById('metric-weekly-complete-circle');
+  if (circle) {
+    const safePercent = yearStats ? Math.max(0, Math.min(100, yearStats.percent)) : 0;
+    const dashOffset = DONUT_CIRCUMFERENCE * (1 - safePercent / 100);
+    circle.setAttribute('stroke-dasharray', DONUT_CIRCUMFERENCE);
+    circle.setAttribute('stroke-dashoffset', dashOffset);
   }
   const metricNext = upcomingWindow && upcomingWindow.length ? upcomingWindow[0] : monthStats.nextActivity;
   const nextCard = document.getElementById('metric-next-activity-card');
   const nextVisual = document.getElementById('metric-next-activity-visual');
-  const nextLabel = document.getElementById('metric-next-activity');
   const nextDate = document.getElementById('metric-next-activity-date');
   if (metricNext) {
-    if (nextLabel) nextLabel.textContent = metricNext.label;
-    if (nextDate) nextDate.textContent = metricNext.relative || metricNext.dateLabel || '--';
+    if (nextDate) nextDate.textContent = metricNext.relative || metricNext.dateLabel || 'Najbliższe dni';
     if (nextCard) nextCard.dataset.activityType = metricNext.type || 'none';
     if (nextVisual) nextVisual.innerHTML = `<i data-lucide="${metricNext.icon || 'calendar'}" class="icon"></i>`;
   } else {
-    if (nextLabel) nextLabel.textContent = 'Brak';
-    if (nextDate) nextDate.textContent = '--';
+    if (nextDate) nextDate.textContent = 'Brak terminu';
     if (nextCard) nextCard.dataset.activityType = 'none';
     if (nextVisual) nextVisual.innerHTML = '<i data-lucide="calendar-x" class="icon"></i>';
   }
-  document.getElementById('priority-month-label').textContent = monthLabel;
 }
 
 function renderCalendar() {
@@ -1900,75 +1834,6 @@ function renderDayExtras(extras) {
   });
 }
 
-function renderUpcoming(upcoming) {
-  const list = document.getElementById('upcoming-list');
-  const empty = document.getElementById('upcoming-empty');
-  list.innerHTML = '';
-  if (!upcoming.length) {
-    empty.style.display = 'block';
-    return;
-  }
-  empty.style.display = 'none';
-  upcoming.forEach(item => {
-    const li = document.createElement('li');
-    li.className = 'upcoming-item';
-    const whenLabel = item.relative || item.dateLabel;
-    li.innerHTML = `
-      <div class="detail-icon ${item.type === 'extra' ? 'extra' : item.type}"><i data-lucide="${item.icon}" class="icon"></i></div>
-      <div class="upcoming-body">
-        <span class="upcoming-when">${whenLabel}</span>
-        <strong>${item.label}</strong>
-        <div class="meta">
-          <span class="badge">${item.badge}</span>
-          <span>${item.dateLabel}</span>
-        </div>
-      </div>
-    `;
-    list.appendChild(li);
-  });
-}
-
-function renderPriorities() {
-  const monthKey = getMonthKey(currentMonth);
-  ensurePriorityMonth(monthKey);
-  const list = document.getElementById('priority-list');
-  const empty = document.getElementById('priority-empty');
-  const addBtn = document.getElementById('priority-add-btn');
-  const items = [...state.priorities[monthKey]];
-  items.sort((a, b) => {
-    if (a.completed !== b.completed) return a.completed ? 1 : -1;
-    return (a.createdAt || 0) - (b.createdAt || 0);
-  });
-  list.innerHTML = '';
-  if (!items.length) empty.style.display = 'block';
-  else empty.style.display = 'none';
-
-  items.forEach(priority => {
-    const li = document.createElement('li');
-    li.className = 'priority-item';
-    if (priority.completed) li.classList.add('completed');
-    li.innerHTML = `
-      <div class="priority-body">
-        <span class="priority-title">${priority.title}</span>
-        <span class="priority-meta">${PRIORITY_IMPACT_LABELS[priority.impact] || ''}</span>
-      </div>
-      <div class="priority-actions">
-        <button class="priority-btn" data-action="toggle-priority" data-month-key="${monthKey}" data-priority-id="${priority.id}"><i data-lucide="${priority.completed ? 'rotate-ccw' : 'check'}" class="icon"></i></button>
-        <button class="priority-btn" data-action="delete-priority" data-month-key="${monthKey}" data-priority-id="${priority.id}"><i data-lucide="trash-2" class="icon"></i></button>
-      </div>
-    `;
-    list.appendChild(li);
-  });
-
-  if (items.length >= MAX_PRIORITIES) {
-    addBtn.disabled = true;
-    addBtn.innerHTML = '<i data-lucide="check" class="icon"></i>Limit priorytetów';
-  } else {
-    addBtn.disabled = false;
-    addBtn.innerHTML = '<i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet';
-  }
-}
-
 function renderGoalProgress(goalPercents) {
   const container = document.getElementById('goal-progress-list');
   container.innerHTML = '';
@@ -2083,37 +1948,6 @@ function addExtra(dateString, title, category) {
     createdAt: Date.now()
   });
   if (state.vacations && state.vacations[dateString]) delete state.vacations[dateString];
-  saveState();
-  render();
-}
-
-function addPriority(title, impact) {
-  const monthKey = getMonthKey(currentMonth);
-  ensurePriorityMonth(monthKey);
-  if (state.priorities[monthKey].length >= MAX_PRIORITIES) return;
-  state.priorities[monthKey].push({
-    id: `prio_${Date.now()}_${Math.random().toString(16).slice(2)}`,
-    title,
-    impact,
-    completed: false,
-    createdAt: Date.now()
-  });
-  saveState();
-  render();
-}
-
-function togglePriority(id, monthKey) {
-  const list = state.priorities[monthKey] || [];
-  const priority = list.find(p => p.id === id);
-  if (!priority) return;
-  priority.completed = !priority.completed;
-  saveState();
-  render();
-}
-
-function deletePriority(id, monthKey) {
-  if (!state.priorities[monthKey]) return;
-  state.priorities[monthKey] = state.priorities[monthKey].filter(p => p.id !== id);
   saveState();
   render();
 }
@@ -2300,26 +2134,6 @@ function showVacationRangeModal() {
   });
 }
 
-function showPriorityModal() {
-  const monthKey = getMonthKey(currentMonth);
-  ensurePriorityMonth(monthKey);
-  if (state.priorities[monthKey].length >= MAX_PRIORITIES) return;
-  showModal({
-    title: 'Nowy priorytet',
-    text: `Określ priorytet na ${formatMonth(currentMonth)}.`,
-    textarea: { placeholder: 'Opisz priorytet' },
-    options: PRIORITY_IMPACT_OPTIONS.map((opt, index) => ({ value: opt.value, label: opt.label, checked: index === 0 })),
-    buttons: [
-      { text: 'Anuluj', class: 'btn soft', action: 'close' },
-      { text: 'Dodaj', class: 'btn', action: (value, selected) => {
-          const textValue = (value || '').trim();
-          if (!textValue) return false;
-          addPriority(textValue, selected || 'high');
-        } }
-    ]
-  });
-}
-
 function showModal(config) {
   const overlay = document.getElementById('modal-overlay');
   document.getElementById('modal-title').textContent = config.title || '';
@@ -2456,7 +2270,6 @@ function setupEventListeners() {
   document.getElementById('add-extra-btn').addEventListener('click', showAddExtraModal);
   document.getElementById('plan-vacation-range-btn').addEventListener('click', showVacationRangeModal);
   document.getElementById('toggle-vacation-btn').addEventListener('click', () => toggleVacationDay(selectedDate));
-  document.getElementById('priority-add-btn').addEventListener('click', showPriorityModal);
 
   document.getElementById('day-plan-list').addEventListener('click', (event) => {
     const target = event.target.closest('[data-action]');
@@ -2478,16 +2291,6 @@ function setupEventListeners() {
     const action = target.dataset.action;
     if (action === 'toggle-extra') toggleExtra(day, id);
     if (action === 'delete-extra') deleteExtra(day, id);
-  });
-
-  document.getElementById('priority-list').addEventListener('click', (event) => {
-    const target = event.target.closest('[data-action]');
-    if (!target) return;
-    const monthKey = target.dataset.monthKey;
-    const id = target.dataset.priorityId;
-    const action = target.dataset.action;
-    if (action === 'toggle-priority') togglePriority(id, monthKey);
-    if (action === 'delete-priority') deletePriority(id, monthKey);
   });
 
   document.getElementById('modal-overlay').addEventListener('click', (event) => {

--- a/trainings.html
+++ b/trainings.html
@@ -9,394 +9,867 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
   <style>
-    :root {
-      --bg: #f8fafc; --card: #fff; --ink: #0f172a; --muted: #64748b; --line: #e2e8f0;
-      --green: #059669; --green-soft: #f0fdf4; --green-border: #a7f3d0;
-      --red: #dc2626; --red-soft: #fef2f2; --red-border: #fecaca;
-      --orange: #ea580c; --orange-soft: #fff7ed; --orange-border: #fed7aa;
-      --blue: #2563eb; --blue-soft: #eff6ff; --blue-border: #bfdbfe;
-      --purple: #7c3aed; --yellow: #ca8a04;
-      --gym-color: #5b21b6; --gym-soft: #f5f3ff; --gym-border: #ddd6fe;
-      --run-color: #047857; --run-soft: #ecfdf5; --run-border: #a7f3d0;
-      --read-color: #0369a1; --read-soft: #f0f9ff; --read-border: #bae6fd;
-      --extra-training: #9333ea; --extra-learning: #2563eb; --extra-relax: #0ea5e9;
-      --extra-home: #f97316; --extra-other: #334155;
-      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-      --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-      --transition-fast: all .2s ease-in-out;
-    }
-    *, *::before, *::after { box-sizing: border-box; }
-    body { margin: 0; min-height: 100vh; background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 20%, #f8fafc 100%); color: var(--ink); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto; font-size: 14px; line-height: 1.5; -webkit-font-smoothing: antialiased; }
-    .wrap { max-width: 1240px; margin: 0 auto; padding: 32px 24px 56px; }
-    .grid { display: grid; gap: 16px; }
-    .g-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .g-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    @media(max-width: 1024px) { .g-3, .g-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-    @media(max-width: 768px) { .g-3, .g-2 { grid-template-columns: 1fr; } }
-    
-    .card { background: var(--card); border: 1px solid rgba(148, 163, 184, 0.2); border-radius: 20px; padding: 24px; box-shadow: var(--shadow); transition: var(--transition-fast); position: relative; overflow: hidden; }
-    .card::after { content: ""; position: absolute; inset: 0; background: linear-gradient(135deg, rgba(37, 99, 235, 0.06), transparent); opacity: 0; transition: opacity .3s ease; }
-    .card:hover::after { opacity: 1; }
-    .card > * { position: relative; z-index: 1; }
-    .card:hover { box-shadow: var(--shadow-md); }
-    .title { margin: 0 0 8px 0; font-weight: 700; font-size: 18px; display: flex; align-items: center; gap: 8px; }
-    .muted { color: var(--muted); }
-    .btn { display: inline-flex; gap: 8px; align-items: center; justify-content: center; border-radius: 12px; padding: 10px 16px; border: 1px solid transparent; background: var(--ink); color: #fff; cursor: pointer; text-decoration: none; font-weight: 600; transition: var(--transition-fast); }
-    .btn:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
-    .btn.soft { background: #fff; border-color: rgba(148, 163, 184, 0.3); color: var(--ink); }
-    .btn.soft:hover { background: var(--bg); border-color: #d1d5db; }
-    .btn.ghost { background: rgba(255, 255, 255, 0.6); border-color: rgba(148, 163, 184, 0.2); color: var(--muted); }
-    .btn.ghost:hover { background: rgba(255, 255, 255, 0.95); color: var(--ink); }
-    .btn.danger { background: var(--red-soft); border-color: var(--red-border); color: var(--red); }
-    .btn.danger:hover { background: var(--red); color: #fff; }
-    .btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; box-shadow: none; }
-    .btn:disabled:hover { transform: none; box-shadow: none; }
-    
-    .progress-bar { height: 8px; background: var(--line); border-radius: 999px; overflow: hidden; margin-top: 4px; }
-    .progress-bar > div { height: 100%; transition: width .4s cubic-bezier(0.22, 1, 0.36, 1); }
-    .tiny { font-size: 12px; color: var(--muted); }
-    .row { display: flex; justify-content: space-between; align-items: center; }
 
-    /* Header */
-    .page-header { display: grid; grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr); gap: 24px; margin-bottom: 32px; align-items: stretch; }
-    @media(max-width: 1100px) { .page-header { grid-template-columns: 1fr; } }
-    .page-header-main { display: flex; flex-direction: column; gap: 18px; padding: 24px; border-radius: 22px; background: linear-gradient(135deg, rgba(59, 130, 246, 0.05) 0%, rgba(14, 165, 233, 0.03) 100%); border: 1px solid rgba(148, 163, 184, 0.2); position: relative; overflow: hidden; box-shadow: var(--shadow-sm); }
-    .page-header-main::after { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at top right, rgba(59,130,246,0.14), transparent 60%); pointer-events: none; }
-    .page-header-main > * { position: relative; z-index: 1; }
-    .header-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
-    .header-title-block { display: flex; flex-direction: column; gap: 6px; }
-    .header-title-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-    .header-title-row h1 { margin: 0; font-size: 28px; font-weight: 800; letter-spacing: -0.3px; }
-    .header-subtitle { max-width: 600px; font-size: 14px; margin: 0; }
-    .header-week-range { font-size: 13px; color: var(--muted); }
-    .week-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--blue-soft); color: var(--blue); font-size: 12px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; }
-    .header-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-    .eyebrow { text-transform: uppercase; letter-spacing: 0.12em; font-size: 11px; font-weight: 600; color: var(--blue); }
-    .header-insights { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
-    .insight-card { background: rgba(255, 255, 255, 0.8); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 16px; padding: 14px; box-shadow: var(--shadow-sm); display: flex; flex-direction: column; gap: 6px; }
-    .insight-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); font-weight: 600; }
-    .insight-value { font-size: 20px; font-weight: 700; color: var(--ink); }
-    .insight-sub { font-size: 12px; color: var(--muted); }
-    .header-kpis { display: flex; flex-direction: column; gap: 18px; padding: 24px; }
-    .kpi-item { text-align: left; display: flex; flex-direction: column; gap: 6px; }
-    .kpi-value { font-size: 24px; font-weight: 800; line-height: 1.1; }
-    .kpi-note { margin: 0; color: var(--muted); }
-    .weekly-overview-card { position: relative; overflow: visible; display: flex; flex-direction: column; gap: 20px; }
-    .overview-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
-    .overview-header h3 { margin-bottom: 0; }
-    .button-group { display: flex; gap: 8px; flex-wrap: wrap; }
-    .overview-progress { display: flex; flex-direction: column; gap: 10px; }
-    .progress-summary { display: flex; justify-content: space-between; align-items: center; }
-    .goal-grid { display: grid; gap: 16px; grid-template-columns: 1fr; }
-    .goal-card { padding: 22px; border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 18px; display: flex; flex-direction: column; gap: 12px; transition: var(--transition-fast); }
-    .goal-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
-    .goal-card .title { font-size: 16px; margin-bottom: 0; }
-    .goal-card .kpi-value { font-size: 22px; font-weight: 700; }
-    .goal-card .goal-actions { display: flex; gap: 8px; flex-wrap: wrap; }
-    .goal-card .btn { flex: 1; min-width: 140px; padding: 8px 12px; font-size: 13px; }
-    .goal-meta { font-size: 12px; color: var(--muted); margin-top: 4px; }
-    .goal-card.goal-gym { background: var(--gym-soft); border-color: var(--gym-border); }
-    .goal-card.goal-running { background: var(--run-soft); border-color: var(--run-border); }
-    .goal-card.goal-reading { background: var(--read-soft); border-color: var(--read-border); }
-    .page-layout { display: grid; grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr); gap: 24px; align-items: flex-start; }
-    .layout-main, .layout-side { display: flex; flex-direction: column; gap: 24px; }
-    @media(max-width: 1100px) { .page-layout { grid-template-columns: 1fr; } }
-    .insights-grid { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
-    .insights-grid .card { min-height: 220px; display: flex; flex-direction: column; gap: 12px; }
-    .priority-list, .next-actions-list { list-style: none; padding: 0; margin: 12px 0; display: flex; flex-direction: column; gap: 12px; }
-    .priority-item { display: flex; align-items: flex-start; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.35); background: rgba(248, 250, 252, 0.7); transition: var(--transition-fast); }
-    .priority-item:hover { border-color: rgba(37, 99, 235, 0.35); box-shadow: var(--shadow-sm); }
-    .priority-item.completed { background: var(--green-soft); border-color: var(--green-border); }
-    .priority-details { flex: 1; display: flex; flex-direction: column; gap: 4px; }
-    .priority-title { font-weight: 600; font-size: 14px; }
-    .priority-item.completed .priority-title { text-decoration: line-through; color: var(--muted); }
-    .priority-meta { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
-    .priority-actions { display: flex; gap: 6px; }
-    .priority-toggle, .priority-delete { background: transparent; border: none; cursor: pointer; border-radius: 8px; padding: 4px; display: flex; align-items: center; justify-content: center; transition: var(--transition-fast); color: var(--muted); }
-    .priority-toggle:hover { color: var(--green); background: var(--green-soft); }
-    .priority-delete:hover { color: var(--red); background: var(--red-soft); }
-    .empty-priority { margin: 0; text-align: center; font-size: 13px; color: var(--muted); }
-    .next-actions-card { position: relative; }
-    .next-action-item { display: flex; gap: 12px; align-items: center; padding: 10px 12px; border-radius: 12px; border: 1px solid rgba(148, 163, 184, 0.35); background: #fff; }
-    .next-action-info { display: flex; flex-direction: column; gap: 4px; flex: 1; }
-    .next-action-meta { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
-    .next-action-date { font-size: 12px; color: var(--muted); }
-    .next-action-badge { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); background: rgba(37, 99, 235, 0.12); border-radius: 999px; padding: 4px 8px; }
-    @media(max-width: 640px) {
-      .header-top { width: 100%; flex-direction: column; align-items: flex-start; }
-      .header-actions { width: 100%; justify-content: flex-start; }
-      .back-btn { width: 100%; }
-    }
-
-    /* Planner */
-    .planner-card { padding: 24px; overflow: visible; }
-    .planner-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
-    .planner-title { display: flex; flex-direction: column; gap: 4px; }
-    .planner-title .title { margin: 0; font-size: 20px; }
-    .planner-range { font-size: 13px; color: var(--muted); }
-    .planner-controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-    .week-nav { display: flex; gap: 8px; }
-    .planner-meta { display: flex; justify-content: space-between; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 12px; }
-    .planner-status { font-weight: 600; font-size: 13px; }
-    .planner-instructions { display: none; margin: 0; margin-top: 12px; padding: 12px 16px; border-radius: 12px; background: var(--blue-soft); color: var(--blue); font-weight: 500; }
-    .btn.small { padding: 6px 12px; font-size: 12px; border-radius: 10px; }
-    .planner-grid-wrapper { margin-top: 20px; overflow-x: auto; padding-bottom: 12px; }
-    .planner-grid { display: grid; grid-template-columns: repeat(7, minmax(160px, 1fr)); gap: 16px; min-width: 1120px; }
-    .day-column { position: relative; background: var(--bg); border-radius: 12px; padding: 12px; transition: var(--transition-fast); border: 2px solid transparent; min-width: 160px; }
-    .day-header { font-weight: 600; text-align: center; font-size: 13px; padding-bottom: 8px; margin-bottom: 8px; border-bottom: 1px solid var(--line); }
-    .day-header.today { color: var(--blue); }
-    .activities-container { min-height: 120px; display: flex; flex-direction: column; gap: 8px; }
-    .activity-pill { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border-radius: 8px; font-size: 13px; font-weight: 500; cursor: grab; border: 1px solid; transition: var(--transition-fast); text-align: left; }
-    .activity-pill.dragging { opacity: 0.5; transform: scale(1.05); box-shadow: var(--shadow-lg); }
-    .activity-pill:not(.completed):hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
-    .activity-pill.gym { background: var(--gym-soft); color: var(--gym-color); border-color: var(--gym-border); }
-    .activity-pill.running { background: var(--run-soft); color: var(--run-color); border-color: var(--run-border); }
-    .activity-pill.reading { background: var(--read-soft); color: var(--read-color); border-color: var(--read-border); }
-    .activity-pill.completed { background: var(--green-soft); color: var(--green); border-color: var(--green-border); cursor: pointer; }
-    .activity-pill.completed:hover { opacity: 1; box-shadow: var(--shadow-sm); }
-    .activity-pill > span { text-decoration: none; }
-    .activity-pill.completed > span { text-decoration: line-through; opacity: 0.7; }
-    .day-column.drag-over { background-color: var(--blue-soft); border-color: var(--blue-border); }
-    .delete-activity-btn { background: transparent; border: none; color: var(--muted); cursor: pointer; padding: 2px; margin-left: 8px; border-radius: 4px; display: flex; align-items: center; transition: var(--transition-fast); }
-    .delete-activity-btn:hover { color: var(--red); background-color: var(--red-soft); }
-
-    .quick-add-btn { position: absolute; top: 8px; right: 8px; background: #fff; border: 1px solid var(--line); border-radius: 50%; width: 28px; height: 28px; color: var(--muted); cursor: pointer; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity .2s; }
-    .day-column:hover .quick-add-btn { opacity: 1; }
-    .quick-add-menu { position: absolute; top: 40px; right: 8px; background: #fff; border: 1px solid var(--line); border-radius: 8px; box-shadow: var(--shadow-md); z-index: 10; display: none; flex-direction: column; overflow: hidden; }
-    .quick-add-menu button { background: none; border: none; padding: 8px 12px; text-align: left; cursor: pointer; width: 100%; font-size: 13px; }
-    .quick-add-menu button:hover { background-color: var(--bg); }
-
-    .extras-container { margin-top: 12px; display: flex; flex-direction: column; gap: 10px; }
-    .extras-header { display: flex; justify-content: space-between; align-items: center; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
-    .extra-pill { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 14px 12px 20px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.4); background: #fff; box-shadow: var(--shadow-sm); transition: var(--transition-fast); }
-    .extra-pill::before { content: ""; position: absolute; left: 8px; top: 12px; bottom: 12px; width: 4px; border-radius: 999px; background: var(--extra-other); }
-    .extra-pill[data-category="training"]::before { background: var(--extra-training); }
-    .extra-pill[data-category="learning"]::before { background: var(--extra-learning); }
-    .extra-pill[data-category="relax"]::before { background: var(--extra-relax); }
-    .extra-pill[data-category="home"]::before { background: var(--extra-home); }
-    .extra-pill:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
-    .extra-pill.completed { background: var(--green-soft); border-color: var(--green-border); }
-    .extra-main { display: flex; align-items: center; gap: 12px; flex: 1; }
-    .extra-toggle { width: 30px; height: 30px; border-radius: 50%; border: none; background: rgba(148, 163, 184, 0.2); color: var(--muted); display: flex; align-items: center; justify-content: center; cursor: pointer; transition: var(--transition-fast); }
-    .extra-toggle:hover { background: rgba(37, 99, 235, 0.12); color: var(--blue); }
-    .extra-pill.completed .extra-toggle { background: var(--green); color: #fff; }
-    .extra-info { display: flex; flex-direction: column; gap: 4px; }
-    .extra-title { font-weight: 600; font-size: 14px; }
-    .extra-pill.completed .extra-title { text-decoration: line-through; color: var(--muted); }
-    .extra-category { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
-    .extra-delete-btn { background: transparent; border: none; color: var(--muted); cursor: pointer; padding: 4px; border-radius: 8px; display: flex; align-items: center; transition: var(--transition-fast); }
-    .extra-delete-btn:hover { color: var(--red); background: var(--red-soft); }
-    .add-extra-btn { align-self: flex-start; display: inline-flex; align-items: center; gap: 6px; border: 1px dashed rgba(148, 163, 184, 0.6); background: transparent; padding: 6px 10px; border-radius: 10px; font-size: 12px; color: var(--muted); cursor: pointer; transition: var(--transition-fast); }
-    .add-extra-btn:hover { border-color: var(--blue); color: var(--blue); }
-
-    .empty-planner { text-align: center; padding: 40px; color: var(--muted); border: 2px dashed var(--line); border-radius: 16px; margin-top: 24px; background: rgba(255, 255, 255, 0.7); }
-
-    /* Modal */
-    .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(15, 23, 42, 0.6); display: flex; justify-content: center; align-items: center; z-index: 1000; backdrop-filter: blur(4px); opacity: 0; pointer-events: none; transition: opacity .2s ease-out; }
-    .modal-overlay.visible { opacity: 1; pointer-events: all; }
-    .modal-card { background: var(--card); padding: 32px; border-radius: 16px; box-shadow: var(--shadow-lg); max-width: 450px; width: 90%; text-align: center; transition: transform .2s ease-out; transform: scale(0.95); }
-    .modal-overlay.visible .modal-card { transform: scale(1); }
-    .modal-actions { margin-top: 24px; display: flex; justify-content: center; gap: 12px; }
-    .modal-card input { border: 1px solid var(--line); border-radius: 10px; margin-top: 12px; text-align: center; font-size: 18px; padding: 12px; width: 100%; }
-    .modal-options { margin-top: 16px; display: flex; flex-direction: column; gap: 12px; }
-    .option-label { display: flex; align-items: center; padding: 12px; border: 1px solid var(--line); border-radius: 12px; cursor: pointer; transition: var(--transition-fast); }
-    .option-label:hover { background-color: var(--bg); border-color: var(--blue-border); }
-    .option-label input { margin-right: 12px; }
-
-    /* Planning Mode */
-    .planning-mode .day-column { cursor: pointer; border: 2px dashed var(--blue-border); }
-    .planning-mode .day-column:hover { border-color: var(--blue); background: var(--blue-soft); }
-
-    /* Stats */
-    .heatmap-container { margin-top: 16px; overflow-x: auto; padding-bottom: 12px; }
-    .heatmap { display: flex; gap: 4px; min-width: max-content; align-items: flex-start; }
-    .heatmap-week { display: flex; flex-direction: column; gap: 4px; align-items: center; }
-    .heatmap-week-label { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap; }
-    .heatmap-cell { width: 15px; height: 15px; background: var(--line); border-radius: 3px; position: relative; }
-    .heatmap-cell[data-level="1"] { background: #9be9a8; }
-    .heatmap-cell[data-level="2"] { background: #40c463; }
-    .heatmap-cell[data-level="3"] { background: #30a14e; }
-    .heatmap-cell[data-level="4"] { background: #216e39; }
-    .heatmap-legend { display: flex; align-items: center; gap: 4px; justify-content: flex-end; margin-top: 8px; }
-
-    /* Save Status */
-    #save-status { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: var(--ink); color: #fff; padding: 10px 20px; border-radius: 12px; box-shadow: var(--shadow-lg); z-index: 2000; opacity: 0; transition: opacity .3s, transform .3s; pointer-events: none; }
-    #save-status.visible { opacity: 1; transform: translateX(-50%) translateY(-10px); }
-    
-    .icon { width: 1em; height: 1em; }
+:root {
+  --bg: #f3f5f9;
+  --card: #ffffff;
+  --ink: #0f172a;
+  --muted: #64748b;
+  --line: #e2e8f0;
+  --green: #059669;
+  --green-soft: #ecfdf5;
+  --green-border: #a7f3d0;
+  --red: #dc2626;
+  --red-soft: #fef2f2;
+  --red-border: #fecaca;
+  --orange: #ea580c;
+  --orange-soft: #fff7ed;
+  --orange-border: #fed7aa;
+  --blue: #2563eb;
+  --blue-soft: #eff6ff;
+  --blue-border: #bfdbfe;
+  --purple: #7c3aed;
+  --yellow: #ca8a04;
+  --gym-color: #5b21b6;
+  --gym-soft: #f5f3ff;
+  --gym-border: #ddd6fe;
+  --run-color: #047857;
+  --run-soft: #ecfdf5;
+  --run-border: #a7f3d0;
+  --read-color: #0369a1;
+  --read-soft: #f0f9ff;
+  --read-border: #bae6fd;
+  --extra-training: #9333ea;
+  --extra-learning: #2563eb;
+  --extra-relax: #0ea5e9;
+  --extra-home: #f97316;
+  --extra-other: #334155;
+  --shadow-sm: 0 6px 18px rgba(15, 23, 42, 0.07);
+  --shadow-md: 0 16px 30px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 22px 45px rgba(15, 23, 42, 0.12);
+  --transition-fast: all .2s ease;
+}
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #e0e7ff 0%, #f3f5f9 45%, #f8fafc 100%);
+  color: var(--ink);
+  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto;
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+h1, h2, h3, h4, h5 { margin: 0; color: var(--ink); }
+p { margin: 0; }
+.wrap {
+  max-width: 1260px;
+  margin: 0 auto;
+  padding: 24px 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 100vh;
+}
+.muted { color: var(--muted); }
+.tiny { font-size: 11px; letter-spacing: 0.02em; }
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.card {
+  background: var(--card);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 18px;
+  padding: 18px 20px;
+  box-shadow: var(--shadow-sm);
+  transition: var(--transition-fast);
+  position: relative;
+}
+.card:hover { box-shadow: var(--shadow-md); }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 10px;
+  padding: 6px 12px;
+  border: 1px solid transparent;
+  background: var(--ink);
+  color: #fff;
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 12px;
+  transition: var(--transition-fast);
+}
+.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.btn.soft {
+  background: #fff;
+  border-color: rgba(148, 163, 184, 0.45);
+  color: var(--ink);
+}
+.btn.soft:hover { border-color: var(--blue); color: var(--blue); }
+.btn.ghost {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--ink);
+}
+.btn.ghost:hover { background: rgba(148, 163, 184, 0.26); }
+.btn.danger {
+  background: var(--red-soft);
+  border-color: var(--red-border);
+  color: var(--red);
+}
+.btn.danger:hover { background: var(--red); color: #fff; }
+.btn.small { padding: 5px 10px; font-size: 11px; }
+.btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; box-shadow: none; }
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(6px);
+}
+.page-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex: 1;
+  min-width: 0;
+}
+.header-title-block { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.header-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.header-title-row h1 { font-size: 22px; font-weight: 800; letter-spacing: -0.2px; }
+.header-week-range { font-size: 12px; color: var(--muted); }
+.week-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--blue-soft);
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+}
+.metric-card {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: linear-gradient(140deg, rgba(37, 99, 235, 0.06), rgba(14, 165, 233, 0.04));
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 78px;
+}
+.metric-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  font-weight: 600;
+}
+.metric-value { font-size: 18px; font-weight: 700; color: var(--ink); }
+.metric-sub { font-size: 11px; color: var(--muted); min-height: 14px; }
+.dashboard {
+  display: grid;
+  grid-template-columns: minmax(0, 1.85fr) minmax(0, 1fr);
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+.dashboard-main {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 16px;
+  min-height: 0;
+}
+.dashboard-side {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 16px;
+  min-height: 0;
+}
+.section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 16px;
+  font-weight: 700;
+}
+.planner-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+.planner-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.planner-title { display: flex; flex-direction: column; gap: 4px; }
+.planner-range { font-size: 12px; color: var(--muted); }
+.planner-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.week-nav { display: flex; gap: 8px; }
+.planner-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.planner-status { font-weight: 600; font-size: 12px; }
+.planner-instructions {
+  display: none;
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--blue-soft);
+  color: var(--blue);
+  font-weight: 500;
+}
+.planner-grid-wrapper { flex: 1; min-height: 0; }
+.planner-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 10px;
+  min-height: 0;
+}
+.day-column {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 14px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  transition: var(--transition-fast);
+  position: relative;
+}
+.day-header {
+  font-weight: 600;
+  text-align: center;
+  font-size: 12px;
+  padding-bottom: 6px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--line);
+}
+.day-header.today { color: var(--blue); }
+.activities-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 80px;
+}
+.activity-pill {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 9px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  cursor: grab;
+  transition: var(--transition-fast);
+}
+.activity-pill.dragging { opacity: 0.6; transform: scale(1.02); box-shadow: var(--shadow-md); }
+.activity-pill:not(.completed):hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
+.activity-pill.gym { background: var(--gym-soft); color: var(--gym-color); border-color: var(--gym-border); }
+.activity-pill.running { background: var(--run-soft); color: var(--run-color); border-color: var(--run-border); }
+.activity-pill.reading { background: var(--read-soft); color: var(--read-color); border-color: var(--read-border); }
+.activity-pill.completed {
+  background: var(--green-soft);
+  color: var(--green);
+  border-color: var(--green-border);
+  cursor: pointer;
+}
+.activity-pill span { flex: 1; }
+.activity-pill.completed span { text-decoration: line-through; opacity: 0.75; }
+.day-column.drag-over { border-color: var(--blue); box-shadow: inset 0 0 0 1px var(--blue-border); }
+.delete-activity-btn {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  transition: var(--transition-fast);
+}
+.delete-activity-btn:hover { color: var(--red); background-color: var(--red-soft); }
+.quick-add-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  width: 26px;
+  height: 26px;
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity .2s;
+  font-size: 14px;
+  padding: 0;
+}
+.day-column:hover .quick-add-btn { opacity: 1; }
+.quick-add-menu {
+  position: absolute;
+  top: 36px;
+  right: 8px;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: var(--shadow-md);
+  z-index: 10;
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+}
+.quick-add-menu button {
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  font-size: 12px;
+}
+.quick-add-menu button:hover { background-color: var(--bg); }
+.extras-container { display: flex; flex-direction: column; gap: 8px; }
+.extras-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+.extra-pill {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px 10px 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+  transition: var(--transition-fast);
+  font-size: 12px;
+}
+.extra-pill::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: 10px;
+  bottom: 10px;
+  width: 4px;
+  border-radius: 999px;
+  background: var(--extra-other);
+}
+.extra-pill[data-category="training"]::before { background: var(--extra-training); }
+.extra-pill[data-category="learning"]::before { background: var(--extra-learning); }
+.extra-pill[data-category="relax"]::before { background: var(--extra-relax); }
+.extra-pill[data-category="home"]::before { background: var(--extra-home); }
+.extra-pill:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+.extra-pill.completed { background: var(--green-soft); border-color: var(--green-border); }
+.extra-main { display: flex; align-items: center; gap: 10px; flex: 1; }
+.extra-toggle {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+.extra-toggle:hover { background: rgba(37, 99, 235, 0.15); color: var(--blue); }
+.extra-pill.completed .extra-toggle { background: var(--green); color: #fff; }
+.extra-info { display: flex; flex-direction: column; gap: 4px; }
+.extra-title { font-weight: 600; font-size: 12px; }
+.extra-pill.completed .extra-title { text-decoration: line-through; color: var(--muted); }
+.extra-category { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.extra-delete-btn {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  transition: var(--transition-fast);
+}
+.extra-delete-btn:hover { color: var(--red); background: var(--red-soft); }
+.add-extra-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  background: transparent;
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+.add-extra-btn:hover { border-color: var(--blue); color: var(--blue); }
+.analytics-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  gap: 16px;
+  align-items: start;
+}
+.panel-header { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+.next-actions-panel { display: flex; flex-direction: column; gap: 8px; }
+.next-actions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.next-action-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #fff;
+  font-size: 12px;
+}
+.next-action-info { display: flex; flex-direction: column; gap: 4px; flex: 1; }
+.next-action-meta { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.next-action-date { font-size: 11px; color: var(--muted); }
+.next-action-badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  background: rgba(37, 99, 235, 0.12);
+  border-radius: 999px;
+  padding: 4px 8px;
+}
+.heatmap-panel { display: flex; flex-direction: column; gap: 8px; }
+.heatmap-container { overflow: hidden; }
+.heatmap {
+  display: flex;
+  gap: 3px;
+  align-items: flex-end;
+  min-width: max-content;
+}
+.heatmap-week { display: flex; flex-direction: column; gap: 3px; align-items: center; }
+.heatmap-week-label {
+  font-size: 9px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+.heatmap-cell {
+  width: 12px;
+  height: 12px;
+  background: var(--line);
+  border-radius: 3px;
+  position: relative;
+}
+.heatmap-cell[data-level="1"] { background: #9be9a8; }
+.heatmap-cell[data-level="2"] { background: #40c463; }
+.heatmap-cell[data-level="3"] { background: #30a14e; }
+.heatmap-cell[data-level="4"] { background: #216e39; }
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
+  font-size: 11px;
+}
+.weekly-overview-card { display: flex; flex-direction: column; gap: 14px; }
+.overview-progress { display: flex; flex-direction: column; gap: 8px; }
+.progress-summary { display: flex; justify-content: space-between; align-items: center; }
+.progress-bar {
+  height: 8px;
+  background: var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress-bar > div { height: 100%; transition: width .4s cubic-bezier(0.22, 1, 0.36, 1); }
+.goal-grid { display: grid; gap: 12px; }
+.goal-card {
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: var(--transition-fast);
+}
+.goal-card.goal-gym { background: var(--gym-soft); border-color: var(--gym-border); }
+.goal-card.goal-running { background: var(--run-soft); border-color: var(--run-border); }
+.goal-card.goal-reading { background: var(--read-soft); border-color: var(--read-border); }
+.goal-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-sm); }
+.goal-title { font-size: 15px; font-weight: 700; }
+.goal-value { font-size: 18px; font-weight: 700; }
+.goal-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.goal-actions .btn { flex: 1; min-width: 120px; }
+.goal-meta { font-size: 11px; color: var(--muted); }
+.priorities-card { display: flex; flex-direction: column; gap: 12px; }
+.priority-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.priority-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.8);
+  transition: var(--transition-fast);
+}
+.priority-item:hover { border-color: rgba(37, 99, 235, 0.35); box-shadow: var(--shadow-sm); }
+.priority-item.completed { background: var(--green-soft); border-color: var(--green-border); }
+.priority-details { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+.priority-title { font-weight: 600; font-size: 13px; }
+.priority-item.completed .priority-title { text-decoration: line-through; color: var(--muted); }
+.priority-meta { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.priority-actions { display: flex; gap: 6px; }
+.priority-toggle, .priority-delete {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-fast);
+  color: var(--muted);
+}
+.priority-toggle:hover { color: var(--green); background: var(--green-soft); }
+.priority-delete:hover { color: var(--red); background: var(--red-soft); }
+.empty-priority { margin: 0; text-align: center; font-size: 12px; color: var(--muted); }
+.empty-planner {
+  text-align: center;
+  padding: 24px;
+  color: var(--muted);
+  border: 1px dashed var(--line);
+  border-radius: 14px;
+  margin-top: 8px;
+  background: rgba(255, 255, 255, 0.65);
+}
+.empty-planner h4 { margin: 0 0 6px 0; font-size: 15px; }
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease-out;
+}
+.modal-overlay.visible { opacity: 1; pointer-events: all; }
+.modal-card {
+  background: var(--card);
+  padding: 28px;
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg);
+  max-width: 440px;
+  width: 90%;
+  text-align: center;
+  transition: transform .2s ease-out;
+  transform: scale(0.95);
+}
+.modal-overlay.visible .modal-card { transform: scale(1); }
+.modal-actions { margin-top: 20px; display: flex; justify-content: center; gap: 12px; }
+.modal-card input {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  margin-top: 12px;
+  text-align: center;
+  font-size: 18px;
+  padding: 12px;
+  width: 100%;
+}
+.modal-options { margin-top: 16px; display: flex; flex-direction: column; gap: 12px; }
+.option-label {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+.option-label:hover { background-color: var(--bg); border-color: var(--blue-border); }
+.option-label input { margin-right: 12px; }
+.planning-mode .day-column { cursor: pointer; border: 1px dashed var(--blue-border); }
+.planning-mode .day-column:hover { border-color: var(--blue); background: var(--blue-soft); }
+#save-status {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ink);
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  z-index: 2000;
+  opacity: 0;
+  transition: opacity .3s, transform .3s;
+  pointer-events: none;
+  font-size: 12px;
+}
+#save-status.visible { opacity: 1; transform: translateX(-50%) translateY(-10px); }
+.icon { width: 16px; height: 16px; }
+@media (max-width: 1180px) {
+  .dashboard { grid-template-columns: 1fr; }
+  .dashboard-side { grid-template-rows: auto auto; }
+}
+@media (max-width: 860px) {
+  .analytics-card { grid-template-columns: 1fr; }
+  .metrics-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+  .planner-grid { grid-template-columns: repeat(7, minmax(130px, 1fr)); }
+  .planner-grid-wrapper { overflow-x: auto; }
+}
+@media (max-width: 600px) {
+  .page-header-top { flex-direction: column; align-items: flex-start; }
+  .header-left { flex-direction: column; align-items: flex-start; }
+  .week-chip { align-self: flex-start; }
+  .btn { width: 100%; justify-content: center; }
+  .planner-controls { width: 100%; justify-content: space-between; }
+  .week-nav { flex: 1; justify-content: space-between; }
+}
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <header class="page-header">
-      <div class="page-header-main">
-        <div class="header-top">
-          <div class="header-title-block">
-            <span class="eyebrow">Strategiczne zarządzanie rozwojem</span>
-            <div class="header-title-row">
-              <h1>Panel treningów</h1>
-              <span class="week-chip" id="header-week-label">Tydzień --</span>
-            </div>
-            <span class="header-week-range" id="header-week-range">--</span>
+
+<div class="wrap">
+  <header class="page-header card">
+    <div class="page-header-top">
+      <div class="header-left">
+        <a href="./index.html" class="btn ghost"><i data-lucide="arrow-left" class="icon"></i>Powrót</a>
+        <div class="header-title-block">
+          <span class="eyebrow">Strategiczne zarządzanie rozwojem</span>
+          <div class="header-title-row">
+            <h1>Panel treningów</h1>
+            <span class="week-chip" id="header-week-label">Tydzień --</span>
           </div>
-          <div class="header-actions">
-            <a href="./index.html" class="btn soft back-btn"><i data-lucide="arrow-left" class="icon"></i> Powrót</a>
-          </div>
-        </div>
-        <p class="muted header-subtitle">Planowanie, realizacja i analiza Twoich kluczowych celów w jednym miejscu.</p>
-        <div class="header-insights">
-          <div class="insight-card">
-            <span class="insight-label">Realizacja celów</span>
-            <span class="insight-value" id="header-week-progress">0%</span>
-            <span class="insight-sub">Średni postęp celów głównych</span>
-          </div>
-          <div class="insight-card">
-            <span class="insight-label">Aktywności tygodnia</span>
-            <span class="insight-value" id="header-planned-activities">0/0</span>
-            <span class="insight-sub">ukończone / zaplanowane</span>
-          </div>
-          <div class="insight-card">
-            <span class="insight-label">Status planu</span>
-            <span class="insight-value" id="header-plan-status">W trakcie</span>
-            <span class="insight-sub" id="header-plan-status-hint">Uzupełnij plan, aby zamknąć cele tygodnia.</span>
-          </div>
+          <span class="header-week-range" id="header-week-range">--</span>
         </div>
       </div>
-      <div class="card header-kpis">
-        <div class="kpi-item">
-            <div class="muted">Ukończone tyg.</div>
-            <div id="yearly-progress-value" class="kpi-value" style="color: var(--green);">0/36</div>
-            <p class="kpi-note tiny">Cel roczny</p>
-        </div>
-        <div class="kpi-item">
-            <div class="muted">Seria</div>
-            <div id="streak-value" class="kpi-value" style="color: var(--orange);">0</div>
-            <p class="kpi-note tiny">Najdłuższa passa</p>
-        </div>
-        <div class="kpi-item">
-            <div class="muted">Najbliższa aktywność</div>
-            <div id="next-activity-kpi" class="kpi-value" style="color: var(--blue); font-size: 18px;">Brak planu</div>
-            <p id="next-activity-date" class="kpi-note tiny muted"></p>
-        </div>
-      </div>
-    </header>
-
-    <div class="page-layout">
-      <section class="layout-main">
-        <div id="planner-shell" class="card planner-card">
-          <div class="planner-header">
-            <div class="planner-title">
-              <h3 class="title"><i data-lucide="layout-grid" class="icon"></i>Planer tygodniowy</h3>
-              <span class="planner-range" id="planner-week-range">--</span>
-            </div>
-            <div class="planner-controls">
-              <button id="copy-plan-btn" class="btn ghost" style="display: none;"><i data-lucide="copy" class="icon"></i>Kopiuj plan</button>
-              <div class="week-nav">
-                <button id="prev-week-btn" class="btn soft"><i data-lucide="chevron-left" class="icon"></i>Poprzedni</button>
-                <button id="today-week-btn" class="btn soft" style="display: none;">Bieżący</button>
-                <button id="next-week-btn" class="btn soft">Następny<i data-lucide="chevron-right" class="icon"></i></button>
-              </div>
-            </div>
-          </div>
-          <div class="planner-meta">
-            <span id="planning-status" class="planner-status muted"></span>
-            <button id="cancel-planning-btn" class="btn soft small" style="display: none;">Zakończ planowanie</button>
-          </div>
-          <p id="planning-instructions" class="planner-instructions"></p>
-          <div class="planner-grid-wrapper">
-            <div class="planner-grid"></div>
-          </div>
-          <div id="empty-planner-placeholder" class="empty-planner" style="display: none;">
-            <h4 style="margin: 0 0 4px 0;">Brak zaplanowanych działań</h4>
-            <p class="muted" style="margin: 0;">Dodaj cele z panelu obok lub użyj szybkich przycisków w kalendarzu.</p>
-          </div>
-        </div>
-
-        <div class="insights-grid">
-          <div class="card next-actions-card">
-              <h3 class="title"><i data-lucide="alarm-clock" class="icon"></i>Najbliższe kroki</h3>
-              <p class="muted tiny" style="margin-top:-4px;">Automatyczne podpowiedzi z planera i aktywności dodatkowych.</p>
-              <ul id="next-actions-list" class="next-actions-list"></ul>
-              <p id="next-actions-empty" class="empty-priority">Brak zaplanowanych aktywności na horyzoncie.</p>
-          </div>
-          <div class="card stats-card">
-              <h3 class="title"><i data-lucide="flame" class="icon"></i>Aktywność w czasie</h3>
-              <p class="muted tiny" style="margin-top:-8px; margin-bottom: 12px;">Każdy kwadrat to jeden dzień roku. Im ciemniejszy odcień, tym więcej ukończonych działań.</p>
-              <div class="heatmap-container"></div>
-              <div class="heatmap-legend">
-                  <span class="muted tiny">Mniej</span>
-                  <div class="heatmap-cell" style="background: var(--line)"></div>
-                  <div class="heatmap-cell" data-level="1"></div>
-                  <div class="heatmap-cell" data-level="2"></div>
-                  <div class="heatmap-cell" data-level="3"></div>
-                  <div class="heatmap-cell" data-level="4"></div>
-                  <span class="muted tiny">Więcej</span>
-              </div>
-          </div>
-        </div>
-      </section>
-
-      <aside class="layout-side">
-        <div class="card weekly-overview-card">
-          <div class="overview-header">
-            <div>
-              <h3 class="title"><i data-lucide="calendar-check" class="icon"></i><span id="week-title">Cele tygodniowe</span></h3>
-              <p class="muted tiny" style="margin-top:-4px;">Monitoruj realizację kluczowych wskaźników.</p>
-            </div>
-          </div>
-          <div class="overview-progress">
-              <div class="progress-summary">
-                  <span id="overall-progress-label" class="tiny muted">Postęp tygodnia: 0%</span>
-              </div>
-              <div class="progress-bar"><div id="overall-progress-bar" style="width:0%; background: var(--blue);"></div></div>
-          </div>
-          <div class="goal-grid">
-              <div class="goal-card goal-gym">
-                  <h4 class="title">💪 Trening siłowy</h4>
-                  <div id="goal-gym-progress" class="kpi-value">0/3 sesje</div>
-                  <div class="progress-bar"><div id="goal-gym-bar" style="width:0%; background: var(--gym-color);"></div></div>
-                  <p class="goal-meta" id="goal-gym-remaining">Pozostało: 3 sesje</p>
-                  <div class="goal-actions">
-                    <button class="btn soft" data-activity-type="gym" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
-                  </div>
-              </div>
-              <div class="goal-card goal-running">
-                  <h4 class="title">🏃 Bieg</h4>
-                  <div id="goal-running-progress" class="kpi-value">0/5 km</div>
-                  <div class="progress-bar"><div id="goal-running-bar" style="width:0%; background: var(--run-color);"></div></div>
-                  <p class="goal-meta" id="goal-running-remaining">Pozostało: 5 km</p>
-                  <div class="goal-actions">
-                    <button class="btn soft" data-activity-type="running" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
-                  </div>
-              </div>
-              <div class="goal-card goal-reading">
-                  <h4 class="title">📚 Czytanie</h4>
-                  <div id="goal-reading-progress" class="kpi-value">0/100 stron</div>
-                  <div class="progress-bar"><div id="goal-reading-bar" style="width:0%; background: var(--read-color);"></div></div>
-                  <p class="goal-meta" id="goal-reading-remaining">Pozostało: 100 stron</p>
-                  <div class="goal-actions">
-                    <button class="btn soft" data-activity-type="reading" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
-                  </div>
-              </div>
-          </div>
-        </div>
-
-        <div class="card priorities-card">
-              <h3 class="title"><i data-lucide="star" class="icon"></i>Priorytety tygodnia</h3>
-              <p class="muted tiny" style="margin-top:-4px;">Skup się na maksymalnie trzech działaniach o największym wpływie.</p>
-              <ul id="priority-list" class="priority-list"></ul>
-              <p id="priority-empty" class="empty-priority">Dodaj pierwszy priorytet, by mieć jasność działań.</p>
-              <button id="add-priority-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
-        </div>
-      </aside>
     </div>
-  </div>
+    <div class="metrics-grid">
+      <div class="metric-card">
+        <span class="metric-label">Realizacja celów</span>
+        <span class="metric-value" id="header-week-progress">0%</span>
+        <span class="metric-sub">Średni postęp celów głównych</span>
+      </div>
+      <div class="metric-card">
+        <span class="metric-label">Aktywności tygodnia</span>
+        <span class="metric-value" id="header-planned-activities">0/0</span>
+        <span class="metric-sub">ukończone / zaplanowane</span>
+      </div>
+      <div class="metric-card">
+        <span class="metric-label">Status planu</span>
+        <span class="metric-value" id="header-plan-status">W trakcie</span>
+        <span class="metric-sub" id="header-plan-status-hint">Uzupełnij plan, aby zamknąć cele tygodnia.</span>
+      </div>
+      <div class="metric-card">
+        <span class="metric-label">Ukończone tyg.</span>
+        <span class="metric-value" id="yearly-progress-value">0/36</span>
+        <span class="metric-sub">Cel roczny</span>
+      </div>
+      <div class="metric-card">
+        <span class="metric-label">Seria</span>
+        <span class="metric-value" id="streak-value">0</span>
+        <span class="metric-sub">Najdłuższa passa</span>
+      </div>
+      <div class="metric-card">
+        <span class="metric-label">Najbliższa aktywność</span>
+        <span class="metric-value" id="next-activity-kpi">Brak planu</span>
+        <span class="metric-sub" id="next-activity-date"></span>
+      </div>
+    </div>
+  </header>
+
+  <main class="dashboard">
+    <section class="dashboard-main">
+      <div id="planner-shell" class="card planner-card">
+        <div class="planner-header">
+          <div class="planner-title">
+            <h3 class="section-title"><i data-lucide="layout-grid" class="icon"></i>Planer tygodniowy</h3>
+            <span class="planner-range" id="planner-week-range">--</span>
+          </div>
+          <div class="planner-controls">
+            <button id="copy-plan-btn" class="btn ghost" style="display: none;"><i data-lucide="copy" class="icon"></i>Kopiuj plan</button>
+            <div class="week-nav">
+              <button id="prev-week-btn" class="btn soft"><i data-lucide="chevron-left" class="icon"></i>Poprzedni</button>
+              <button id="today-week-btn" class="btn soft" style="display: none;">Bieżący</button>
+              <button id="next-week-btn" class="btn soft">Następny<i data-lucide="chevron-right" class="icon"></i></button>
+            </div>
+          </div>
+        </div>
+        <div class="planner-meta">
+          <span id="planning-status" class="planner-status muted"></span>
+          <button id="cancel-planning-btn" class="btn soft small" style="display: none;">Zakończ planowanie</button>
+        </div>
+        <p id="planning-instructions" class="planner-instructions"></p>
+        <div class="planner-grid-wrapper">
+          <div class="planner-grid"></div>
+        </div>
+        <div id="empty-planner-placeholder" class="empty-planner" style="display: none;">
+          <h4>Brak zaplanowanych działań</h4>
+          <p class="muted">Dodaj cele z panelu obok lub użyj szybkich przycisków w kalendarzu.</p>
+        </div>
+      </div>
+
+      <div class="card analytics-card">
+        <div class="next-actions-panel">
+          <div class="panel-header">
+            <h3 class="section-title"><i data-lucide="alarm-clock" class="icon"></i>Najbliższe kroki</h3>
+            <p class="muted tiny">Automatyczne podpowiedzi z planera i aktywności dodatkowych.</p>
+          </div>
+          <ul id="next-actions-list" class="next-actions-list"></ul>
+          <p id="next-actions-empty" class="empty-priority">Brak zaplanowanych aktywności na horyzoncie.</p>
+        </div>
+        <div class="heatmap-panel">
+          <div class="panel-header">
+            <h3 class="section-title"><i data-lucide="flame" class="icon"></i>Aktywność w czasie</h3>
+            <p class="muted tiny">Każdy kwadrat to jeden dzień roku. Im ciemniejszy odcień, tym więcej ukończonych działań.</p>
+          </div>
+          <div class="heatmap-container"></div>
+          <div class="heatmap-legend">
+            <span class="muted tiny">Mniej</span>
+            <div class="heatmap-cell" style="background: var(--line)"></div>
+            <div class="heatmap-cell" data-level="1"></div>
+            <div class="heatmap-cell" data-level="2"></div>
+            <div class="heatmap-cell" data-level="3"></div>
+            <div class="heatmap-cell" data-level="4"></div>
+            <span class="muted tiny">Więcej</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <aside class="dashboard-side">
+      <div class="card weekly-overview-card">
+        <div class="panel-header">
+          <h3 class="section-title"><i data-lucide="calendar-check" class="icon"></i><span id="week-title">Cele tygodniowe</span></h3>
+          <p class="muted tiny">Monitoruj realizację kluczowych wskaźników.</p>
+        </div>
+        <div class="overview-progress">
+          <div class="progress-summary">
+            <span id="overall-progress-label" class="tiny muted">Postęp tygodnia: 0%</span>
+          </div>
+          <div class="progress-bar"><div id="overall-progress-bar" style="width:0%; background: var(--blue);"></div></div>
+        </div>
+        <div class="goal-grid">
+          <div class="goal-card goal-gym">
+            <div class="goal-title">💪 Trening siłowy</div>
+            <div id="goal-gym-progress" class="goal-value">0/3 sesje</div>
+            <div class="progress-bar"><div id="goal-gym-bar" style="width:0%; background: var(--gym-color);"></div></div>
+            <p class="goal-meta" id="goal-gym-remaining">Pozostało: 3 sesje</p>
+            <div class="goal-actions">
+              <button class="btn soft" data-activity-type="gym" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
+            </div>
+          </div>
+          <div class="goal-card goal-running">
+            <div class="goal-title">🏃 Bieg</div>
+            <div id="goal-running-progress" class="goal-value">0/5 km</div>
+            <div class="progress-bar"><div id="goal-running-bar" style="width:0%; background: var(--run-color);"></div></div>
+            <p class="goal-meta" id="goal-running-remaining">Pozostało: 5 km</p>
+            <div class="goal-actions">
+              <button class="btn soft" data-activity-type="running" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
+            </div>
+          </div>
+          <div class="goal-card goal-reading">
+            <div class="goal-title">📚 Czytanie</div>
+            <div id="goal-reading-progress" class="goal-value">0/100 stron</div>
+            <div class="progress-bar"><div id="goal-reading-bar" style="width:0%; background: var(--read-color);"></div></div>
+            <p class="goal-meta" id="goal-reading-remaining">Pozostało: 100 stron</p>
+            <div class="goal-actions">
+              <button class="btn soft" data-activity-type="reading" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card priorities-card">
+        <div class="panel-header">
+          <h3 class="section-title"><i data-lucide="star" class="icon"></i>Priorytety tygodnia</h3>
+          <p class="muted tiny">Skup się na maksymalnie trzech działaniach o największym wpływie.</p>
+        </div>
+        <ul id="priority-list" class="priority-list"></ul>
+        <p id="priority-empty" class="empty-priority">Dodaj pierwszy priorytet, by mieć jasność działań.</p>
+        <button id="add-priority-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
+      </div>
+    </aside>
+  </main>
+</div>
 
 <div id="modal-overlay" class="modal-overlay">
   <div class="modal-card">
-    <h3 id="modal-title" class="title" style="justify-content: center;"></h3>
+    <h3 id="modal-title" class="section-title" style="justify-content: center;"></h3>
     <p id="modal-text" class="muted"></p>
     <div id="modal-input-container"></div>
     <div id="modal-options-container"></div>

--- a/trainings.html
+++ b/trainings.html
@@ -3,136 +3,81 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>LifeOS – Plany i Progres</title>
+  <title>LifeOS – Trainings</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
   <style>
-
 :root {
-  --bg: #f3f5f9;
+  --bg: #eef2ff;
+  --bg-alt: #f8fafc;
   --card: #ffffff;
   --ink: #0f172a;
   --muted: #64748b;
   --line: #e2e8f0;
-  --green: #059669;
-  --green-soft: #ecfdf5;
-  --green-border: #a7f3d0;
-  --red: #dc2626;
-  --red-soft: #fef2f2;
-  --red-border: #fecaca;
-  --orange: #ea580c;
-  --orange-soft: #fff7ed;
-  --orange-border: #fed7aa;
-  --blue: #2563eb;
-  --blue-soft: #eff6ff;
-  --blue-border: #bfdbfe;
-  --purple: #7c3aed;
-  --yellow: #ca8a04;
+  --primary: #2563eb;
+  --primary-soft: #eff6ff;
+  --primary-border: #bfdbfe;
+  --success: #0f9d58;
+  --success-soft: #ecfdf5;
+  --success-border: #bbf7d0;
+  --warning: #f59e0b;
+  --danger: #dc2626;
+  --shadow-sm: 0 12px 30px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 28px 60px rgba(15, 23, 42, 0.12);
+  --transition: all .2s ease;
   --gym-color: #5b21b6;
-  --gym-soft: #f5f3ff;
-  --gym-border: #ddd6fe;
   --run-color: #047857;
-  --run-soft: #ecfdf5;
-  --run-border: #a7f3d0;
-  --read-color: #0369a1;
-  --read-soft: #f0f9ff;
-  --read-border: #bae6fd;
-  --extra-training: #9333ea;
-  --extra-learning: #2563eb;
-  --extra-relax: #0ea5e9;
-  --extra-home: #f97316;
-  --extra-other: #334155;
-  --shadow-sm: 0 6px 18px rgba(15, 23, 42, 0.07);
-  --shadow-md: 0 16px 30px rgba(15, 23, 42, 0.08);
-  --shadow-lg: 0 22px 45px rgba(15, 23, 42, 0.12);
-  --transition-fast: all .2s ease;
+  --read-color: #1d4ed8;
+  --extra-color: #0ea5e9;
 }
+
 *, *::before, *::after { box-sizing: border-box; }
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #e0e7ff 0%, #f3f5f9 45%, #f8fafc 100%);
+  background: linear-gradient(160deg, #e0e7ff 0%, #f1f5f9 45%, #ffffff 100%);
   color: var(--ink);
   font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto;
   font-size: 13px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
+
 h1, h2, h3, h4, h5 { margin: 0; color: var(--ink); }
 p { margin: 0; }
+
 .wrap {
-  max-width: 1260px;
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 24px 28px 32px;
+  padding: 28px 32px 40px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  min-height: 100vh;
+  gap: 20px;
 }
-.muted { color: var(--muted); }
-.tiny { font-size: 11px; letter-spacing: 0.02em; }
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--muted);
-}
+
+a { color: inherit; text-decoration: none; }
+
 .card {
   background: var(--card);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 18px;
-  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 20px 24px;
   box-shadow: var(--shadow-sm);
-  transition: var(--transition-fast);
-  position: relative;
 }
-.card:hover { box-shadow: var(--shadow-md); }
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border-radius: 10px;
-  padding: 6px 12px;
-  border: 1px solid transparent;
-  background: var(--ink);
-  color: #fff;
-  cursor: pointer;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 12px;
-  transition: var(--transition-fast);
-}
-.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
-.btn.soft {
-  background: #fff;
-  border-color: rgba(148, 163, 184, 0.45);
-  color: var(--ink);
-}
-.btn.soft:hover { border-color: var(--blue); color: var(--blue); }
-.btn.ghost {
-  background: rgba(148, 163, 184, 0.16);
-  color: var(--ink);
-}
-.btn.ghost:hover { background: rgba(148, 163, 184, 0.26); }
-.btn.danger {
-  background: var(--red-soft);
-  border-color: var(--red-border);
-  color: var(--red);
-}
-.btn.danger:hover { background: var(--red); color: #fff; }
-.btn.small { padding: 5px 10px; font-size: 11px; }
-.btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; box-shadow: none; }
+
 .page-header {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
   background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(12px);
 }
+
 .page-header-top {
   display: flex;
   align-items: center;
@@ -140,1984 +85,1436 @@ p { margin: 0; }
   gap: 16px;
   flex-wrap: wrap;
 }
-.header-left {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex: 1;
-  min-width: 0;
-}
-.header-title-block { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
-.header-title-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-.header-title-row h1 { font-size: 22px; font-weight: 800; letter-spacing: -0.2px; }
-.header-week-range { font-size: 12px; color: var(--muted); }
-.week-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--blue-soft);
-  color: var(--blue);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+
+.title-block { display: flex; flex-direction: column; gap: 6px; }
+.eyebrow {
   text-transform: uppercase;
-}
-.metrics-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 12px;
-}
-.metric-card {
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: linear-gradient(140deg, rgba(37, 99, 235, 0.06), rgba(14, 165, 233, 0.04));
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-height: 78px;
-}
-.metric-label {
+  letter-spacing: 0.14em;
   font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
   font-weight: 600;
+  color: var(--muted);
 }
-.metric-value { font-size: 18px; font-weight: 700; color: var(--ink); }
-.metric-sub { font-size: 11px; color: var(--muted); min-height: 14px; }
-.dashboard {
-  display: grid;
-  grid-template-columns: minmax(0, 1.85fr) minmax(0, 1fr);
-  gap: 16px;
-  flex: 1;
-  min-height: 0;
-}
-.dashboard-main {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  gap: 16px;
-  min-height: 0;
-}
-.dashboard-side {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  gap: 16px;
-  min-height: 0;
-}
-.section-title {
+
+.title-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.title-row h1 { font-size: 26px; font-weight: 800; letter-spacing: -0.3px; }
+
+.page-header-actions { display: flex; gap: 10px; align-items: center; }
+
+.btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  font-size: 16px;
-  font-weight: 700;
+  padding: 8px 14px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 12px;
+  border: 1px solid transparent;
+  background: var(--ink);
+  color: #fff;
+  cursor: pointer;
+  transition: var(--transition);
 }
-.planner-card {
+
+.btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.btn .icon { width: 16px; height: 16px; }
+.btn.soft { background: #fff; color: var(--ink); border-color: rgba(148, 163, 184, 0.45); }
+.btn.soft:hover { border-color: var(--primary); color: var(--primary); }
+.btn.ghost { background: rgba(148, 163, 184, 0.16); color: var(--ink); }
+.btn.ghost:hover { background: rgba(148, 163, 184, 0.3); }
+.btn:disabled { opacity: 0.6; cursor: not-allowed; transform: none; box-shadow: none; }
+
+.icon-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition);
+  color: var(--ink);
+}
+
+.icon-btn:hover { border-color: var(--primary); color: var(--primary); transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+
+.icon { width: 16px; height: 16px; }
+
+.month-bar { display: flex; justify-content: space-between; align-items: center; }
+.month-controls { display: flex; align-items: center; gap: 12px; }
+.month-labels { display: flex; flex-direction: column; gap: 4px; align-items: center; }
+.month-labels h2 { font-size: 20px; font-weight: 700; text-transform: capitalize; }
+.month-range { font-size: 12px; color: var(--muted); }
+
+.month-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--primary-soft); color: var(--primary); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metric-card {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  min-height: 0;
+  gap: 6px;
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.05));
 }
-.planner-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-  flex-wrap: wrap;
+
+.metric-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); font-weight: 600; }
+.metric-value { font-size: 22px; font-weight: 700; }
+.metric-sub { font-size: 11px; color: var(--muted); }
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
 }
-.planner-title { display: flex; flex-direction: column; gap: 4px; }
-.planner-range { font-size: 12px; color: var(--muted); }
-.planner-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-.week-nav { display: flex; gap: 8px; }
-.planner-meta {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-.planner-status { font-weight: 600; font-size: 12px; }
-.planner-instructions {
-  display: none;
-  margin: 0;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: var(--blue-soft);
-  color: var(--blue);
-  font-weight: 500;
-}
-.planner-grid-wrapper { flex: 1; min-height: 0; }
-.planner-grid {
+
+.calendar-column, .sidebar { display: flex; flex-direction: column; gap: 20px; }
+
+.card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
+.card-header p { margin-top: 4px; }
+
+.muted { color: var(--muted); }
+.tiny { font-size: 11px; letter-spacing: 0.02em; }
+
+.calendar-weekdays {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 10px;
-  min-height: 0;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
 }
-.day-column {
-  background: rgba(248, 250, 252, 0.9);
-  border-radius: 14px;
-  padding: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+
+.calendar-weekdays span {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 4px;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.calendar-day {
+  background: var(--bg-alt);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 10px 12px;
+  min-height: 116px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 0;
-  transition: var(--transition-fast);
+  cursor: pointer;
+  transition: var(--transition);
   position: relative;
 }
-.day-header {
-  font-weight: 600;
-  text-align: center;
-  font-size: 12px;
-  padding-bottom: 6px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid var(--line);
-}
-.day-header.today { color: var(--blue); }
-.activities-container {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-height: 80px;
-}
-.activity-pill {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: 9px;
-  font-size: 12px;
-  font-weight: 500;
-  border: 1px solid transparent;
-  cursor: grab;
-  transition: var(--transition-fast);
-}
-.activity-pill.dragging { opacity: 0.6; transform: scale(1.02); box-shadow: var(--shadow-md); }
-.activity-pill:not(.completed):hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
-.activity-pill.gym { background: var(--gym-soft); color: var(--gym-color); border-color: var(--gym-border); }
-.activity-pill.running { background: var(--run-soft); color: var(--run-color); border-color: var(--run-border); }
-.activity-pill.reading { background: var(--read-soft); color: var(--read-color); border-color: var(--read-border); }
-.activity-pill.completed {
-  background: var(--green-soft);
-  color: var(--green);
-  border-color: var(--green-border);
-  cursor: pointer;
-}
-.activity-pill span { flex: 1; }
-.activity-pill.completed span { text-decoration: line-through; opacity: 0.75; }
-.day-column.drag-over { border-color: var(--blue); box-shadow: inset 0 0 0 1px var(--blue-border); }
-.delete-activity-btn {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  padding: 2px;
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  transition: var(--transition-fast);
-}
-.delete-activity-btn:hover { color: var(--red); background-color: var(--red-soft); }
-.quick-add-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
+
+.calendar-day:hover { border-color: var(--primary); box-shadow: var(--shadow-sm); transform: translateY(-2px); }
+.calendar-day--other-month { opacity: 0.55; background: rgba(248, 250, 252, 0.6); }
+.calendar-day--selected { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.16); background: #fff; }
+.calendar-day--today { border-color: var(--success); }
+
+.calendar-day-header { display: flex; justify-content: space-between; align-items: center; }
+.calendar-date-number { font-weight: 700; font-size: 14px; }
+.calendar-day-badges { display: flex; gap: 6px; align-items: center; }
+.calendar-badge {
   background: #fff;
-  border: 1px solid var(--line);
   border-radius: 999px;
-  width: 26px;
-  height: 26px;
-  color: var(--muted);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transition: opacity .2s;
-  font-size: 14px;
-  padding: 0;
-}
-.day-column:hover .quick-add-btn { opacity: 1; }
-.quick-add-menu {
-  position: absolute;
-  top: 36px;
-  right: 8px;
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  box-shadow: var(--shadow-md);
-  z-index: 10;
-  display: none;
-  flex-direction: column;
-  overflow: hidden;
-}
-.quick-add-menu button {
-  background: none;
-  border: none;
-  padding: 8px 12px;
-  text-align: left;
-  cursor: pointer;
-  width: 100%;
-  font-size: 12px;
-}
-.quick-add-menu button:hover { background-color: var(--bg); }
-.extras-container { display: flex; flex-direction: column; gap: 8px; }
-.extras-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  padding: 2px 8px;
   font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  border: 1px solid rgba(148, 163, 184, 0.4);
   color: var(--muted);
 }
-.extra-pill {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 10px 12px 10px 18px;
+
+.calendar-day-dots { display: flex; flex-wrap: wrap; gap: 4px; min-height: 20px; }
+.activity-dot, .legend-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+.activity-dot.gym, .legend-dot.gym { background: var(--gym-color); }
+.activity-dot.running, .legend-dot.running { background: var(--run-color); }
+.activity-dot.reading, .legend-dot.reading { background: var(--read-color); }
+.activity-dot.extra, .legend-dot.extra { background: var(--extra-color); }
+
+.calendar-day-footer { margin-top: auto; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; align-items: center; }
+.calendar-footer-label { font-weight: 600; color: var(--success); }
+
+.calendar-legend { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; font-size: 11px; color: var(--muted); }
+.calendar-legend span { display: inline-flex; align-items: center; gap: 6px; }
+
+.upcoming-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.upcoming-item { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.25); background: rgba(248, 250, 252, 0.7); }
+.upcoming-item strong { display: block; font-size: 13px; }
+.upcoming-item .meta { display: flex; gap: 8px; font-size: 11px; color: var(--muted); }
+.upcoming-item .badge { background: rgba(37, 99, 235, 0.12); color: var(--primary); border-radius: 999px; padding: 2px 8px; font-weight: 600; }
+
+.empty-state {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: center;
+  padding: 18px 12px;
   border-radius: 12px;
+  background: rgba(248, 250, 252, 0.7);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+}
+.day-detail-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
+.detail-block { display: flex; flex-direction: column; gap: 10px; margin-top: 16px; }
+.detail-block-header { font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.detail-list { display: flex; flex-direction: column; gap: 10px; }
+.detail-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(248, 250, 252, 0.8);
+  transition: var(--transition);
+}
+.detail-item:hover { border-color: var(--primary-border); box-shadow: var(--shadow-sm); background: #fff; }
+.detail-item.completed { background: var(--success-soft); border-color: var(--success-border); }
+.detail-info { display: flex; gap: 12px; }
+.detail-icon { width: 38px; height: 38px; border-radius: 12px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 600; font-size: 14px; }
+.detail-icon.gym { background: rgba(91, 33, 182, 0.2); color: var(--gym-color); }
+.detail-icon.running { background: rgba(4, 120, 87, 0.18); color: var(--run-color); }
+.detail-icon.reading { background: rgba(29, 78, 216, 0.18); color: var(--read-color); }
+.detail-icon.extra { background: rgba(14, 165, 233, 0.18); color: var(--extra-color); }
+.detail-title { font-weight: 600; font-size: 13px; }
+.detail-meta { font-size: 11px; color: var(--muted); }
+.detail-actions-inline { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+
+.action-btn {
+  border-radius: 10px;
   border: 1px solid rgba(148, 163, 184, 0.4);
   background: #fff;
-  box-shadow: var(--shadow-sm);
-  transition: var(--transition-fast);
-  font-size: 12px;
-}
-.extra-pill::before {
-  content: "";
-  position: absolute;
-  left: 8px;
-  top: 10px;
-  bottom: 10px;
-  width: 4px;
-  border-radius: 999px;
-  background: var(--extra-other);
-}
-.extra-pill[data-category="training"]::before { background: var(--extra-training); }
-.extra-pill[data-category="learning"]::before { background: var(--extra-learning); }
-.extra-pill[data-category="relax"]::before { background: var(--extra-relax); }
-.extra-pill[data-category="home"]::before { background: var(--extra-home); }
-.extra-pill:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
-.extra-pill.completed { background: var(--green-soft); border-color: var(--green-border); }
-.extra-main { display: flex; align-items: center; gap: 10px; flex: 1; }
-.extra-toggle {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: none;
-  background: rgba(148, 163, 184, 0.2);
-  color: var(--muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: var(--transition-fast);
-}
-.extra-toggle:hover { background: rgba(37, 99, 235, 0.15); color: var(--blue); }
-.extra-pill.completed .extra-toggle { background: var(--green); color: #fff; }
-.extra-info { display: flex; flex-direction: column; gap: 4px; }
-.extra-title { font-weight: 600; font-size: 12px; }
-.extra-pill.completed .extra-title { text-decoration: line-through; color: var(--muted); }
-.extra-category { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
-.extra-delete-btn {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  transition: var(--transition-fast);
-}
-.extra-delete-btn:hover { color: var(--red); background: var(--red-soft); }
-.add-extra-btn {
-  align-self: flex-start;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border: 1px dashed rgba(148, 163, 184, 0.6);
-  background: transparent;
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 600;
   padding: 6px 10px;
-  border-radius: 10px;
-  font-size: 11px;
-  color: var(--muted);
   cursor: pointer;
-  transition: var(--transition-fast);
+  transition: var(--transition);
 }
-.add-extra-btn:hover { border-color: var(--blue); color: var(--blue); }
-.analytics-card {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
-  gap: 16px;
-  align-items: start;
-}
-.panel-header { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
-.next-actions-panel { display: flex; flex-direction: column; gap: 8px; }
-.next-actions-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.next-action-item {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: #fff;
-  font-size: 12px;
-}
-.next-action-info { display: flex; flex-direction: column; gap: 4px; flex: 1; }
-.next-action-meta { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
-.next-action-date { font-size: 11px; color: var(--muted); }
-.next-action-badge {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted);
-  background: rgba(37, 99, 235, 0.12);
-  border-radius: 999px;
-  padding: 4px 8px;
-}
-.heatmap-panel { display: flex; flex-direction: column; gap: 8px; }
-.heatmap-container { overflow: hidden; }
-.heatmap {
-  display: flex;
-  gap: 3px;
-  align-items: flex-end;
-  min-width: max-content;
-}
-.heatmap-week { display: flex; flex-direction: column; gap: 3px; align-items: center; }
-.heatmap-week-label {
-  font-size: 9px;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  white-space: nowrap;
-}
-.heatmap-cell {
-  width: 12px;
-  height: 12px;
-  background: var(--line);
-  border-radius: 3px;
-  position: relative;
-}
-.heatmap-cell[data-level="1"] { background: #9be9a8; }
-.heatmap-cell[data-level="2"] { background: #40c463; }
-.heatmap-cell[data-level="3"] { background: #30a14e; }
-.heatmap-cell[data-level="4"] { background: #216e39; }
-.heatmap-legend {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  justify-content: flex-end;
-  font-size: 11px;
-}
-.weekly-overview-card { display: flex; flex-direction: column; gap: 14px; }
-.overview-progress { display: flex; flex-direction: column; gap: 8px; }
-.progress-summary { display: flex; justify-content: space-between; align-items: center; }
-.progress-bar {
-  height: 8px;
-  background: var(--line);
-  border-radius: 999px;
-  overflow: hidden;
-}
-.progress-bar > div { height: 100%; transition: width .4s cubic-bezier(0.22, 1, 0.36, 1); }
-.goal-grid { display: grid; gap: 12px; }
-.goal-card {
-  padding: 16px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.7);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  transition: var(--transition-fast);
-}
-.goal-card.goal-gym { background: var(--gym-soft); border-color: var(--gym-border); }
-.goal-card.goal-running { background: var(--run-soft); border-color: var(--run-border); }
-.goal-card.goal-reading { background: var(--read-soft); border-color: var(--read-border); }
-.goal-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-sm); }
-.goal-title { font-size: 15px; font-weight: 700; }
-.goal-value { font-size: 18px; font-weight: 700; }
-.goal-actions { display: flex; gap: 8px; flex-wrap: wrap; }
-.goal-actions .btn { flex: 1; min-width: 120px; }
-.goal-meta { font-size: 11px; color: var(--muted); }
-.priorities-card { display: flex; flex-direction: column; gap: 12px; }
-.priority-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.priority-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.8);
-  transition: var(--transition-fast);
-}
-.priority-item:hover { border-color: rgba(37, 99, 235, 0.35); box-shadow: var(--shadow-sm); }
-.priority-item.completed { background: var(--green-soft); border-color: var(--green-border); }
-.priority-details { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+
+.action-btn.primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+.action-btn.success { background: var(--success); color: #fff; border-color: var(--success); }
+.action-btn.danger { border-color: rgba(220, 38, 38, 0.3); color: var(--danger); background: #fff5f5; }
+.action-btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+
+.detail-actions { display: flex; gap: 10px; margin-top: 18px; flex-wrap: wrap; }
+
+.priority-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.priority-item { display: flex; justify-content: space-between; gap: 12px; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.3); background: rgba(248, 250, 252, 0.8); transition: var(--transition); }
+.priority-item.completed { background: var(--success-soft); border-color: var(--success-border); }
+.priority-body { display: flex; flex-direction: column; gap: 4px; }
 .priority-title { font-weight: 600; font-size: 13px; }
-.priority-item.completed .priority-title { text-decoration: line-through; color: var(--muted); }
-.priority-meta { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
-.priority-actions { display: flex; gap: 6px; }
-.priority-toggle, .priority-delete {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  border-radius: 8px;
-  padding: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: var(--transition-fast);
-  color: var(--muted);
-}
-.priority-toggle:hover { color: var(--green); background: var(--green-soft); }
-.priority-delete:hover { color: var(--red); background: var(--red-soft); }
-.empty-priority { margin: 0; text-align: center; font-size: 12px; color: var(--muted); }
-.empty-planner {
-  text-align: center;
-  padding: 24px;
-  color: var(--muted);
-  border: 1px dashed var(--line);
-  border-radius: 14px;
-  margin-top: 8px;
-  background: rgba(255, 255, 255, 0.65);
-}
-.empty-planner h4 { margin: 0 0 6px 0; font-size: 15px; }
+.priority-meta { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; }
+.priority-item.completed .priority-title { text-decoration: line-through; }
+.priority-actions { display: flex; gap: 8px; }
+.priority-btn { border: none; background: rgba(148, 163, 184, 0.16); border-radius: 10px; padding: 6px 8px; cursor: pointer; color: var(--muted); display: inline-flex; align-items: center; justify-content: center; transition: var(--transition); }
+.priority-btn:hover { background: rgba(37, 99, 235, 0.15); color: var(--primary); }
+
+.goal-progress-list { display: flex; flex-direction: column; gap: 14px; }
+.goal-progress-item { display: flex; flex-direction: column; gap: 8px; }
+.goal-progress-label { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+.goal-progress-label strong { font-size: 13px; }
+.goal-progress-value { font-size: 11px; font-weight: 600; color: var(--muted); }
+.goal-progress-bar { width: 100%; height: 10px; border-radius: 999px; background: var(--line); overflow: hidden; }
+.goal-progress-bar span { display: block; height: 100%; border-radius: 999px; transition: width .3s ease; }
+
+.heatmap-card { display: flex; flex-direction: column; gap: 16px; }
+.heatmap { display: flex; gap: 4px; overflow-x: auto; padding-bottom: 6px; }
+.heatmap-week { display: grid; grid-template-rows: repeat(7, 14px) auto; gap: 4px; align-items: center; }
+.heatmap-cell { width: 14px; height: 14px; border-radius: 3px; background: #e2e8f0; }
+.heatmap-cell[data-level="0"] { background: #e2e8f0; }
+.heatmap-cell[data-level="1"] { background: #b7f3d0; }
+.heatmap-cell[data-level="2"] { background: #6ee7b7; }
+.heatmap-cell[data-level="3"] { background: #34d399; }
+.heatmap-cell[data-level="4"] { background: #059669; }
+.heatmap-cell--empty { background: transparent; }
+.heatmap-month-label { font-size: 9px; text-transform: uppercase; color: var(--muted); text-align: center; letter-spacing: 0.08em; }
+.heatmap-legend { display: flex; align-items: center; justify-content: flex-end; gap: 10px; font-size: 11px; color: var(--muted); }
+.heatmap-legend-scale { display: inline-flex; align-items: center; gap: 4px; }
+.heatmap-legend-scale span { width: 14px; height: 14px; border-radius: 3px; background: #e2e8f0; }
+.heatmap-legend-scale span[data-level="1"] { background: #b7f3d0; }
+.heatmap-legend-scale span[data-level="2"] { background: #6ee7b7; }
+.heatmap-legend-scale span[data-level="3"] { background: #34d399; }
+.heatmap-legend-scale span[data-level="4"] { background: #059669; }
 .modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(15, 23, 42, 0.6);
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
   display: flex;
-  justify-content: center;
   align-items: center;
-  z-index: 1000;
-  backdrop-filter: blur(4px);
+  justify-content: center;
   opacity: 0;
   pointer-events: none;
-  transition: opacity .2s ease-out;
+  transition: opacity .2s ease;
+  z-index: 100;
 }
+
 .modal-overlay.visible { opacity: 1; pointer-events: all; }
+
 .modal-card {
-  background: var(--card);
+  background: #fff;
   padding: 28px;
-  border-radius: 16px;
-  box-shadow: var(--shadow-lg);
+  border-radius: 18px;
   max-width: 440px;
   width: 90%;
-  text-align: center;
-  transition: transform .2s ease-out;
-  transform: scale(0.95);
-}
-.modal-overlay.visible .modal-card { transform: scale(1); }
-.modal-actions { margin-top: 20px; display: flex; justify-content: center; gap: 12px; }
-.modal-card input {
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  margin-top: 12px;
-  text-align: center;
-  font-size: 18px;
-  padding: 12px;
-  width: 100%;
-}
-.modal-options { margin-top: 16px; display: flex; flex-direction: column; gap: 12px; }
-.option-label {
+  box-shadow: var(--shadow-lg);
   display: flex;
-  align-items: center;
-  padding: 12px;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  cursor: pointer;
-  transition: var(--transition-fast);
+  flex-direction: column;
+  gap: 16px;
 }
-.option-label:hover { background-color: var(--bg); border-color: var(--blue-border); }
-.option-label input { margin-right: 12px; }
-.planning-mode .day-column { cursor: pointer; border: 1px dashed var(--blue-border); }
-.planning-mode .day-column:hover { border-color: var(--blue); background: var(--blue-soft); }
+
+.modal-card h3 { font-size: 18px; font-weight: 700; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 10px; }
+.modal-card input, .modal-card textarea, .modal-card select { width: 100%; border: 1px solid var(--line); border-radius: 12px; padding: 12px; font-family: inherit; font-size: 13px; }
+.modal-options { display: flex; flex-direction: column; gap: 10px; }
+.option-label { border: 1px solid var(--line); border-radius: 12px; padding: 10px 12px; display: flex; align-items: center; gap: 10px; cursor: pointer; transition: var(--transition); }
+.option-label:hover { border-color: var(--primary); background: var(--primary-soft); }
+.option-label input { accent-color: var(--primary); }
+
 #save-status {
   position: fixed;
-  bottom: 20px;
+  bottom: 24px;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateY(20px);
   background: var(--ink);
   color: #fff;
   padding: 10px 20px;
-  border-radius: 12px;
+  border-radius: 14px;
   box-shadow: var(--shadow-lg);
-  z-index: 2000;
   opacity: 0;
-  transition: opacity .3s, transform .3s;
   pointer-events: none;
+  transition: opacity .3s ease, transform .3s ease;
   font-size: 12px;
+  z-index: 120;
 }
-#save-status.visible { opacity: 1; transform: translateX(-50%) translateY(-10px); }
-.icon { width: 16px; height: 16px; }
-@media (max-width: 1180px) {
-  .dashboard { grid-template-columns: 1fr; }
-  .dashboard-side { grid-template-rows: auto auto; }
+
+#save-status.visible { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+@media (max-width: 1080px) {
+  .layout { grid-template-columns: 1fr; }
 }
-@media (max-width: 860px) {
-  .analytics-card { grid-template-columns: 1fr; }
-  .metrics-grid { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
-  .planner-grid { grid-template-columns: repeat(7, minmax(130px, 1fr)); }
-  .planner-grid-wrapper { overflow-x: auto; }
-}
-@media (max-width: 600px) {
+
+@media (max-width: 720px) {
+  .wrap { padding: 24px 18px 40px; }
   .page-header-top { flex-direction: column; align-items: flex-start; }
-  .header-left { flex-direction: column; align-items: flex-start; }
-  .week-chip { align-self: flex-start; }
-  .btn { width: 100%; justify-content: center; }
-  .planner-controls { width: 100%; justify-content: space-between; }
-  .week-nav { flex: 1; justify-content: space-between; }
+  .page-header-actions { width: 100%; }
+  .page-header-actions .btn { flex: 1; justify-content: center; }
+  .metrics-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .calendar-weekdays { display: none; }
+  .calendar-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
   </style>
 </head>
 <body>
-
 <div class="wrap">
   <header class="page-header card">
     <div class="page-header-top">
-      <div class="header-left">
-        <a href="./index.html" class="btn ghost"><i data-lucide="arrow-left" class="icon"></i>Powrót</a>
-        <div class="header-title-block">
-          <span class="eyebrow">Strategiczne zarządzanie rozwojem</span>
-          <div class="header-title-row">
-            <h1>Panel treningów</h1>
-            <span class="week-chip" id="header-week-label">Tydzień --</span>
-          </div>
-          <span class="header-week-range" id="header-week-range">--</span>
+      <div class="title-block">
+        <span class="eyebrow">Program treningowy</span>
+        <div class="title-row">
+          <h1>Panel treningów</h1>
+          <span class="month-chip" id="header-month-chip">--</span>
         </div>
       </div>
+      <div class="page-header-actions">
+        <a href="./index.html" class="btn ghost"><i data-lucide="arrow-left" class="icon"></i>Powrót</a>
+        <button id="today-month-btn" class="btn soft"><i data-lucide="calendar" class="icon"></i>Dzisiaj</button>
+      </div>
     </div>
-    <div class="metrics-grid">
+    <div class="month-bar">
+      <div class="month-controls">
+        <button id="prev-month-btn" class="icon-btn" aria-label="Poprzedni miesiąc"><i data-lucide="chevron-left" class="icon"></i></button>
+        <div class="month-labels">
+          <h2 id="current-month-label">--</h2>
+          <span class="month-range muted" id="current-month-range">--</span>
+        </div>
+        <button id="next-month-btn" class="icon-btn" aria-label="Następny miesiąc"><i data-lucide="chevron-right" class="icon"></i></button>
+      </div>
+    </div>
+    <div class="metrics-row">
       <div class="metric-card">
         <span class="metric-label">Realizacja celów</span>
-        <span class="metric-value" id="header-week-progress">0%</span>
-        <span class="metric-sub">Średni postęp celów głównych</span>
+        <span class="metric-value" id="metric-goal-progress">0%</span>
+        <span class="metric-sub">Średni postęp głównych celów</span>
       </div>
       <div class="metric-card">
-        <span class="metric-label">Aktywności tygodnia</span>
-        <span class="metric-value" id="header-planned-activities">0/0</span>
-        <span class="metric-sub">ukończone / zaplanowane</span>
+        <span class="metric-label">Zamknięte działania</span>
+        <span class="metric-value" id="metric-plan-completion">0/0</span>
+        <span class="metric-sub">Ukończone vs zaplanowane</span>
       </div>
       <div class="metric-card">
-        <span class="metric-label">Status planu</span>
-        <span class="metric-value" id="header-plan-status">W trakcie</span>
-        <span class="metric-sub" id="header-plan-status-hint">Uzupełnij plan, aby zamknąć cele tygodnia.</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-label">Ukończone tyg.</span>
-        <span class="metric-value" id="yearly-progress-value">0/36</span>
-        <span class="metric-sub">Cel roczny</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-label">Seria</span>
-        <span class="metric-value" id="streak-value">0</span>
-        <span class="metric-sub">Najdłuższa passa</span>
+        <span class="metric-label">Aktywne dni</span>
+        <span class="metric-value" id="metric-active-days">0/0</span>
+        <span class="metric-sub">Dni z planem w miesiącu</span>
       </div>
       <div class="metric-card">
         <span class="metric-label">Najbliższa aktywność</span>
-        <span class="metric-value" id="next-activity-kpi">Brak planu</span>
-        <span class="metric-sub" id="next-activity-date"></span>
+        <span class="metric-value" id="metric-next-activity">Brak</span>
+        <span class="metric-sub" id="metric-next-activity-date">--</span>
       </div>
     </div>
   </header>
 
-  <main class="dashboard">
-    <section class="dashboard-main">
-      <div id="planner-shell" class="card planner-card">
-        <div class="planner-header">
-          <div class="planner-title">
-            <h3 class="section-title"><i data-lucide="layout-grid" class="icon"></i>Planer tygodniowy</h3>
-            <span class="planner-range" id="planner-week-range">--</span>
+  <main class="layout">
+    <section class="calendar-column">
+      <div class="card calendar-card">
+        <div class="card-header">
+          <div>
+            <h3>Harmonogram miesięczny</h3>
+            <p class="muted tiny">Planowanie i realizacja celów bez przewijania</p>
           </div>
-          <div class="planner-controls">
-            <button id="copy-plan-btn" class="btn ghost" style="display: none;"><i data-lucide="copy" class="icon"></i>Kopiuj plan</button>
-            <div class="week-nav">
-              <button id="prev-week-btn" class="btn soft"><i data-lucide="chevron-left" class="icon"></i>Poprzedni</button>
-              <button id="today-week-btn" class="btn soft" style="display: none;">Bieżący</button>
-              <button id="next-week-btn" class="btn soft">Następny<i data-lucide="chevron-right" class="icon"></i></button>
-            </div>
+          <div class="calendar-legend">
+            <span><span class="legend-dot gym"></span>Siłownia</span>
+            <span><span class="legend-dot running"></span>Bieganie</span>
+            <span><span class="legend-dot reading"></span>Czytanie</span>
+            <span><span class="legend-dot extra"></span>Dodatkowe</span>
           </div>
         </div>
-        <div class="planner-meta">
-          <span id="planning-status" class="planner-status muted"></span>
-          <button id="cancel-planning-btn" class="btn soft small" style="display: none;">Zakończ planowanie</button>
+        <div class="calendar-weekdays">
+          <span>Pon</span><span>Wt</span><span>Śr</span><span>Czw</span><span>Pt</span><span>Sob</span><span>Niedz</span>
         </div>
-        <p id="planning-instructions" class="planner-instructions"></p>
-        <div class="planner-grid-wrapper">
-          <div class="planner-grid"></div>
-        </div>
-        <div id="empty-planner-placeholder" class="empty-planner" style="display: none;">
-          <h4>Brak zaplanowanych działań</h4>
-          <p class="muted">Dodaj cele z panelu obok lub użyj szybkich przycisków w kalendarzu.</p>
-        </div>
+        <div id="calendar-grid" class="calendar-grid"></div>
       </div>
 
-      <div class="card analytics-card">
-        <div class="next-actions-panel">
-          <div class="panel-header">
-            <h3 class="section-title"><i data-lucide="alarm-clock" class="icon"></i>Najbliższe kroki</h3>
-            <p class="muted tiny">Automatyczne podpowiedzi z planera i aktywności dodatkowych.</p>
-          </div>
-          <ul id="next-actions-list" class="next-actions-list"></ul>
-          <p id="next-actions-empty" class="empty-priority">Brak zaplanowanych aktywności na horyzoncie.</p>
-        </div>
-        <div class="heatmap-panel">
-          <div class="panel-header">
-            <h3 class="section-title"><i data-lucide="flame" class="icon"></i>Aktywność w czasie</h3>
-            <p class="muted tiny">Każdy kwadrat to jeden dzień roku. Im ciemniejszy odcień, tym więcej ukończonych działań.</p>
-          </div>
-          <div class="heatmap-container"></div>
-          <div class="heatmap-legend">
-            <span class="muted tiny">Mniej</span>
-            <div class="heatmap-cell" style="background: var(--line)"></div>
-            <div class="heatmap-cell" data-level="1"></div>
-            <div class="heatmap-cell" data-level="2"></div>
-            <div class="heatmap-cell" data-level="3"></div>
-            <div class="heatmap-cell" data-level="4"></div>
-            <span class="muted tiny">Więcej</span>
+      <div class="card overview-card">
+        <div class="card-header">
+          <div>
+            <h3>Najbliższe działania</h3>
+            <p class="muted tiny">Lista priorytetów na obecny miesiąc</p>
           </div>
         </div>
+        <ul id="upcoming-list" class="upcoming-list"></ul>
+        <p id="upcoming-empty" class="empty-state">Brak zaplanowanych aktywności w nadchodzących dniach.</p>
       </div>
     </section>
 
-    <aside class="dashboard-side">
-      <div class="card weekly-overview-card">
-        <div class="panel-header">
-          <h3 class="section-title"><i data-lucide="calendar-check" class="icon"></i><span id="week-title">Cele tygodniowe</span></h3>
-          <p class="muted tiny">Monitoruj realizację kluczowych wskaźników.</p>
+    <aside class="sidebar">
+      <div class="card day-detail-card">
+        <div class="day-detail-header">
+          <div>
+            <h3 id="selected-day-title">--</h3>
+            <p class="muted tiny" id="selected-day-summary">Wybierz dzień z kalendarza, aby zarządzać planem.</p>
+          </div>
+          <span class="month-chip" id="selected-day-chip">--</span>
         </div>
-        <div class="overview-progress">
-          <div class="progress-summary">
-            <span id="overall-progress-label" class="tiny muted">Postęp tygodnia: 0%</span>
+
+        <div class="detail-block">
+          <div class="detail-block-header">
+            <span>Plan treningowy</span>
           </div>
-          <div class="progress-bar"><div id="overall-progress-bar" style="width:0%; background: var(--blue);"></div></div>
+          <div id="day-plan-list" class="detail-list"></div>
+          <p id="day-plan-empty" class="empty-state">Brak zaplanowanych treningów na ten dzień.</p>
         </div>
-        <div class="goal-grid">
-          <div class="goal-card goal-gym">
-            <div class="goal-title">💪 Trening siłowy</div>
-            <div id="goal-gym-progress" class="goal-value">0/3 sesje</div>
-            <div class="progress-bar"><div id="goal-gym-bar" style="width:0%; background: var(--gym-color);"></div></div>
-            <p class="goal-meta" id="goal-gym-remaining">Pozostało: 3 sesje</p>
-            <div class="goal-actions">
-              <button class="btn soft" data-activity-type="gym" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
-            </div>
+
+        <div class="detail-block">
+          <div class="detail-block-header">
+            <span>Aktywności dodatkowe</span>
           </div>
-          <div class="goal-card goal-running">
-            <div class="goal-title">🏃 Bieg</div>
-            <div id="goal-running-progress" class="goal-value">0/5 km</div>
-            <div class="progress-bar"><div id="goal-running-bar" style="width:0%; background: var(--run-color);"></div></div>
-            <p class="goal-meta" id="goal-running-remaining">Pozostało: 5 km</p>
-            <div class="goal-actions">
-              <button class="btn soft" data-activity-type="running" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
-            </div>
-          </div>
-          <div class="goal-card goal-reading">
-            <div class="goal-title">📚 Czytanie</div>
-            <div id="goal-reading-progress" class="goal-value">0/100 stron</div>
-            <div class="progress-bar"><div id="goal-reading-bar" style="width:0%; background: var(--read-color);"></div></div>
-            <p class="goal-meta" id="goal-reading-remaining">Pozostało: 100 stron</p>
-            <div class="goal-actions">
-              <button class="btn soft" data-activity-type="reading" data-action="plan"><i data-lucide="plus-circle" class="icon"></i>Dodaj do planu</button>
-            </div>
-          </div>
+          <div id="day-extra-list" class="detail-list"></div>
+          <p id="day-extra-empty" class="empty-state">Dodaj krótkie działania lub przypomnienia.</p>
+        </div>
+
+        <div class="detail-actions">
+          <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj trening</button>
+          <button id="add-extra-btn" class="btn ghost"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
         </div>
       </div>
 
       <div class="card priorities-card">
-        <div class="panel-header">
-          <h3 class="section-title"><i data-lucide="star" class="icon"></i>Priorytety tygodnia</h3>
-          <p class="muted tiny">Skup się na maksymalnie trzech działaniach o największym wpływie.</p>
+        <div class="card-header">
+          <div>
+            <h3>Priorytety miesiąca</h3>
+            <p class="muted tiny" id="priority-month-label">--</p>
+          </div>
         </div>
         <ul id="priority-list" class="priority-list"></ul>
-        <p id="priority-empty" class="empty-priority">Dodaj pierwszy priorytet, by mieć jasność działań.</p>
-        <button id="add-priority-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
+        <p id="priority-empty" class="empty-state">Ustal maksymalnie trzy kluczowe priorytety, które dociągniesz do końca miesiąca.</p>
+        <button id="priority-add-btn" class="btn soft"><i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet</button>
+      </div>
+
+      <div class="card analytics-card">
+        <div class="card-header">
+          <div>
+            <h3>Postęp celów</h3>
+            <p class="muted tiny">Porównanie z planem miesięcznym</p>
+          </div>
+        </div>
+        <div id="goal-progress-list" class="goal-progress-list"></div>
       </div>
     </aside>
   </main>
+
+  <div class="card heatmap-card">
+    <div class="card-header">
+      <div>
+        <h3>Historia aktywności</h3>
+        <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
+      </div>
+      <span class="month-chip" id="heatmap-year-label">--</span>
+    </div>
+    <div id="heatmap" class="heatmap"></div>
+    <div class="heatmap-legend">
+      <span>Brak</span>
+      <div class="heatmap-legend-scale">
+        <span data-level="0"></span>
+        <span data-level="1"></span>
+        <span data-level="2"></span>
+        <span data-level="3"></span>
+        <span data-level="4"></span>
+      </div>
+      <span>Intensywnie</span>
+    </div>
+  </div>
 </div>
 
 <div id="modal-overlay" class="modal-overlay">
   <div class="modal-card">
-    <h3 id="modal-title" class="section-title" style="justify-content: center;"></h3>
+    <h3 id="modal-title"></h3>
     <p id="modal-text" class="muted"></p>
     <div id="modal-input-container"></div>
     <div id="modal-options-container"></div>
     <div id="modal-actions" class="modal-actions"></div>
   </div>
 </div>
-
-<div id="save-status">Zapisano!</div>
+<div id="save-status">Zapisano zmiany</div>
 
 <script>
-// --- KONFIGURACJA ---
-const STORAGE_KEY = 'lifeos_trainings_v1';
+const STORAGE_KEY = 'lifeos_trainings_month_v1';
 const GOAL_DEFINITIONS = {
-    gym: { target: 3, unit: 'sesje', label: 'Trening siłowy', icon: 'dumbbell' },
-    running: { target: 5, unit: 'km', label: 'Bieg', icon: 'activity' },
-    reading: { target: 100, unit: 'stron', label: 'Czytanie', icon: 'book-open' }
+  gym: { target: 10, unit: 'sesji', label: 'Trening siłowy', icon: 'dumbbell', color: 'var(--gym-color)' },
+  running: { target: 60, unit: 'km', label: 'Bieganie', icon: 'activity', color: 'var(--run-color)' },
+  reading: { target: 300, unit: 'stron', label: 'Czytanie', icon: 'book-open', color: 'var(--read-color)' }
 };
 const EXTRA_ACTIVITY_CATEGORIES = [
-    { value: 'training', label: 'Trening / ruch' },
-    { value: 'learning', label: 'Nauka / rozwój' },
-    { value: 'relax', label: 'Regeneracja' },
-    { value: 'home', label: 'Dom i organizacja' },
-    { value: 'other', label: 'Inne' }
+  { value: 'training', label: 'Trening / ruch' },
+  { value: 'learning', label: 'Nauka / rozwój' },
+  { value: 'relax', label: 'Regeneracja' },
+  { value: 'home', label: 'Dom i organizacja' },
+  { value: 'other', label: 'Inne' }
 ];
 const EXTRA_CATEGORY_LABELS = EXTRA_ACTIVITY_CATEGORIES.reduce((acc, item) => {
-    acc[item.value] = item.label;
-    return acc;
+  acc[item.value] = item.label;
+  return acc;
 }, {});
-const MAX_PRIORITIES = 3;
 const PRIORITY_IMPACT_OPTIONS = [
-    { value: 'high', label: 'Wysoki wpływ' },
-    { value: 'medium', label: 'Średni wpływ' },
-    { value: 'low', label: 'Lekki wpływ' }
+  { value: 'high', label: 'Wysoki wpływ' },
+  { value: 'medium', label: 'Średni wpływ' },
+  { value: 'low', label: 'Lekki wpływ' }
 ];
 const PRIORITY_IMPACT_LABELS = PRIORITY_IMPACT_OPTIONS.reduce((acc, opt) => {
-    acc[opt.value] = opt.label;
-    return acc;
+  acc[opt.value] = opt.label;
+  return acc;
 }, {});
-const DEFAULT_EXTRA_CATEGORY = 'other';
-const MAX_NEXT_ACTIONS = 5;
-const DAY_NAMES = ['Niedz', 'Pon', 'Wt', 'Śr', 'Czw', 'Pt', 'Sob'];
+const MAX_PRIORITIES = 3;
 
-function createEmptyDayMapping() {
-    return { 1: [], 2: [], 3: [], 4: [], 5: [], 6: [], 0: [] };
-}
-
-let state = {};
-let currentDate = new Date();
-let planningState = { isPlanning: false, activityType: null };
-let dragState = { activityId: null, sourceDay: null };
+let state = { activities: {}, extras: {}, priorities: {} };
+let currentMonth = startOfMonth(new Date());
+let selectedDate = toYYYYMMDD(new Date());
 let saveTimeout;
 
-function ensureWeekDataShape(weekData) {
-    if (!weekData.plan) weekData.plan = createEmptyDayMapping();
-    if (!weekData.progress) weekData.progress = { gym: 0, running: 0, reading: 0 };
-    if (!weekData.extras) weekData.extras = createEmptyDayMapping();
-    if (!Array.isArray(weekData.priorities)) weekData.priorities = [];
+function startOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
 }
 
-function getCurrentWeekContext() {
-    const [year, week] = getWeekNumber(currentDate);
-    initializeWeekData(year, week);
-    return { year, week, weekData: state[year][week] };
+function toYYYYMMDD(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function parseDate(dateString) {
+  const [y, m, d] = dateString.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function formatMonth(date) {
+  return date.toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+}
+
+function formatRange(start, end) {
+  return `${start.toLocaleDateString('pl-PL', { day: '2-digit', month: 'short' })} – ${end.toLocaleDateString('pl-PL', { day: '2-digit', month: 'short' })}`;
 }
 
 function formatDateWithDay(date) {
-    const dayLabel = DAY_NAMES[date.getDay()] || '';
-    return `${dayLabel} · ${date.toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit' })}`;
+  return date.toLocaleDateString('pl-PL', { weekday: 'short', day: '2-digit', month: 'short' });
 }
 
-function formatWeekRange(startDate) {
-    const endDate = new Date(startDate);
-    endDate.setDate(startDate.getDate() + 6);
-    const options = { day: '2-digit', month: 'short' };
-    const startLabel = startDate.toLocaleDateString('pl-PL', options);
-    const endLabel = endDate.toLocaleDateString('pl-PL', options);
-    return `${startLabel} – ${endLabel}`;
+function addDays(date, days) {
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + days);
+  return copy;
 }
 
-// --- STAN APLIKACJI ---
-function loadState() { state = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {}; }
-function saveState() { 
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    const saveStatus = document.getElementById('save-status');
-    clearTimeout(saveTimeout);
-    saveStatus.classList.add('visible');
-    saveTimeout = setTimeout(() => saveStatus.classList.remove('visible'), 1500);
+function ensureDay(dateString) {
+  if (!state.activities[dateString]) state.activities[dateString] = [];
+  if (!state.extras[dateString]) state.extras[dateString] = [];
 }
 
-// --- POMOCNICY DATY ---
-function getWeekNumber(d) {
-    d = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
-    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay()||7));
-    var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
-    var weekNo = Math.ceil((((d - yearStart) / 86400000) + 1)/7);
-    return [d.getUTCFullYear(), weekNo];
+function ensurePriorityMonth(monthKey) {
+  if (!state.priorities[monthKey]) state.priorities[monthKey] = [];
 }
-function getStartOfWeek(year, week) {
-    const d = new Date(Date.UTC(year, 0, 1 + (week - 1) * 7));
-    const day = d.getUTCDay();
-    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-    return new Date(d.setUTCDate(diff));
-}
-function toYYYYMMDD(date) { return date.toISOString().slice(0, 10); }
 
-// --- LOGIKA BIZNESOWA ---
-function initializeWeekData(year, week) {
-    if (!state[year]) state[year] = {};
-    if (!state[year][week]) {
-        state[year][week] = {
-            progress: { gym: 0, running: 0, reading: 0 },
-            plan: createEmptyDayMapping(),
-            extras: createEmptyDayMapping(),
-            priorities: [],
-            isComplete: false,
-            summaryShown: false
-        };
+function sameMonth(date, reference) {
+  return date.getFullYear() === reference.getFullYear() && date.getMonth() === reference.getMonth();
+}
+
+function normalizeDate(date) {
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      state.activities = parsed.activities || {};
+      state.extras = parsed.extras || {};
+      state.priorities = parsed.priorities || {};
     }
-    ensureWeekDataShape(state[year][week]);
+  } catch (error) {
+    state = { activities: {}, extras: {}, priorities: {} };
+  }
 }
 
-function addActivity(type, dayIndex, plannedValue) {
-    const { weekData } = getCurrentWeekContext();
-    const newActivity = {
-        id: `act_${Date.now()}_${Math.random()}`,
-        type: type,
-        completed: false,
-        day: dayIndex,
-        plannedValue: plannedValue,
-        loggedValue: 0
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  const status = document.getElementById('save-status');
+  status.classList.add('visible');
+  clearTimeout(saveTimeout);
+  saveTimeout = setTimeout(() => status.classList.remove('visible'), 1600);
+}
+
+function getMonthKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function getCalendarDays(monthDate) {
+  const start = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1);
+  const offset = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - offset);
+  const days = [];
+  for (let i = 0; i < 42; i++) {
+    const cell = new Date(start);
+    cell.setDate(start.getDate() + i);
+    days.push(cell);
+  }
+  return days;
+}
+
+function ensureSelectionInMonth() {
+  const currentSelection = parseDate(selectedDate);
+  if (!sameMonth(currentSelection, currentMonth)) {
+    selectedDate = toYYYYMMDD(currentMonth);
+  }
+}
+
+function calculateMonthlyStats(monthDate) {
+  const firstDay = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1);
+  const lastDay = new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0);
+  const totalDays = lastDay.getDate();
+  const totals = { planned: 0, completed: 0 };
+  const goalProgress = { gym: 0, running: 0, reading: 0 };
+  const activeDays = new Set();
+  const upcoming = [];
+  const today = normalizeDate(new Date());
+
+  Object.entries(state.activities).forEach(([dateString, activities]) => {
+    const date = parseDate(dateString);
+    if (!sameMonth(date, monthDate)) return;
+    if (activities.length) activeDays.add(dateString);
+    totals.planned += activities.length;
+    activities.forEach(activity => {
+      if (activity.completed) {
+        totals.completed += 1;
+        if (activity.type === 'gym') goalProgress.gym += 1;
+        else goalProgress[activity.type] += Number(activity.loggedValue) || Number(activity.plannedValue) || 0;
+      } else if (normalizeDate(date) >= today) {
+        const goal = GOAL_DEFINITIONS[activity.type];
+        if (!goal) return;
+        let label = goal.label;
+        if (activity.type !== 'gym' && activity.plannedValue) {
+          label += ` • ${Number(activity.plannedValue).toLocaleString('pl-PL')} ${goal.unit}`;
+        }
+        upcoming.push({
+          type: activity.type,
+          label,
+          badge: 'Trening',
+          icon: goal.icon || 'activity',
+          date,
+          dateLabel: formatDateWithDay(date)
+        });
+      }
+    });
+  });
+
+  Object.entries(state.extras).forEach(([dateString, extras]) => {
+    const date = parseDate(dateString);
+    if (!sameMonth(date, monthDate)) return;
+    if (extras.length) activeDays.add(dateString);
+    totals.planned += extras.length;
+    extras.forEach(extra => {
+      if (extra.completed) {
+        totals.completed += 1;
+      } else if (normalizeDate(date) >= today) {
+        upcoming.push({
+          type: 'extra',
+          label: extra.title,
+          badge: EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność',
+          icon: 'sparkles',
+          date,
+          dateLabel: formatDateWithDay(date)
+        });
+      }
+    });
+  });
+
+  upcoming.sort((a, b) => {
+    const diff = a.date - b.date;
+    if (diff !== 0) return diff;
+    return a.type.localeCompare(b.type);
+  });
+
+  const goalPercents = {};
+  Object.keys(GOAL_DEFINITIONS).forEach(type => {
+    const progressValue = goalProgress[type] || 0;
+    const target = GOAL_DEFINITIONS[type].target;
+    const percent = target > 0 ? Math.min(100, Math.round((progressValue / target) * 100)) : 0;
+    goalPercents[type] = {
+      percent,
+      progress: progressValue,
+      target
     };
-    if(!weekData.plan[dayIndex]) weekData.plan[dayIndex] = [];
-    weekData.plan[dayIndex].push(newActivity);
-    saveState();
-    render();
+  });
+  const averageGoalPercent = Math.round(Object.values(goalPercents).reduce((acc, info) => acc + info.percent, 0) / Object.keys(GOAL_DEFINITIONS).length) || 0;
+
+  return {
+    plannedCount: totals.planned,
+    completedCount: totals.completed,
+    activeDays: activeDays.size,
+    totalDays,
+    goalPercents,
+    averageGoalPercent,
+    nextActivity: upcoming.length ? { label: upcoming[0].label, dateLabel: upcoming[0].dateLabel } : null,
+    upcoming,
+    range: { start: firstDay, end: lastDay }
+  };
 }
 
-function deleteActivity(activityId) {
-    const { year, week, weekData } = getCurrentWeekContext();
-    for (const day in weekData.plan) {
-        const initialLength = weekData.plan[day].length;
-        weekData.plan[day] = weekData.plan[day].filter(a => a.id !== activityId);
-        if (weekData.plan[day].length < initialLength) break;
-    }
-    recalculateWeekProgress(year, week);
-    checkWeekCompletion(year, week);
-    saveState();
-    render();
-}
-
-function logActivity(activityId, value, isCompleted) {
-    const { year, week, weekData } = getCurrentWeekContext();
-    let activityFound = null;
-    for (const day in weekData.plan) {
-        const activity = weekData.plan[day].find(a => a.id === activityId);
-        if (activity) { activityFound = activity; break; }
-    }
-    if (activityFound) {
-        activityFound.completed = isCompleted;
-        activityFound.loggedValue = Number(value) || 0;
-        recalculateWeekProgress(year, week);
-        checkWeekCompletion(year, week);
-        saveState();
-        render();
-    }
-}
-
-function addExtraActivity(dayIndex, title, category = DEFAULT_EXTRA_CATEGORY) {
-    const trimmedTitle = (title || '').trim();
-    if (!trimmedTitle) return;
-    const { weekData } = getCurrentWeekContext();
-    if (!weekData.extras[dayIndex]) weekData.extras[dayIndex] = [];
-    weekData.extras[dayIndex].push({
-        id: `extra_${Date.now()}_${Math.random()}`,
-        title: trimmedTitle,
-        category: category || DEFAULT_EXTRA_CATEGORY,
-        completed: false,
-        day: dayIndex,
-        createdAt: Date.now()
-    });
-    saveState();
-    render();
-}
-
-function toggleExtraActivity(activityId) {
-    const { weekData } = getCurrentWeekContext();
-    let updated = false;
-    for (const day in weekData.extras) {
-        const activity = weekData.extras[day].find(a => a.id === activityId);
-        if (activity) {
-            activity.completed = !activity.completed;
-            updated = true;
-            break;
-        }
-    }
-    if (updated) {
-        saveState();
-        render();
-    }
-}
-
-function deleteExtraActivity(activityId) {
-    const { weekData } = getCurrentWeekContext();
-    let removed = false;
-    for (const day in weekData.extras) {
-        const before = weekData.extras[day].length;
-        weekData.extras[day] = weekData.extras[day].filter(a => a.id !== activityId);
-        if (weekData.extras[day].length !== before) {
-            removed = true;
-            break;
-        }
-    }
-    if (removed) {
-        saveState();
-        render();
-    }
-}
-
-function recalculateWeekProgress(year, week) {
-    const weekData = state[year][week];
-    weekData.progress = { gym: 0, running: 0, reading: 0 };
-    Object.values(weekData.plan).flat().forEach(activity => {
-        if (activity.completed) {
-            weekData.progress[activity.type] += (Number(activity.loggedValue) || 0);
-        }
-    });
-}
-
-function checkWeekCompletion(year, week) {
-    const weekData = state[year][week];
-    const allGoalsMet = Object.keys(GOAL_DEFINITIONS).every(type => 
-        (weekData.progress[type] || 0) >= GOAL_DEFINITIONS[type].target
-    );
-    if (weekData.isComplete !== allGoalsMet) {
-        weekData.isComplete = allGoalsMet;
-    }
-}
-
-function copyPreviousWeek(copyProgress = false) {
-    const [currentYear, currentWeek] = getWeekNumber(currentDate);
-    
-    let prevWeekDate = new Date(currentDate);
-    prevWeekDate.setDate(prevWeekDate.getDate() - 7);
-    const [prevYear, prevWeek] = getWeekNumber(prevWeekDate);
-
-    const prevWeekData = state[prevYear]?.[prevWeek];
-    if (!prevWeekData) return;
-
-    // Deep copy of the plan
-    const newPlan = JSON.parse(JSON.stringify(prevWeekData.plan));
-
-    Object.values(newPlan).flat().forEach(activity => {
-        activity.id = `act_${Date.now()}_${Math.random()}`; // New unique ID
-        if (!copyProgress) {
-            activity.completed = false;
-            activity.loggedValue = 0;
-        }
-    });
-
-    initializeWeekData(currentYear, currentWeek);
-    state[currentYear][currentWeek].plan = newPlan;
-
-    const newExtras = createEmptyDayMapping();
-    if (prevWeekData.extras) {
-        Object.keys(prevWeekData.extras).forEach(day => {
-            newExtras[day] = prevWeekData.extras[day].map(extra => ({
-                ...extra,
-                id: `extra_${Date.now()}_${Math.random()}`,
-                completed: copyProgress ? extra.completed : false,
-                day: parseInt(day, 10)
-            }));
-        });
-    }
-    state[currentYear][currentWeek].extras = newExtras;
-
-    state[currentYear][currentWeek].priorities = copyProgress && Array.isArray(prevWeekData.priorities)
-        ? prevWeekData.priorities.map(priority => ({
-            ...priority,
-            id: `prio_${Date.now()}_${Math.random()}`,
-            completed: copyProgress ? priority.completed : false
-        }))
-        : [];
-
-    recalculateWeekProgress(currentYear, currentWeek);
-    checkWeekCompletion(currentYear, currentWeek);
-    saveState();
-    render();
-}
-
-
-// --- FUNKCJE RENDERUJĄCE ---
 function render() {
-    const [year, week] = getWeekNumber(currentDate);
-    initializeWeekData(year, week);
-    
-    const weekData = state[year][week];
-    const startOfWeek = getStartOfWeek(year, week);
-    
-    const weekTitleEl = document.getElementById('week-title');
-    if (weekTitleEl) weekTitleEl.textContent = `Cele tygodniowe · ${week}/${year}`;
-
-    const weekRangeLabel = formatWeekRange(startOfWeek);
-    const headerWeekLabel = document.getElementById('header-week-label');
-    if (headerWeekLabel) headerWeekLabel.textContent = `Tydzień ${week}`;
-    const headerWeekRange = document.getElementById('header-week-range');
-    if (headerWeekRange) headerWeekRange.textContent = `${weekRangeLabel} · ${year}`;
-    const plannerRangeEl = document.getElementById('planner-week-range');
-    if (plannerRangeEl) plannerRangeEl.textContent = weekRangeLabel;
-
-    const todayBtn = document.getElementById('today-week-btn');
-    const [currentYear, currentWeek] = getWeekNumber(new Date());
-    if (todayBtn) {
-        todayBtn.style.display = (year === currentYear && week === currentWeek) ? 'none' : 'inline-flex';
-    }
-
-    renderCopyPlanButton();
-    renderGoals(weekData.progress);
-    renderPriorities(weekData.priorities);
-    const upcoming = renderNextActions(weekData, startOfWeek);
-    renderPlanner(weekData, startOfWeek);
-    renderHeaderKPIs(year, upcoming[0]);
-    renderPlanningStatus(weekData.plan);
-    renderOverallProgress(weekData.progress);
-    updateHeaderActivitiesOverview(weekData);
-    renderStats();
-    lucide.createIcons();
+  ensureSelectionInMonth();
+  const stats = calculateMonthlyStats(currentMonth);
+  renderHeader(stats);
+  renderCalendar();
+  renderDayDetail();
+  renderUpcoming(stats.upcoming);
+  renderPriorities();
+  renderGoalProgress(stats.goalPercents);
+  renderHeatmap();
+  lucide.createIcons();
 }
 
-function renderGoals(progress) {
-    for (const type in GOAL_DEFINITIONS) {
-        const goal = GOAL_DEFINITIONS[type];
-        const currentProgress = parseFloat(progress[type] || 0);
-        const progressPercent = Math.min(100, (currentProgress / goal.target) * 100);
+function renderHeader(stats) {
+  const monthLabel = formatMonth(currentMonth);
+  document.getElementById('header-month-chip').textContent = monthLabel;
+  document.getElementById('current-month-label').textContent = monthLabel;
+  document.getElementById('current-month-range').textContent = `${formatRange(stats.range.start, stats.range.end)} ${currentMonth.getFullYear()}`;
+  const todayButton = document.getElementById('today-month-btn');
+  if (sameMonth(new Date(), currentMonth)) todayButton.style.display = 'none';
+  else todayButton.style.display = 'inline-flex';
 
-        document.getElementById(`goal-${type}-progress`).textContent = `${currentProgress.toLocaleString('pl-PL')}/${goal.target} ${goal.unit}`;
-        document.getElementById(`goal-${type}-bar`).style.width = `${progressPercent}%`;
-        const remainingValue = Math.max(0, goal.target - currentProgress);
-        const remainingEl = document.getElementById(`goal-${type}-remaining`);
-        if (remainingEl) {
-            remainingEl.textContent = remainingValue <= 0
-                ? 'Cel zrealizowany! Świetna robota!'
-                : `Pozostało: ${remainingValue.toLocaleString('pl-PL')} ${goal.unit}`;
-        }
-    }
+  document.getElementById('metric-goal-progress').textContent = `${stats.averageGoalPercent}%`;
+  document.getElementById('metric-plan-completion').textContent = `${stats.completedCount}/${stats.plannedCount}`;
+  document.getElementById('metric-active-days').textContent = `${stats.activeDays}/${stats.totalDays}`;
+  if (stats.nextActivity) {
+    document.getElementById('metric-next-activity').textContent = stats.nextActivity.label;
+    document.getElementById('metric-next-activity-date').textContent = stats.nextActivity.dateLabel;
+  } else {
+    document.getElementById('metric-next-activity').textContent = 'Brak';
+    document.getElementById('metric-next-activity-date').textContent = '--';
+  }
+  document.getElementById('priority-month-label').textContent = monthLabel;
 }
 
-function renderPlanner(weekData, startOfWeek) {
-    const plannerGrid = document.querySelector('.planner-grid');
-    const emptyPlaceholder = document.getElementById('empty-planner-placeholder');
-    plannerGrid.innerHTML = '';
-    const today = new Date();
-    today.setHours(0,0,0,0);
+function renderCalendar() {
+  const grid = document.getElementById('calendar-grid');
+  grid.innerHTML = '';
+  const today = normalizeDate(new Date());
+  const days = getCalendarDays(currentMonth);
+  days.forEach(date => {
+    const dateString = toYYYYMMDD(date);
+    ensureDay(dateString);
+    const activities = state.activities[dateString] || [];
+    const extras = state.extras[dateString] || [];
+    const plannedCount = activities.length + extras.length;
+    const completedCount = activities.filter(a => a.completed).length + extras.filter(e => e.completed).length;
 
-    let isPlanEmpty = true;
-    const plan = weekData.plan || {};
-    const extrasMap = weekData.extras || {};
+    const cell = document.createElement('div');
+    cell.className = 'calendar-day';
+    if (date.getMonth() !== currentMonth.getMonth()) cell.classList.add('calendar-day--other-month');
+    if (dateString === selectedDate) cell.classList.add('calendar-day--selected');
+    if (normalizeDate(date).getTime() === today.getTime()) cell.classList.add('calendar-day--today');
 
-    for (let i = 1; i <= 7; i++) {
-        const dayIndex = i % 7;
-        const currentDay = new Date(startOfWeek);
-        currentDay.setDate(startOfWeek.getDate() + (dayIndex - 1 + 7) % 7);
-
-        const dayColumn = document.createElement('div');
-        dayColumn.className = 'day-column';
-        dayColumn.dataset.dayIndex = dayIndex;
-
-        const dayHeader = document.createElement('div');
-        dayHeader.className = 'day-header';
-        dayHeader.textContent = `${DAY_NAMES[dayIndex]} ${currentDay.getDate()}`;
-        if (currentDay.getTime() === today.getTime()) dayHeader.classList.add('today');
-        
-        const activitiesContainer = document.createElement('div');
-        activitiesContainer.className = 'activities-container';
-
-        const plannedActivities = plan[dayIndex] || [];
-        if (plannedActivities.length > 0) {
-            isPlanEmpty = false;
-            plannedActivities.forEach(activity => {
-                const goal = GOAL_DEFINITIONS[activity.type];
-                const pill = document.createElement('div');
-                pill.className = `activity-pill ${activity.type}`;
-                pill.dataset.activityId = activity.id;
-
-                let text = `<span>${goal.label}`;
-                if (activity.type !== 'gym') {
-                     if (activity.completed) text += ` (${activity.loggedValue.toLocaleString('pl-PL')}/${activity.plannedValue.toLocaleString('pl-PL')} ${goal.unit})`;
-                     else if (activity.plannedValue) text += ` (${activity.plannedValue.toLocaleString('pl-PL')} ${goal.unit})`;
-                }
-                text += '</span>';
-                pill.innerHTML = text;
-
-                if (activity.completed) {
-                    pill.classList.add('completed');
-                } else {
-                    pill.draggable = true;
-                    const deleteBtn = document.createElement('button');
-                    deleteBtn.className = 'delete-activity-btn';
-                    deleteBtn.dataset.activityId = activity.id;
-                    deleteBtn.setAttribute('aria-label', 'Usuń aktywność');
-                    deleteBtn.innerHTML = `<i data-lucide="x" class="icon" style="width:16px; height:16px;"></i>`;
-                    pill.appendChild(deleteBtn);
-                }
-                
-                pill.addEventListener('dragstart', handleDragStart);
-                pill.addEventListener('dragend', handleDragEnd);
-                activitiesContainer.appendChild(pill);
-            });
-        }
-
-        const quickAddBtn = document.createElement('button');
-        quickAddBtn.className = 'quick-add-btn';
-        quickAddBtn.innerHTML = '<i data-lucide="plus" class="icon" style="width:18px; height:18px;"></i>';
-        quickAddBtn.setAttribute('aria-label', 'Szybko dodaj aktywność');
-        dayColumn.appendChild(quickAddBtn);
-
-        const quickAddMenu = document.createElement('div');
-        quickAddMenu.className = 'quick-add-menu';
-        for(const type in GOAL_DEFINITIONS) {
-            const btn = document.createElement('button');
-            btn.textContent = GOAL_DEFINITIONS[type].label;
-            btn.onclick = (e) => {
-                e.stopPropagation();
-                showPlanModal(type, dayIndex);
-                quickAddMenu.style.display = 'none';
-            };
-            quickAddMenu.appendChild(btn);
-        }
-        const customBtn = document.createElement('button');
-        customBtn.textContent = 'Aktywność własna';
-        customBtn.onclick = (e) => {
-            e.stopPropagation();
-            showExtraActivityModal(dayIndex);
-            quickAddMenu.style.display = 'none';
-        };
-        quickAddMenu.appendChild(customBtn);
-        dayColumn.appendChild(quickAddMenu);
-
-        dayColumn.appendChild(dayHeader);
-        dayColumn.appendChild(activitiesContainer);
-
-        const extras = extrasMap[dayIndex] || [];
-        if (extras.length > 0) {
-            isPlanEmpty = false;
-        }
-
-        const extrasContainer = document.createElement('div');
-        extrasContainer.className = 'extras-container';
-        if (extras.length > 0) {
-            const extrasHeader = document.createElement('div');
-            extrasHeader.className = 'extras-header';
-            extrasHeader.innerHTML = '<span>Aktywności dodatkowe</span>';
-            extrasContainer.appendChild(extrasHeader);
-        }
-
-        extras.forEach(extra => {
-            const extraPill = document.createElement('div');
-            extraPill.className = 'extra-pill';
-            extraPill.dataset.extraId = extra.id;
-            extraPill.dataset.category = extra.category || DEFAULT_EXTRA_CATEGORY;
-            if (extra.completed) extraPill.classList.add('completed');
-
-            const extraMain = document.createElement('div');
-            extraMain.className = 'extra-main';
-
-            const toggleBtn = document.createElement('button');
-            toggleBtn.className = 'extra-toggle';
-            toggleBtn.dataset.extraId = extra.id;
-            toggleBtn.innerHTML = `<i data-lucide="${extra.completed ? 'check-circle-2' : 'circle'}" class="icon" style="width:18px; height:18px;"></i>`;
-            extraMain.appendChild(toggleBtn);
-
-            const info = document.createElement('div');
-            info.className = 'extra-info';
-            const title = document.createElement('span');
-            title.className = 'extra-title';
-            title.textContent = extra.title;
-            info.appendChild(title);
-            const categoryLabel = document.createElement('span');
-            categoryLabel.className = 'extra-category';
-            categoryLabel.textContent = EXTRA_CATEGORY_LABELS[extra.category] || EXTRA_CATEGORY_LABELS[DEFAULT_EXTRA_CATEGORY];
-            info.appendChild(categoryLabel);
-            extraMain.appendChild(info);
-
-            extraPill.appendChild(extraMain);
-
-            const deleteBtn = document.createElement('button');
-            deleteBtn.className = 'extra-delete-btn';
-            deleteBtn.dataset.extraId = extra.id;
-            deleteBtn.setAttribute('aria-label', 'Usuń aktywność dodatkową');
-            deleteBtn.innerHTML = '<i data-lucide="trash-2" class="icon" style="width:16px; height:16px;"></i>';
-            extraPill.appendChild(deleteBtn);
-
-            extrasContainer.appendChild(extraPill);
-        });
-
-        const addExtraBtn = document.createElement('button');
-        addExtraBtn.type = 'button';
-        addExtraBtn.className = 'add-extra-btn';
-        addExtraBtn.dataset.dayIndex = dayIndex;
-        addExtraBtn.innerHTML = '<i data-lucide="plus" class="icon" style="width:16px; height:16px;"></i>Dodaj aktywność';
-        extrasContainer.appendChild(addExtraBtn);
-
-        dayColumn.appendChild(extrasContainer);
-        dayColumn.addEventListener('dragover', handleDragOver);
-        dayColumn.addEventListener('dragleave', handleDragLeave);
-        dayColumn.addEventListener('drop', handleDrop);
-        plannerGrid.appendChild(dayColumn);
+    const header = document.createElement('div');
+    header.className = 'calendar-day-header';
+    const number = document.createElement('span');
+    number.className = 'calendar-date-number';
+    number.textContent = date.getDate();
+    header.appendChild(number);
+    const badges = document.createElement('div');
+    badges.className = 'calendar-day-badges';
+    if (plannedCount > 0) {
+      const badge = document.createElement('span');
+      badge.className = 'calendar-badge';
+      badge.textContent = plannedCount;
+      badges.appendChild(badge);
     }
-    
-    emptyPlaceholder.style.display = isPlanEmpty ? 'block' : 'none';
-}
+    header.appendChild(badges);
+    cell.appendChild(header);
 
-function renderHeaderKPIs(year, nextUpcoming) {
-    const yearData = state[year] || {};
-    const [currentYear, currentWeek] = getWeekNumber(new Date());
-
-    const relevantWeeks = (year < currentYear) ? getWeekNumber(new Date(year, 11, 28))[1] : currentWeek;
-    const completedWeeks = Object.keys(yearData).filter(weekNum => parseInt(weekNum) <= relevantWeeks && yearData[weekNum].isComplete).length;
-    
-    const percentage = relevantWeeks > 0 ? Math.round((completedWeeks / relevantWeeks) * 100) : 0;
-    document.getElementById('yearly-progress-value').innerHTML = `${completedWeeks}/${relevantWeeks} <span class="tiny" style="font-weight: 500;">(${percentage}%)</span>`;
-
-    let currentStreak = 0;
-    for (let w = currentWeek; w >= 1; w--) {
-        if (state[currentYear]?.[w]?.isComplete) currentStreak++;
-        else break;
-    }
-
-    let maxStreak = 0, tempStreak = 0;
-    Object.keys(state).sort().forEach(y => {
-        const totalWeeksInYear = getWeekNumber(new Date(y, 11, 28))[1];
-        for (let w = 1; w <= totalWeeksInYear; w++) {
-            if (state[y]?.[w]?.isComplete) tempStreak++;
-            else { maxStreak = Math.max(maxStreak, tempStreak); tempStreak = 0; }
-        }
+    const dots = document.createElement('div');
+    dots.className = 'calendar-day-dots';
+    const dotTypes = [];
+    activities.forEach(activity => dotTypes.push(activity.type));
+    extras.forEach(() => dotTypes.push('extra'));
+    dotTypes.slice(0, 8).forEach(type => {
+      const dot = document.createElement('span');
+      dot.className = `activity-dot ${type}`;
+      dots.appendChild(dot);
     });
-    maxStreak = Math.max(maxStreak, tempStreak);
+    cell.appendChild(dots);
 
-    document.getElementById('streak-value').innerHTML = `${currentStreak} <span class="tiny" style="font-weight: 500;">(max ${maxStreak})</span>`;
+    const footer = document.createElement('div');
+    footer.className = 'calendar-day-footer';
+    const done = document.createElement('span');
+    done.className = 'calendar-footer-label';
+    done.textContent = completedCount > 0 ? `${completedCount} ukończ.` : 'Brak';
+    const remaining = document.createElement('span');
+    const openCount = Math.max(0, plannedCount - completedCount);
+    remaining.textContent = openCount > 0 ? `${openCount} otwarte` : '';
+    footer.appendChild(done);
+    footer.appendChild(remaining);
+    cell.appendChild(footer);
 
-    const nextLabelEl = document.getElementById('next-activity-kpi');
-    const nextDateEl = document.getElementById('next-activity-date');
-    if (nextUpcoming && nextLabelEl && nextDateEl) {
-        nextLabelEl.textContent = nextUpcoming.label;
-        nextDateEl.textContent = `${nextUpcoming.badge} • ${formatDateWithDay(nextUpcoming.date)}`;
-    } else if (nextLabelEl && nextDateEl) {
-        nextLabelEl.textContent = 'Brak planu';
-        nextDateEl.textContent = '';
-    }
-}
-
-function renderPlanningStatus(plan) {
-    const statusEl = document.getElementById('planning-status');
-    const headerPlanStatus = document.getElementById('header-plan-status');
-    const headerPlanHint = document.getElementById('header-plan-status-hint');
-    const plannedTotals = { gym: 0, running: 0, reading: 0 };
-    Object.values(plan).flat().forEach(activity => {
-        plannedTotals[activity.type] += activity.completed ? activity.loggedValue : (activity.plannedValue || 0);
+    cell.addEventListener('click', () => {
+      selectedDate = dateString;
+      if (date.getMonth() !== currentMonth.getMonth()) {
+        currentMonth = startOfMonth(date);
+      }
+      render();
     });
 
-    const allGoalsPlanned = Object.keys(GOAL_DEFINITIONS).every(type => plannedTotals[type] >= GOAL_DEFINITIONS[type].target);
-
-    if (statusEl) {
-        if (allGoalsPlanned) {
-            statusEl.textContent = '✅ Wszystkie cele mają zaplanowane działania.';
-            statusEl.style.color = 'var(--green)';
-        } else {
-            statusEl.textContent = '🧭 Zaplanuj brakujące działania, aby domknąć tydzień.';
-            statusEl.style.color = 'var(--orange)';
-        }
-    }
-
-    if (headerPlanStatus && headerPlanHint) {
-        if (allGoalsPlanned) {
-            headerPlanStatus.textContent = 'Gotowy';
-            headerPlanStatus.style.color = 'var(--green)';
-            headerPlanHint.textContent = 'Cele mają pełny plan działania.';
-        } else {
-            headerPlanStatus.textContent = 'W trakcie';
-            headerPlanStatus.style.color = 'var(--orange)';
-            headerPlanHint.textContent = 'Uzupełnij plan, aby zamknąć cele tygodnia.';
-        }
-    }
+    grid.appendChild(cell);
+  });
 }
 
-function renderOverallProgress(progress) {
-    let totalPercent = 0;
-    for (const type in GOAL_DEFINITIONS) {
-        totalPercent += Math.min(100, ((progress[type] || 0) / GOAL_DEFINITIONS[type].target) * 100);
-    }
-    const avgPercent = totalPercent / Object.keys(GOAL_DEFINITIONS).length;
-    document.getElementById('overall-progress-bar').style.width = `${avgPercent}%`;
-    document.getElementById('overall-progress-label').textContent = `Postęp tygodnia: ${Math.round(avgPercent)}%`;
-    const headerProgress = document.getElementById('header-week-progress');
-    if (headerProgress) {
-        headerProgress.textContent = `${Math.round(avgPercent)}%`;
-    }
+function renderDayDetail() {
+  ensureDay(selectedDate);
+  const date = parseDate(selectedDate);
+  const activities = state.activities[selectedDate] || [];
+  const extras = state.extras[selectedDate] || [];
+  const completedCount = activities.filter(a => a.completed).length + extras.filter(e => e.completed).length;
+  const total = activities.length + extras.length;
+  document.getElementById('selected-day-title').textContent = date.toLocaleDateString('pl-PL', { weekday: 'long', day: 'numeric', month: 'long' });
+  document.getElementById('selected-day-summary').textContent = total > 0 ? `Zaplanowane: ${total} · Ukończone: ${completedCount}` : 'Brak zaplanowanych aktywności na ten dzień.';
+  document.getElementById('selected-day-chip').textContent = date.toLocaleDateString('pl-PL', { day: '2-digit', month: 'short' }).replace('.', '').toUpperCase();
+
+  renderDayActivities(activities);
+  renderDayExtras(extras);
 }
 
-function updateHeaderActivitiesOverview(weekData) {
-    const headerActivities = document.getElementById('header-planned-activities');
-    if (!headerActivities) return;
-    const planned = Object.values(weekData.plan || {}).flat();
-    const extras = Object.values(weekData.extras || {}).flat();
-    const total = planned.length + extras.length;
-    const completed = planned.filter(a => a.completed).length + extras.filter(a => a.completed).length;
-    headerActivities.textContent = total > 0 ? `${completed}/${total}` : '0/0';
-}
+function renderDayActivities(activities) {
+  const list = document.getElementById('day-plan-list');
+  const empty = document.getElementById('day-plan-empty');
+  list.innerHTML = '';
+  if (!activities.length) {
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
 
-function renderCopyPlanButton() {
-    let prevWeekDate = new Date(currentDate);
-    prevWeekDate.setDate(prevWeekDate.getDate() - 7);
-    const [prevYear, prevWeek] = getWeekNumber(prevWeekDate);
-
-    const prevWeekData = state[prevYear]?.[prevWeek];
-    const hasPreviousPlan = prevWeekData && (
-        Object.values(prevWeekData.plan || {}).some(day => day.length > 0) ||
-        Object.values(prevWeekData.extras || {}).some(day => day.length > 0)
-    );
-
-    const copyBtn = document.getElementById('copy-plan-btn');
-    if (copyBtn) {
-        copyBtn.style.display = hasPreviousPlan ? 'inline-flex' : 'none';
+  activities.forEach(activity => {
+    const goal = GOAL_DEFINITIONS[activity.type];
+    const item = document.createElement('div');
+    item.className = 'detail-item';
+    if (activity.completed) item.classList.add('completed');
+    const plannedInfo = activity.type === 'gym' ? 'Sesja siłowa' : (activity.plannedValue ? `Plan: ${Number(activity.plannedValue).toLocaleString('pl-PL')} ${goal.unit}` : 'Plan: brak');
+    let progressInfo = '';
+    if (activity.completed) {
+      if (activity.type === 'gym') progressInfo = 'Sesja zakończona';
+      else progressInfo = `Zrealizowano: ${Number(activity.loggedValue).toLocaleString('pl-PL')} ${goal.unit}`;
     }
+    const metaText = [plannedInfo, progressInfo].filter(Boolean).join(' · ');
+    item.innerHTML = `
+      <div class="detail-info">
+        <div class="detail-icon ${activity.type}"><i data-lucide="${goal.icon}" class="icon"></i></div>
+        <div>
+          <div class="detail-title">${goal.label}</div>
+          <div class="detail-meta">${metaText}</div>
+        </div>
+      </div>
+      <div class="detail-actions-inline">
+        ${activity.completed ? `<button class="action-btn" data-action="undo-activity" data-day="${selectedDate}" data-activity-id="${activity.id}">Cofnij</button>` : `<button class="action-btn primary" data-action="complete-activity" data-day="${selectedDate}" data-type="${activity.type}" data-activity-id="${activity.id}">${activity.type === 'gym' ? 'Oznacz wykonane' : 'Zaloguj wynik'}</button>`}
+        ${activity.type !== 'gym' ? `<button class="action-btn" data-action="edit-activity" data-day="${selectedDate}" data-activity-id="${activity.id}">Edytuj wynik</button>` : ''}
+        <button class="action-btn danger" data-action="delete-activity" data-day="${selectedDate}" data-activity-id="${activity.id}">Usuń</button>
+      </div>
+    `;
+    list.appendChild(item);
+  });
 }
 
-function renderPriorities(priorities = []) {
-    const listEl = document.getElementById('priority-list');
-    const emptyEl = document.getElementById('priority-empty');
-    const addBtn = document.getElementById('add-priority-btn');
-    if (!listEl || !emptyEl || !addBtn) return;
+function renderDayExtras(extras) {
+  const list = document.getElementById('day-extra-list');
+  const empty = document.getElementById('day-extra-empty');
+  list.innerHTML = '';
+  if (!extras.length) {
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
+  extras.forEach(extra => {
+    const item = document.createElement('div');
+    item.className = 'detail-item';
+    if (extra.completed) item.classList.add('completed');
+    item.innerHTML = `
+      <div class="detail-info">
+        <div class="detail-icon extra"><i data-lucide="sparkles" class="icon"></i></div>
+        <div>
+          <div class="detail-title">${extra.title}</div>
+          <div class="detail-meta">${EXTRA_CATEGORY_LABELS[extra.category] || 'Aktywność'}</div>
+        </div>
+      </div>
+      <div class="detail-actions-inline">
+        <button class="action-btn ${extra.completed ? '' : 'success'}" data-action="toggle-extra" data-day="${selectedDate}" data-extra-id="${extra.id}">${extra.completed ? 'Cofnij' : 'Zakończ'}</button>
+        <button class="action-btn danger" data-action="delete-extra" data-day="${selectedDate}" data-extra-id="${extra.id}">Usuń</button>
+      </div>
+    `;
+    list.appendChild(item);
+  });
+}
 
-    listEl.innerHTML = '';
-    const sorted = [...priorities].sort((a, b) => {
-        if (a.completed !== b.completed) return a.completed ? 1 : -1;
-        return (a.createdAt || 0) - (b.createdAt || 0);
-    });
+function renderUpcoming(upcoming) {
+  const list = document.getElementById('upcoming-list');
+  const empty = document.getElementById('upcoming-empty');
+  list.innerHTML = '';
+  const limited = upcoming.slice(0, 6);
+  if (!limited.length) {
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
+  limited.forEach(item => {
+    const li = document.createElement('li');
+    li.className = 'upcoming-item';
+    li.innerHTML = `
+      <div class="detail-icon ${item.type === 'extra' ? 'extra' : item.type}"><i data-lucide="${item.icon}" class="icon"></i></div>
+      <div>
+        <strong>${item.label}</strong>
+        <div class="meta">
+          <span class="badge">${item.badge}</span>
+          <span>${item.dateLabel}</span>
+        </div>
+      </div>
+    `;
+    list.appendChild(li);
+  });
+}
 
-    if (sorted.length === 0) {
-        emptyEl.style.display = 'block';
+function renderPriorities() {
+  const monthKey = getMonthKey(currentMonth);
+  ensurePriorityMonth(monthKey);
+  const list = document.getElementById('priority-list');
+  const empty = document.getElementById('priority-empty');
+  const addBtn = document.getElementById('priority-add-btn');
+  const items = [...state.priorities[monthKey]];
+  items.sort((a, b) => {
+    if (a.completed !== b.completed) return a.completed ? 1 : -1;
+    return (a.createdAt || 0) - (b.createdAt || 0);
+  });
+  list.innerHTML = '';
+  if (!items.length) empty.style.display = 'block';
+  else empty.style.display = 'none';
+
+  items.forEach(priority => {
+    const li = document.createElement('li');
+    li.className = 'priority-item';
+    if (priority.completed) li.classList.add('completed');
+    li.innerHTML = `
+      <div class="priority-body">
+        <span class="priority-title">${priority.title}</span>
+        <span class="priority-meta">${PRIORITY_IMPACT_LABELS[priority.impact] || ''}</span>
+      </div>
+      <div class="priority-actions">
+        <button class="priority-btn" data-action="toggle-priority" data-month-key="${monthKey}" data-priority-id="${priority.id}"><i data-lucide="${priority.completed ? 'rotate-ccw' : 'check'}" class="icon"></i></button>
+        <button class="priority-btn" data-action="delete-priority" data-month-key="${monthKey}" data-priority-id="${priority.id}"><i data-lucide="trash-2" class="icon"></i></button>
+      </div>
+    `;
+    list.appendChild(li);
+  });
+
+  if (items.length >= MAX_PRIORITIES) {
+    addBtn.disabled = true;
+    addBtn.innerHTML = '<i data-lucide="check" class="icon"></i>Limit priorytetów';
+  } else {
+    addBtn.disabled = false;
+    addBtn.innerHTML = '<i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet';
+  }
+}
+
+function renderGoalProgress(goalPercents) {
+  const container = document.getElementById('goal-progress-list');
+  container.innerHTML = '';
+  Object.entries(goalPercents).forEach(([type, info]) => {
+    const def = GOAL_DEFINITIONS[type];
+    const item = document.createElement('div');
+    item.className = 'goal-progress-item';
+    const progressValue = Number(info.progress || 0).toLocaleString('pl-PL');
+    const targetValue = Number(info.target || 0).toLocaleString('pl-PL');
+    item.innerHTML = `
+      <div class="goal-progress-label">
+        <div>
+          <strong>${def.label}</strong>
+          <div class="muted tiny">${progressValue} / ${targetValue} ${def.unit}</div>
+        </div>
+        <span class="goal-progress-value">${info.percent}%</span>
+      </div>
+      <div class="goal-progress-bar"><span style="width:${info.percent}%; background:${def.color};"></span></div>
+    `;
+    container.appendChild(item);
+  });
+}
+
+function getHeatLevel(value) {
+  if (value >= 5) return 4;
+  if (value >= 3) return 3;
+  if (value >= 2) return 2;
+  if (value >= 1) return 1;
+  return 0;
+}
+
+function renderHeatmap() {
+  const container = document.getElementById('heatmap');
+  container.innerHTML = '';
+  const year = currentMonth.getFullYear();
+  document.getElementById('heatmap-year-label').textContent = year;
+  const counts = {};
+  Object.entries(state.activities).forEach(([dateString, activities]) => {
+    const date = parseDate(dateString);
+    if (date.getFullYear() !== year) return;
+    const completed = activities.filter(a => a.completed).length;
+    if (completed > 0) counts[dateString] = (counts[dateString] || 0) + completed;
+  });
+  Object.entries(state.extras).forEach(([dateString, extras]) => {
+    const date = parseDate(dateString);
+    if (date.getFullYear() !== year) return;
+    const completed = extras.filter(e => e.completed).length;
+    if (completed > 0) counts[dateString] = (counts[dateString] || 0) + completed;
+  });
+
+  const start = new Date(year, 0, 1);
+  const offset = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - offset);
+  for (let week = 0; week < 53; week++) {
+    const column = document.createElement('div');
+    column.className = 'heatmap-week';
+    const weekStart = new Date(start);
+    weekStart.setDate(start.getDate() + week * 7);
+    for (let day = 0; day < 7; day++) {
+      const current = new Date(weekStart);
+      current.setDate(weekStart.getDate() + day);
+      const key = toYYYYMMDD(current);
+      const cell = document.createElement('div');
+      cell.className = 'heatmap-cell';
+      if (current.getFullYear() === year) {
+        const value = counts[key] || 0;
+        const level = getHeatLevel(value);
+        cell.dataset.level = level;
+        const label = current.toLocaleDateString('pl-PL', { day: '2-digit', month: 'short' });
+        cell.title = value > 0 ? `${label}: ${value} ukończone aktywności` : label;
+      } else {
+        cell.classList.add('heatmap-cell--empty');
+      }
+      column.appendChild(cell);
+    }
+    const label = document.createElement('span');
+    label.className = 'heatmap-month-label';
+    if (weekStart.getFullYear() === year) {
+      label.textContent = weekStart.toLocaleDateString('pl-PL', { month: 'short' }).replace('.', '').toUpperCase();
+      label.title = `${formatRange(weekStart, addDays(weekStart, 6))} ${weekStart.getFullYear()}`;
     } else {
-        emptyEl.style.display = 'none';
+      label.textContent = '';
     }
-
-    sorted.forEach(priority => {
-        const item = document.createElement('li');
-        item.className = 'priority-item';
-        item.dataset.priorityId = priority.id;
-        if (priority.completed) item.classList.add('completed');
-
-        const toggleBtn = document.createElement('button');
-        toggleBtn.className = 'priority-toggle';
-        toggleBtn.dataset.priorityId = priority.id;
-        toggleBtn.innerHTML = `<i data-lucide="${priority.completed ? 'check-circle-2' : 'circle'}" class="icon" style="width:18px; height:18px;"></i>`;
-
-        const details = document.createElement('div');
-        details.className = 'priority-details';
-        const title = document.createElement('span');
-        title.className = 'priority-title';
-        title.textContent = priority.title;
-        details.appendChild(title);
-        const meta = document.createElement('span');
-        meta.className = 'priority-meta';
-        meta.textContent = PRIORITY_IMPACT_LABELS[priority.impact] || 'Priorytet';
-        details.appendChild(meta);
-
-        const actions = document.createElement('div');
-        actions.className = 'priority-actions';
-        const deleteBtn = document.createElement('button');
-        deleteBtn.className = 'priority-delete';
-        deleteBtn.dataset.priorityId = priority.id;
-        deleteBtn.innerHTML = '<i data-lucide="trash-2" class="icon" style="width:16px; height:16px;"></i>';
-        actions.appendChild(deleteBtn);
-
-        item.appendChild(toggleBtn);
-        item.appendChild(details);
-        item.appendChild(actions);
-        listEl.appendChild(item);
-    });
-
-    if (sorted.length >= MAX_PRIORITIES) {
-        addBtn.disabled = true;
-        addBtn.innerHTML = '<i data-lucide="check" class="icon"></i>Limit priorytetów';
-    } else {
-        addBtn.disabled = false;
-        addBtn.innerHTML = '<i data-lucide="plus-circle" class="icon"></i>Dodaj priorytet';
-    }
+    column.appendChild(label);
+    container.appendChild(column);
+  }
 }
 
-function renderNextActions(weekData, startOfWeek) {
-    const listEl = document.getElementById('next-actions-list');
-    const emptyEl = document.getElementById('next-actions-empty');
-    if (!listEl || !emptyEl) return [];
-
-    listEl.innerHTML = '';
-    const upcoming = [];
-    for (let i = 1; i <= 7; i++) {
-        const dayIndex = i % 7;
-        const currentDay = new Date(startOfWeek);
-        currentDay.setDate(startOfWeek.getDate() + (dayIndex - 1 + 7) % 7);
-
-        const plannedActivities = weekData.plan?.[dayIndex] || [];
-        plannedActivities.forEach((activity, index) => {
-            if (activity.completed) return;
-            const goal = GOAL_DEFINITIONS[activity.type];
-            if (!goal) return;
-            let label = goal.label;
-            if (activity.type === 'gym') {
-                label += ' • sesja';
-            } else if (activity.plannedValue) {
-                label += ` • cel ${activity.plannedValue.toLocaleString('pl-PL')} ${goal.unit}`;
-            }
-            upcoming.push({
-                label,
-                badge: 'Cel tygodnia',
-                date: new Date(currentDay),
-                icon: goal.icon || 'check',
-                order: index,
-                type: 'goal'
-            });
-        });
-
-        const extras = weekData.extras?.[dayIndex] || [];
-        extras.forEach((extra, index) => {
-            if (extra.completed) return;
-            upcoming.push({
-                label: extra.title,
-                badge: EXTRA_CATEGORY_LABELS[extra.category] || EXTRA_CATEGORY_LABELS[DEFAULT_EXTRA_CATEGORY],
-                date: new Date(currentDay),
-                icon: 'sparkles',
-                order: index,
-                type: 'extra'
-            });
-        });
-    }
-
-    upcoming.sort((a, b) => {
-        const diff = a.date - b.date;
-        if (diff !== 0) return diff;
-        if (a.type !== b.type) return a.type === 'goal' ? -1 : 1;
-        return (a.order || 0) - (b.order || 0);
-    });
-
-    const limited = upcoming.slice(0, MAX_NEXT_ACTIONS);
-    if (limited.length === 0) {
-        emptyEl.style.display = 'block';
-    } else {
-        emptyEl.style.display = 'none';
-        limited.forEach(item => {
-            const li = document.createElement('li');
-            li.className = 'next-action-item';
-
-            const iconWrapper = document.createElement('span');
-            iconWrapper.innerHTML = `<i data-lucide="${item.icon}" class="icon" style="width:18px; height:18px;"></i>`;
-            li.appendChild(iconWrapper);
-
-            const info = document.createElement('div');
-            info.className = 'next-action-info';
-            const title = document.createElement('span');
-            title.style.fontWeight = '600';
-            title.textContent = item.label;
-            info.appendChild(title);
-
-            const meta = document.createElement('div');
-            meta.className = 'next-action-meta';
-            const badge = document.createElement('span');
-            badge.className = 'next-action-badge';
-            badge.textContent = item.badge;
-            const date = document.createElement('span');
-            date.className = 'next-action-date';
-            date.textContent = formatDateWithDay(item.date);
-            meta.appendChild(badge);
-            meta.appendChild(date);
-            info.appendChild(meta);
-
-            li.appendChild(info);
-            listEl.appendChild(li);
-        });
-    }
-
-    return limited;
+function addTraining(dateString, type, plannedValue) {
+  ensureDay(dateString);
+  state.activities[dateString].push({
+    id: `act_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    type,
+    plannedValue: type === 'gym' ? 1 : Number(plannedValue) || 0,
+    loggedValue: 0,
+    completed: false,
+    createdAt: Date.now()
+  });
+  saveState();
+  render();
 }
 
-
-// --- MODALE ---
-function showModal(config) {
-    const modal = document.getElementById('modal-overlay');
-    document.getElementById('modal-title').textContent = config.title;
-    document.getElementById('modal-text').innerHTML = config.text || '';
-    const inputContainer = document.getElementById('modal-input-container');
-    const optionsContainer = document.getElementById('modal-options-container');
-    inputContainer.innerHTML = '';
-    optionsContainer.innerHTML = '';
-    
-    if (config.input) {
-        const input = document.createElement('input');
-        input.type = config.input.type;
-        input.placeholder = config.input.placeholder || '';
-        input.value = config.input.value || '';
-        input.autocomplete = 'off';
-        input.dataset.modalInput = 'true';
-        inputContainer.appendChild(input);
-    }
-
-    if (config.textarea) {
-        const textarea = document.createElement('textarea');
-        textarea.placeholder = config.textarea.placeholder || '';
-        textarea.value = config.textarea.value || '';
-        textarea.rows = config.textarea.rows || 4;
-        textarea.style.marginTop = '12px';
-        textarea.style.width = '100%';
-        textarea.style.borderRadius = '12px';
-        textarea.style.border = '1px solid var(--line)';
-        textarea.style.padding = '12px';
-        textarea.style.fontSize = '14px';
-        textarea.dataset.modalInput = 'true';
-        inputContainer.appendChild(textarea);
-    }
-    
-    if (config.options) {
-        const optionsDiv = document.createElement('div');
-        optionsDiv.className = 'modal-options';
-        config.options.forEach(opt => {
-            const label = document.createElement('label');
-            label.className = 'option-label';
-            label.innerHTML = `<input type="radio" name="modal-option" value="${opt.value}" ${opt.checked ? 'checked' : ''}> ${opt.label}`;
-            optionsDiv.appendChild(label);
-        });
-        optionsContainer.appendChild(optionsDiv);
-    }
-
-    const actions = document.getElementById('modal-actions');
-    actions.innerHTML = '';
-    config.buttons.forEach(btnConfig => {
-        const button = document.createElement('button');
-        button.textContent = btnConfig.text;
-        button.className = btnConfig.class;
-        button.onclick = () => {
-            if (btnConfig.action === 'close') {
-                modal.classList.remove('visible');
-            } else {
-                const valueField = inputContainer.querySelector('[data-modal-input]');
-                const value = valueField ? valueField.value : '';
-                const selectedOption = optionsContainer.querySelector('input:checked')?.value;
-                btnConfig.action(value, selectedOption);
-                modal.classList.remove('visible');
-            }
-        };
-        actions.appendChild(button);
-    });
-    modal.classList.add('visible');
-    const focusTarget = inputContainer.querySelector('[data-modal-input]');
-    if (focusTarget) { focusTarget.focus(); }
+function addExtra(dateString, title, category) {
+  ensureDay(dateString);
+  state.extras[dateString].push({
+    id: `extra_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    title,
+    category,
+    completed: false,
+    createdAt: Date.now()
+  });
+  saveState();
+  render();
 }
 
-function showPlanModal(type, dayIndex) {
-    const goal = GOAL_DEFINITIONS[type];
-    if (type === 'gym') { addActivity(type, dayIndex, 1); return; }
-    showModal({
-        title: `Zaplanuj: ${goal.label}`,
-        text: `Ile ${goal.unit} planujesz na ten dzień?`,
-        input: { type: 'number', placeholder: '0' },
-        buttons: [
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            { text: 'Dodaj plan', class: 'btn', action: (value) => addActivity(type, dayIndex, parseFloat(value) || 0) }
-        ]
-    });
+function addPriority(title, impact) {
+  const monthKey = getMonthKey(currentMonth);
+  ensurePriorityMonth(monthKey);
+  if (state.priorities[monthKey].length >= MAX_PRIORITIES) return;
+  state.priorities[monthKey].push({
+    id: `prio_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    title,
+    impact,
+    completed: false,
+    createdAt: Date.now()
+  });
+  saveState();
+  render();
 }
 
-function showExtraActivityModal(dayIndex) {
-    showModal({
-        title: 'Dodaj aktywność dodatkową',
-        text: 'Nazwij aktywność i wybierz kategorię, aby mieć pełny obraz tygodnia.',
-        input: { type: 'text', placeholder: 'np. Trening brzucha' },
-        options: EXTRA_ACTIVITY_CATEGORIES.map((cat, index) => ({
-            value: cat.value,
-            label: cat.label,
-            checked: index === 0
-        })),
-        buttons: [
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            { text: 'Dodaj', class: 'btn', action: (value, selectedOption) => addExtraActivity(dayIndex, value, selectedOption || DEFAULT_EXTRA_CATEGORY) }
-        ]
-    });
+function togglePriority(id, monthKey) {
+  const list = state.priorities[monthKey] || [];
+  const priority = list.find(p => p.id === id);
+  if (!priority) return;
+  priority.completed = !priority.completed;
+  saveState();
+  render();
+}
+
+function deletePriority(id, monthKey) {
+  if (!state.priorities[monthKey]) return;
+  state.priorities[monthKey] = state.priorities[monthKey].filter(p => p.id !== id);
+  saveState();
+  render();
+}
+
+function completeActivity(day, id) {
+  const activities = state.activities[day] || [];
+  const activity = activities.find(a => a.id === id);
+  if (!activity) return;
+  if (activity.type === 'gym') {
+    activity.completed = true;
+    activity.loggedValue = 1;
+    saveState();
+    render();
+  } else {
+    showLogModal(activity, day);
+  }
+}
+
+function showLogModal(activity, day) {
+  const goal = GOAL_DEFINITIONS[activity.type];
+  showModal({
+    title: `Zaloguj ${goal.label.toLowerCase()}`,
+    text: `Podaj zrealizowaną wartość dla ${formatDateWithDay(parseDate(day))}.`,
+    input: { type: 'number', value: activity.loggedValue || activity.plannedValue || '', placeholder: `Wartość w ${goal.unit}`, min: '0', step: '1' },
+    buttons: [
+      { text: 'Anuluj', class: 'btn soft', action: 'close' },
+      { text: 'Zapisz', class: 'btn', action: (value) => {
+          const numeric = Number(value);
+          if (!numeric || numeric <= 0) return false;
+          activity.loggedValue = numeric;
+          activity.completed = true;
+          saveState();
+          render();
+        } }
+    ]
+  });
+}
+
+function editActivity(day, id) {
+  const activity = (state.activities[day] || []).find(a => a.id === id);
+  if (!activity || activity.type === 'gym') return;
+  showLogModal(activity, day);
+}
+
+function undoActivity(day, id) {
+  const activity = (state.activities[day] || []).find(a => a.id === id);
+  if (!activity) return;
+  activity.completed = false;
+  activity.loggedValue = 0;
+  saveState();
+  render();
+}
+
+function deleteActivity(day, id) {
+  if (!state.activities[day]) return;
+  state.activities[day] = state.activities[day].filter(a => a.id !== id);
+  saveState();
+  render();
+}
+
+function toggleExtra(day, id) {
+  const extra = (state.extras[day] || []).find(e => e.id === id);
+  if (!extra) return;
+  extra.completed = !extra.completed;
+  saveState();
+  render();
+}
+
+function deleteExtra(day, id) {
+  if (!state.extras[day]) return;
+  state.extras[day] = state.extras[day].filter(e => e.id !== id);
+  saveState();
+  render();
+}
+
+function showAddTrainingModal() {
+  const date = parseDate(selectedDate);
+  showModal({
+    title: 'Zaplanuj trening',
+    text: `Dodaj aktywność na ${date.toLocaleDateString('pl-PL', { day: 'numeric', month: 'long' })}.`,
+    input: { type: 'number', placeholder: 'Docelowa wartość', min: '0', step: '1' },
+    options: [
+      { value: 'gym', label: 'Trening siłowy', checked: true },
+      { value: 'running', label: 'Bieganie' },
+      { value: 'reading', label: 'Czytanie' }
+    ],
+    buttons: [
+      { text: 'Anuluj', class: 'btn soft', action: 'close' },
+      { text: 'Dodaj', class: 'btn', action: (value, selected) => {
+          const type = selected || 'gym';
+          if (type !== 'gym') {
+            const numeric = Number(value);
+            if (!numeric || numeric <= 0) return false;
+            addTraining(selectedDate, type, numeric);
+          } else {
+            addTraining(selectedDate, type, 1);
+          }
+        } }
+    ],
+    onShow: ({ overlay, input }) => {
+      const radios = overlay.querySelectorAll('input[name="modal-option"]');
+      const update = () => {
+        const type = overlay.querySelector('input[name="modal-option"]:checked')?.value;
+        if (!input) return;
+        if (type === 'gym') {
+          input.value = '';
+          input.placeholder = 'Sesja siłowa – bez dodatkowej wartości';
+          input.disabled = true;
+        } else if (type === 'running') {
+          input.disabled = false;
+          input.placeholder = 'Cel w kilometrach';
+        } else if (type === 'reading') {
+          input.disabled = false;
+          input.placeholder = 'Cel w stronach';
+        }
+      };
+      update();
+      radios.forEach(radio => radio.addEventListener('change', update));
+    }
+  });
+}
+
+function showAddExtraModal() {
+  const date = parseDate(selectedDate);
+  showModal({
+    title: 'Dodaj aktywność dodatkową',
+    text: `Dodaj drobne działanie na ${date.toLocaleDateString('pl-PL', { day: 'numeric', month: 'long' })}.`,
+    textarea: { placeholder: 'Opis aktywności' },
+    options: EXTRA_ACTIVITY_CATEGORIES.map((cat, index) => ({ value: cat.value, label: cat.label, checked: index === 0 })),
+    buttons: [
+      { text: 'Anuluj', class: 'btn soft', action: 'close' },
+      { text: 'Dodaj', class: 'btn', action: (value, selected) => {
+          const textValue = (value || '').trim();
+          if (!textValue) return false;
+          addExtra(selectedDate, textValue, selected || 'other');
+        } }
+    ]
+  });
 }
 
 function showPriorityModal() {
-    const { weekData } = getCurrentWeekContext();
-    if (weekData.priorities.length >= MAX_PRIORITIES) return;
-    showModal({
-        title: 'Dodaj priorytet tygodnia',
-        text: 'Wybierz działanie o największym wpływie na Twój cel.',
-        input: { type: 'text', placeholder: 'np. 3 treningi brzucha' },
-        options: PRIORITY_IMPACT_OPTIONS.map((opt, index) => ({
-            value: opt.value,
-            label: opt.label,
-            checked: index === 0
-        })),
-        buttons: [
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            { text: 'Dodaj priorytet', class: 'btn', action: (value, selectedOption) => addPriority(value, selectedOption || 'high') }
-        ]
+  const monthKey = getMonthKey(currentMonth);
+  ensurePriorityMonth(monthKey);
+  if (state.priorities[monthKey].length >= MAX_PRIORITIES) return;
+  showModal({
+    title: 'Nowy priorytet',
+    text: `Określ priorytet na ${formatMonth(currentMonth)}.`,
+    textarea: { placeholder: 'Opisz priorytet' },
+    options: PRIORITY_IMPACT_OPTIONS.map((opt, index) => ({ value: opt.value, label: opt.label, checked: index === 0 })),
+    buttons: [
+      { text: 'Anuluj', class: 'btn soft', action: 'close' },
+      { text: 'Dodaj', class: 'btn', action: (value, selected) => {
+          const textValue = (value || '').trim();
+          if (!textValue) return false;
+          addPriority(textValue, selected || 'high');
+        } }
+    ]
+  });
+}
+
+function showModal(config) {
+  const overlay = document.getElementById('modal-overlay');
+  document.getElementById('modal-title').textContent = config.title || '';
+  document.getElementById('modal-text').innerHTML = config.text || '';
+  const inputContainer = document.getElementById('modal-input-container');
+  const optionsContainer = document.getElementById('modal-options-container');
+  const actions = document.getElementById('modal-actions');
+  inputContainer.innerHTML = '';
+  optionsContainer.innerHTML = '';
+  actions.innerHTML = '';
+
+  if (config.input) {
+    const input = document.createElement('input');
+    input.type = config.input.type || 'text';
+    if (config.input.placeholder) input.placeholder = config.input.placeholder;
+    if (config.input.value !== undefined) input.value = config.input.value;
+    if (config.input.min !== undefined) input.min = config.input.min;
+    if (config.input.step !== undefined) input.step = config.input.step;
+    if (config.input.disabled) input.disabled = true;
+    input.autocomplete = 'off';
+    input.dataset.modalInput = 'true';
+    inputContainer.appendChild(input);
+  }
+
+  if (config.textarea) {
+    const textarea = document.createElement('textarea');
+    textarea.placeholder = config.textarea.placeholder || '';
+    textarea.value = config.textarea.value || '';
+    textarea.rows = config.textarea.rows || 4;
+    textarea.dataset.modalInput = 'true';
+    inputContainer.appendChild(textarea);
+  }
+
+  if (config.options) {
+    const optionsDiv = document.createElement('div');
+    optionsDiv.className = 'modal-options';
+    config.options.forEach(opt => {
+      const label = document.createElement('label');
+      label.className = 'option-label';
+      label.innerHTML = `<input type="radio" name="modal-option" value="${opt.value}" ${opt.checked ? 'checked' : ''}> <span>${opt.label}</span>`;
+      optionsDiv.appendChild(label);
     });
-}
+    optionsContainer.appendChild(optionsDiv);
+  }
 
-function showLogModal(activity) {
-    const { type, id } = activity;
-    const goal = GOAL_DEFINITIONS[type];
-    showModal({
-        title: `Loguj: ${goal.label}`,
-        text: `Wprowadź ile ${goal.unit} udało Ci się zrobić:`,
-        input: { type: 'number', placeholder: activity.plannedValue || '0', value: activity.plannedValue || '' },
-        buttons: [
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            { text: 'Zapisz', class: 'btn', action: (value) => logActivity(id, parseFloat(value) || 0, true) }
-        ]
+  config.buttons.forEach(btn => {
+    const button = document.createElement('button');
+    button.textContent = btn.text;
+    button.className = btn.class;
+    button.addEventListener('click', () => {
+      if (btn.action === 'close') {
+        overlay.classList.remove('visible');
+        return;
+      }
+      const field = inputContainer.querySelector('[data-modal-input]');
+      const selectedOption = optionsContainer.querySelector('input[name="modal-option"]:checked')?.value;
+      const value = field ? field.value : '';
+      const result = btn.action(value, selectedOption);
+      if (result === false) return;
+      overlay.classList.remove('visible');
     });
-}
+    actions.appendChild(button);
+  });
 
-function showEditLogModal(activity) {
-    const { type, id, loggedValue } = activity;
-    const goal = GOAL_DEFINITIONS[type];
-    showModal({
-        title: `Edytuj: ${goal.label}`,
-        text: type === 'gym' ? `Ta sesja jest ukończona. Możesz cofnąć jej zaliczenie.` : `Zaktualizuj, ile ${goal.unit} udało Ci się zrobić:`,
-        input: type === 'gym' ? null : { type: 'number', placeholder: '0', value: loggedValue },
-        buttons: [
-            { text: 'Cofnij ukończenie', class: 'btn danger', action: () => logActivity(id, 0, false) },
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            ...(type !== 'gym' ? [{ text: 'Zapisz', class: 'btn', action: (value) => logActivity(id, parseFloat(value) || 0, true) }] : [])
-        ]
-    });
-}
-
-function showCopyPlanModal() {
-    showModal({
-        title: 'Kopiuj plan z poprzedniego tygodnia',
-        text: 'Wybierz, co chcesz skopiować do bieżącego tygodnia:',
-        options: [
-            { value: 'planOnly', label: 'Tylko plan (bez ukończonych zadań)', checked: true },
-            { value: 'planAndProgress', label: 'Plan wraz z postępem' }
-        ],
-        buttons: [
-            { text: 'Anuluj', class: 'btn soft', action: 'close' },
-            { text: 'Kopiuj', class: 'btn', action: (_, selectedOption) => {
-                copyPreviousWeek(selectedOption === 'planAndProgress');
-            }}
-        ]
-    });
-}
-
-function showWeeklySummary() {
-    const today = new Date();
-    if (today.getDay() !== 1) return; // Uruchom tylko w poniedziałki
-
-    const lastWeekDate = new Date();
-    lastWeekDate.setDate(today.getDate() - 1);
-    const [year, week] = getWeekNumber(lastWeekDate);
-    const weekData = state[year]?.[week];
-
-    if (weekData && !weekData.summaryShown) {
-        let summaryText = `W zeszłym tygodniu udało Ci się:<br><br>`;
-        Object.keys(GOAL_DEFINITIONS).forEach(type => {
-            const progress = weekData.progress[type] || 0;
-            const target = GOAL_DEFINITIONS[type].target;
-            summaryText += `<b>${GOAL_DEFINITIONS[type].label}:</b> ${progress.toLocaleString('pl-PL')}/${target.toLocaleString('pl-PL')} ${GOAL_DEFINITIONS[type].unit}<br>`;
-        });
-        const completedExtras = Object.values(weekData.extras || {}).flat().filter(extra => extra.completed).length;
-        if (completedExtras > 0) {
-            summaryText += `<b>Aktywności dodatkowe:</b> ${completedExtras}<br>`;
-        }
-        summaryText += `<br>${weekData.isComplete ? 'Świetna robota! Osiągnąłeś wszystkie cele.' : 'Dobra robota! Tak trzymaj.'}`;
-
-        showModal({
-            title: `Podsumowanie tygodnia ${week}`,
-            text: summaryText,
-            buttons: [{ text: 'OK', class: 'btn', action: 'close' }]
-        });
-        weekData.summaryShown = true;
-        saveState();
-    }
-}
-
-function addPriority(title, impact = 'high') {
-    const trimmed = (title || '').trim();
-    if (!trimmed) return;
-    const { weekData } = getCurrentWeekContext();
-    if (weekData.priorities.length >= MAX_PRIORITIES) return;
-    weekData.priorities.push({
-        id: `prio_${Date.now()}_${Math.random()}`,
-        title: trimmed,
-        impact,
-        completed: false,
-        createdAt: Date.now()
-    });
-    saveState();
-    render();
-}
-
-function togglePriority(priorityId) {
-    const { weekData } = getCurrentWeekContext();
-    const priority = weekData.priorities.find(p => p.id === priorityId);
-    if (!priority) return;
-    priority.completed = !priority.completed;
-    saveState();
-    render();
-}
-
-function deletePriority(priorityId) {
-    const { weekData } = getCurrentWeekContext();
-    const initialLength = weekData.priorities.length;
-    weekData.priorities = weekData.priorities.filter(p => p.id !== priorityId);
-    if (weekData.priorities.length !== initialLength) {
-        saveState();
-        render();
-    }
-}
-
-
-// --- OBSŁUGA ZDARZEŃ ---
-function handleDragStart(e) {
-    dragState.activityId = e.target.closest('.activity-pill').dataset.activityId;
-    dragState.sourceDay = e.target.closest('.day-column').dataset.dayIndex;
-    setTimeout(() => e.target.closest('.activity-pill').classList.add('dragging'), 0);
-}
-function handleDragEnd(e) {
-    const pill = document.querySelector('.activity-pill.dragging');
-    if(pill) pill.classList.remove('dragging');
-}
-function handleDragOver(e) { e.preventDefault(); e.currentTarget.classList.add('drag-over'); }
-function handleDragLeave(e) { e.currentTarget.classList.remove('drag-over'); }
-function handleDrop(e) {
-    e.preventDefault();
-    e.currentTarget.classList.remove('drag-over');
-    const targetDayIndex = parseInt(e.currentTarget.dataset.dayIndex);
-    const sourceDayIndex = parseInt(dragState.sourceDay);
-    if (targetDayIndex === sourceDayIndex) return;
-
-    const [year, week] = getWeekNumber(currentDate);
-    const weekData = state[year][week];
-    const activityIndex = weekData.plan[sourceDayIndex].findIndex(a => a.id === dragState.activityId);
-    if (activityIndex === -1) return;
-
-    const [activity] = weekData.plan[sourceDayIndex].splice(activityIndex, 1);
-    activity.day = targetDayIndex;
-    
-    if(!weekData.plan[targetDayIndex]) weekData.plan[targetDayIndex] = [];
-    weekData.plan[targetDayIndex].push(activity);
-    saveState();
-    render();
+  overlay.classList.add('visible');
+  if (typeof config.onShow === 'function') {
+    config.onShow({ overlay, input: inputContainer.querySelector('[data-modal-input]'), optionsContainer });
+  }
+  const focusTarget = inputContainer.querySelector('[data-modal-input]');
+  if (focusTarget && !focusTarget.disabled) focusTarget.focus();
 }
 
 function setupEventListeners() {
-    document.getElementById('prev-week-btn').addEventListener('click', () => { currentDate.setDate(currentDate.getDate() - 7); render(); });
-    document.getElementById('next-week-btn').addEventListener('click', () => { currentDate.setDate(currentDate.getDate() + 7); render(); });
-    document.getElementById('today-week-btn').addEventListener('click', () => { currentDate = new Date(); render(); });
-    document.getElementById('copy-plan-btn').addEventListener('click', showCopyPlanModal);
-    
-    document.querySelectorAll('[data-action="plan"]').forEach(btn => {
-        btn.addEventListener('click', (e) => startPlanning(e.currentTarget.dataset.activityType));
-    });
-
-    document.getElementById('add-priority-btn').addEventListener('click', showPriorityModal);
-    document.getElementById('priority-list').addEventListener('click', (e) => {
-        const toggleBtn = e.target.closest('.priority-toggle');
-        if (toggleBtn) { togglePriority(toggleBtn.dataset.priorityId); return; }
-        const deleteBtn = e.target.closest('.priority-delete');
-        if (deleteBtn) { deletePriority(deleteBtn.dataset.priorityId); return; }
-    });
-
-    document.querySelector('.planner-grid').addEventListener('click', (e) => {
-        const dayColumn = e.target.closest('.day-column');
-        if (!dayColumn) return;
-        const dayIndex = parseInt(dayColumn.dataset.dayIndex, 10);
-        
-        if (planningState.isPlanning) {
-            if (!e.target.closest('.activity-pill') && !e.target.closest('.quick-add-btn')) {
-                showPlanModal(planningState.activityType, dayIndex);
-            }
-            return;
-        }
-
-        if (e.target.closest('.quick-add-btn')) {
-            const menu = dayColumn.querySelector('.quick-add-menu');
-            document.querySelectorAll('.quick-add-menu').forEach(m => {
-                if(m !== menu) m.style.display = 'none';
-            });
-            menu.style.display = menu.style.display === 'flex' ? 'none' : 'flex';
-            e.stopPropagation();
-            return;
-        }
-
-        const addExtraBtn = e.target.closest('.add-extra-btn');
-        if (addExtraBtn) {
-            document.querySelectorAll('.quick-add-menu').forEach(menu => menu.style.display = 'none');
-            showExtraActivityModal(dayIndex);
-            return;
-        }
-
-        const extraToggle = e.target.closest('.extra-toggle');
-        if (extraToggle) {
-            toggleExtraActivity(extraToggle.dataset.extraId);
-            return;
-        }
-
-        const extraDelete = e.target.closest('.extra-delete-btn');
-        if (extraDelete) {
-            deleteExtraActivity(extraDelete.dataset.extraId);
-            return;
-        }
-
-        const deleteBtn = e.target.closest('.delete-activity-btn');
-        if (deleteBtn) {
-            deleteActivity(deleteBtn.dataset.activityId);
-            return;
-        }
-        
-        const pill = e.target.closest('.activity-pill');
-        if (pill) {
-            const activityId = pill.dataset.activityId;
-            const [year, week] = getWeekNumber(currentDate);
-            const activity = state[year]?.[week]?.plan?.[dayIndex]?.find(a => a.id === activityId);
-            
-            if (activity) {
-                if (activity.completed) {
-                    showEditLogModal(activity);
-                } else {
-                    if (activity.type === 'gym') logActivity(activityId, 1, true); 
-                    else showLogModal(activity);
-                }
-            }
-        }
-    });
-
-    document.addEventListener('click', e => {
-        if (!e.target.closest('.day-column')) {
-            document.querySelectorAll('.quick-add-menu').forEach(menu => menu.style.display = 'none');
-        }
-    });
-
-    document.getElementById('cancel-planning-btn').addEventListener('click', stopPlanning);
-}
-
-
-// --- INICJALIZACJA ---
-document.addEventListener('DOMContentLoaded', () => {
-    loadState();
+  document.getElementById('prev-month-btn').addEventListener('click', () => {
+    currentMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1);
     render();
-    setupEventListeners();
-    showWeeklySummary();
-});
+  });
+  document.getElementById('next-month-btn').addEventListener('click', () => {
+    currentMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1);
+    render();
+  });
+  document.getElementById('today-month-btn').addEventListener('click', () => {
+    const today = new Date();
+    currentMonth = startOfMonth(today);
+    selectedDate = toYYYYMMDD(today);
+    render();
+  });
+  document.getElementById('add-training-btn').addEventListener('click', showAddTrainingModal);
+  document.getElementById('add-extra-btn').addEventListener('click', showAddExtraModal);
+  document.getElementById('priority-add-btn').addEventListener('click', showPriorityModal);
 
-// --- STATYSTYKI (HEATMAP) ---
-function renderStats() {
-    // Implementacja heatmapy - bez zmian w logice, ale może wymagać dostosowania renderowania
-    const year = getWeekNumber(currentDate)[0];
-    const yearData = state[year] || {};
-    const heatmapContainer = document.querySelector('.heatmap-container');
-    if (!heatmapContainer) return;
-    heatmapContainer.innerHTML = '';
+  document.getElementById('day-plan-list').addEventListener('click', (event) => {
+    const target = event.target.closest('[data-action]');
+    if (!target) return;
+    const day = target.dataset.day;
+    const id = target.dataset.activityId;
+    const action = target.dataset.action;
+    if (action === 'complete-activity') completeActivity(day, id);
+    if (action === 'undo-activity') undoActivity(day, id);
+    if (action === 'delete-activity') deleteActivity(day, id);
+    if (action === 'edit-activity') editActivity(day, id);
+  });
 
-    const activitiesByDay = {};
-    Object.keys(yearData).forEach(week => {
-        Object.keys(yearData[week].plan).forEach(day => {
-            const plannedActivities = yearData[week].plan[day] || [];
-            const extraActivities = yearData[week].extras?.[day] || [];
-            const completedCount = plannedActivities.filter(a => a.completed).length + extraActivities.filter(a => a.completed).length;
-            if (completedCount > 0) {
-                const date = new Date(getStartOfWeek(year, parseInt(week)));
-                date.setDate(date.getDate() + (parseInt(day) - 1 + 7) % 7);
-                const dateString = toYYYYMMDD(date);
-                activitiesByDay[dateString] = (activitiesByDay[dateString] || 0) + completedCount;
-            }
-        });
-    });
+  document.getElementById('day-extra-list').addEventListener('click', (event) => {
+    const target = event.target.closest('[data-action]');
+    if (!target) return;
+    const day = target.dataset.day;
+    const id = target.dataset.extraId;
+    const action = target.dataset.action;
+    if (action === 'toggle-extra') toggleExtra(day, id);
+    if (action === 'delete-extra') deleteExtra(day, id);
+  });
 
-    const firstDayOfYear = new Date(year, 0, 1);
-    let currentDay = new Date(firstDayOfYear);
-    // Przesuń do najbliższego poniedziałku przed 1 stycznia
-    currentDay.setDate(currentDay.getDate() - (currentDay.getDay() - 1 + 7) % 7);
-    
-    const heatmap = document.createElement('div');
-    heatmap.className = 'heatmap';
+  document.getElementById('priority-list').addEventListener('click', (event) => {
+    const target = event.target.closest('[data-action]');
+    if (!target) return;
+    const monthKey = target.dataset.monthKey;
+    const id = target.dataset.priorityId;
+    const action = target.dataset.action;
+    if (action === 'toggle-priority') togglePriority(id, monthKey);
+    if (action === 'delete-priority') deletePriority(id, monthKey);
+  });
 
-    const totalWeeks = 53;
-    for (let weekIndex = 0; weekIndex < totalWeeks; weekIndex++) {
-        const weekColumn = document.createElement('div');
-        weekColumn.className = 'heatmap-week';
-        const weekStart = new Date(currentDay);
-
-        for (let day = 0; day < 7; day++) {
-            const dateString = toYYYYMMDD(currentDay);
-            const cell = document.createElement('div');
-            cell.className = 'heatmap-cell';
-
-            if (currentDay.getFullYear() === year) {
-                const count = activitiesByDay[dateString] || 0;
-                let level = 0;
-                if(count > 0) level = 1;
-                if(count > 1) level = 2;
-                if(count > 2) level = 3;
-                if(count > 3) level = 4;
-                cell.dataset.level = level;
-                cell.title = `${dateString}: ${count} ukończone aktywności`;
-            } else {
-                 cell.style.background = 'transparent';
-            }
-
-            weekColumn.appendChild(cell);
-            currentDay.setDate(currentDay.getDate() + 1);
-        }
-
-        const label = document.createElement('span');
-        label.className = 'heatmap-week-label';
-        if (weekStart.getFullYear() === year) {
-            const monthLabel = weekStart.toLocaleDateString('pl-PL', { month: 'short' }).replace('.', '').toUpperCase();
-            label.textContent = monthLabel;
-            label.title = `${formatWeekRange(weekStart)} ${weekStart.getFullYear()}`;
-        } else {
-            label.textContent = ' ';
-        }
-        weekColumn.appendChild(label);
-        heatmap.appendChild(weekColumn);
+  document.getElementById('modal-overlay').addEventListener('click', (event) => {
+    if (event.target === event.currentTarget) {
+      event.currentTarget.classList.remove('visible');
     }
-
-    heatmapContainer.appendChild(heatmap);
+  });
 }
 
-// --- TRYB PLANOWANIA ---
-function startPlanning(type) {
-    planningState = { isPlanning: true, activityType: type };
-    document.getElementById('planner-shell').classList.add('planning-mode');
-    const instructions = document.getElementById('planning-instructions');
-    instructions.style.display = 'block';
-    instructions.textContent = `Kliknij w kalendarzu, aby dodać: ${GOAL_DEFINITIONS[type].label}`;
-    document.getElementById('cancel-planning-btn').style.display = 'inline-flex';
-    document.querySelectorAll('[data-action="plan"]').forEach(b => b.style.display = 'none');
-}
-
-function stopPlanning() {
-    planningState = { isPlanning: false, activityType: null };
-    document.getElementById('planner-shell').classList.remove('planning-mode');
-    const instructions = document.getElementById('planning-instructions');
-    instructions.style.display = 'none';
-    document.getElementById('cancel-planning-btn').style.display = 'none';
-    document.querySelectorAll('[data-action="plan"]').forEach(b => b.style.display = 'inline-flex');
-}
-
+document.addEventListener('DOMContentLoaded', () => {
+  loadState();
+  ensureDay(selectedDate);
+  render();
+  setupEventListeners();
+});
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- redesign the trainings header with professional insights cards and refreshed hero copy
- reorganize the weekly planner experience with a persistent calendar view and updated planning controls
- remove the weekly focus concept, integrate stats directly on the page, and polish goal/priorities cards

## Testing
- not run (html page)


------
https://chatgpt.com/codex/tasks/task_e_68d13361d0ac8331b70b546f81a9c329