### PR TITLE
Enhance tasks view and analytics

### DIFF
--- a/tasks.html
+++ b/tasks.html
@@ -145,6 +145,9 @@
     .calendar-task-pill.task-done::before { content: '✓'; font-weight: 700; color: var(--green); font-size: 12px; }
     .calendar-task-pill.task-done span { text-decoration: line-through; }
     .calendar-task-pill.task-done:hover { opacity: 0.85; }
+    .calendar-task-pill { cursor: grab; }
+    .calendar-task-pill.dragging { opacity: 0.6; cursor: grabbing; }
+    .calendar-day.drop-target { background: rgba(37, 99, 235, 0.08); outline: 2px dashed var(--accent); outline-offset: -4px; }
     
     /* Segmented Control */
     .segmented-control { display: flex; background: var(--surface); border-radius: 10px; padding: 4px; }
@@ -303,6 +306,7 @@ let tempSubtasks = [];
 let currentCalendarDate = new Date();
 let expandedTasks = new Set(); // Przechowuje ID rozwiniętych zadań
 let collapsedGroups = new Set();
+let draggedTaskId = null;
 const statsState = { range: 7, category: 'all' };
 
 // --- STAN APLIKACJI ---
@@ -397,30 +401,39 @@ function renderTaskList() {
 
     const today = new Date();
     today.setUTCHours(0, 0, 0, 0);
+    const tomorrowDate = new Date(today);
+    tomorrowDate.setUTCDate(tomorrowDate.getUTCDate() + 1);
 
     const overdue = [];
     const todayTasks = [];
+    const tomorrowTasks = [];
     const upcoming = [];
     const completedOverdue = [];
 
     for (const task of filteredTasks) {
         const dueDate = parseDate(task.dueDate);
         const isOverdue = dueDate && dueDate < today;
+        const isToday = dueDate && dueDate.getTime() === today.getTime();
+        const isTomorrow = dueDate && dueDate.getTime() === tomorrowDate.getTime();
 
         if (task.status === 'done') {
             if (hideCompleted) continue;
             if (isOverdue) {
                 completedOverdue.push(task);
-            } else if (dueDate && dueDate.getTime() === today.getTime()) {
+            } else if (isToday) {
                 todayTasks.push(task);
+            } else if (isTomorrow) {
+                tomorrowTasks.push(task);
             } else {
                 upcoming.push(task);
             }
         } else {
             if (isOverdue) {
                 overdue.push(task);
-            } else if (dueDate && dueDate.getTime() === today.getTime()) {
+            } else if (isToday) {
                 todayTasks.push(task);
+            } else if (isTomorrow) {
+                tomorrowTasks.push(task);
             } else {
                 upcoming.push(task);
             }
@@ -447,12 +460,14 @@ function renderTaskList() {
 
     overdue.sort(sortFn);
     todayTasks.sort(sortFn).sort((a, b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
+    tomorrowTasks.sort(sortFn).sort((a, b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
     upcoming.sort(sortFn).sort((a, b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
     completedOverdue.sort((a, b) => (parseDate(b.dueDate) || 0) - (parseDate(a.dueDate) || 0));
 
     const groups = [
         { key: 'overdue', label: 'Zaległe', className: 'overdue-header', tasks: overdue },
         { key: 'today', label: 'Dzisiaj', className: '', tasks: todayTasks },
+        { key: 'tomorrow', label: 'Jutro', className: '', tasks: tomorrowTasks },
         { key: 'upcoming', label: 'Nadchodzące', className: '', tasks: upcoming },
         { key: 'completedOverdue', label: 'Ukończone (Zaległe)', className: 'completed-header', tasks: completedOverdue }
     ];
@@ -594,20 +609,33 @@ function appendTaskRow(task, container) {
 function getTask(id) { return state.tasks.find(t => t.id === id); }
 function getTaskIndex(id) { return state.tasks.findIndex(t => t.id === id); }
 
-function handleTaskStatusChange(e) {
-    const taskId = e.target.dataset.id, isChecked = e.target.checked;
+function updateTaskStatus(taskId, shouldBeDone) {
     const task = getTask(taskId);
     if (!task) return;
-    task.status = isChecked ? 'done' : 'todo';
-    if (isChecked && task.recurrence !== 'none' && task.dueDate) {
+    const wasDone = task.status === 'done';
+    if (shouldBeDone === wasDone) return;
+    task.status = shouldBeDone ? 'done' : 'todo';
+    if (shouldBeDone && task.recurrence !== 'none' && task.dueDate) {
         const d = parseDate(task.dueDate);
         if (task.recurrence === 'daily') d.setUTCDate(d.getUTCDate() + 1);
         if (task.recurrence === 'weekly') d.setUTCDate(d.getUTCDate() + 7);
         if (task.recurrence === 'monthly') d.setUTCMonth(d.getUTCMonth() + 1);
-        state.tasks.push({...task, id: `task_${Date.now()}`, dueDate: toYYYYMMDD(d), status: 'todo', subtasks: task.subtasks.map(st => ({ ...st, done: false })) });
+        state.tasks.push({
+            ...task,
+            id: `task_${Date.now()}`,
+            dueDate: toYYYYMMDD(d),
+            status: 'todo',
+            createdAt: new Date().toISOString(),
+            subtasks: task.subtasks.map(st => ({ ...st, done: false }))
+        });
     }
     saveState();
     render();
+}
+
+function handleTaskStatusChange(e) {
+    const taskId = e.target.dataset.id, isChecked = e.target.checked;
+    updateTaskStatus(taskId, isChecked);
 }
 
 function startEdit(id) {
@@ -691,12 +719,79 @@ function renderCalendar() {
         
         let tasksHtml = tasksForDay.map(t => {
             const statusClass = t.status === 'done' ? 'task-done' : 'task-todo';
-            return `<div class="calendar-task-pill ${t.category} prio-${t.priority || 'low'} ${statusClass}" title="${t.title}"><span>${t.title}</span></div>`;
+            return `<div class="calendar-task-pill ${t.category} prio-${t.priority || 'low'} ${statusClass}" title="${t.title}" draggable="true" data-task-id="${t.id}"><span>${t.title}</span></div>`;
         }).join('');
-        
-        html += `<div class="calendar-day"><div class="day-number">${day}</div><div class="calendar-tasks">${tasksHtml}</div></div>`;
+
+        html += `<div class="calendar-day" data-date="${dateStr}"><div class="day-number">${day}</div><div class="calendar-tasks">${tasksHtml}</div></div>`;
     }
     getEl('calendar-container').innerHTML = html + `</div>`;
+    setupCalendarInteractions();
+}
+
+function setupCalendarInteractions() {
+    const taskElements = document.querySelectorAll('.calendar-task-pill[data-task-id]');
+    taskElements.forEach(el => {
+        el.addEventListener('click', handleCalendarTaskClick);
+        el.addEventListener('dragstart', handleTaskDragStart);
+        el.addEventListener('dragend', handleTaskDragEnd);
+    });
+
+    document.querySelectorAll('.calendar-day[data-date]').forEach(dayEl => {
+        dayEl.addEventListener('dragover', handleDayDragOver);
+        dayEl.addEventListener('drop', handleDayDrop);
+        dayEl.addEventListener('dragleave', handleDayDragLeave);
+    });
+}
+
+function handleCalendarTaskClick(e) {
+    e.preventDefault();
+    if (draggedTaskId) return;
+    const taskId = e.currentTarget.dataset.taskId;
+    const task = getTask(taskId);
+    if (!task) return;
+    updateTaskStatus(taskId, task.status !== 'done');
+}
+
+function handleTaskDragStart(e) {
+    const taskId = e.currentTarget.dataset.taskId;
+    if (!taskId) return;
+    draggedTaskId = taskId;
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', taskId);
+    requestAnimationFrame(() => e.currentTarget.classList.add('dragging'));
+}
+
+function handleTaskDragEnd(e) {
+    e.currentTarget.classList.remove('dragging');
+    document.querySelectorAll('.calendar-day.drop-target').forEach(day => day.classList.remove('drop-target'));
+    draggedTaskId = null;
+}
+
+function handleDayDragOver(e) {
+    if (!draggedTaskId || !e.currentTarget.dataset.date) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    e.currentTarget.classList.add('drop-target');
+}
+
+function handleDayDragLeave(e) {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+        e.currentTarget.classList.remove('drop-target');
+    }
+}
+
+function handleDayDrop(e) {
+    e.preventDefault();
+    const date = e.currentTarget.dataset.date;
+    if (!draggedTaskId || !date) return;
+    const task = getTask(draggedTaskId);
+    if (task) {
+        task.dueDate = date;
+        saveState();
+    }
+    e.currentTarget.classList.remove('drop-target');
+    draggedTaskId = null;
+    render();
 }
 
 // --- STATYSTYKI ---

--- a/tasks.html
+++ b/tasks.html
@@ -64,8 +64,23 @@
     .task-table tbody tr:not(.task-group-header):hover { background-color: var(--surface); }
     .task-title.task-done { text-decoration: line-through; color: var(--muted); font-weight: 400; }
     .task-group-header td { background-color: var(--surface); color: var(--muted); font-weight: 700; text-transform: uppercase; font-size: 10px; padding: 6px 8px; border-top: 2px solid var(--line); border-bottom: 2px solid var(--line); }
+    .task-group-header { cursor: pointer; }
     .task-group-header.overdue-header td { background-color: #fff1f2; color: var(--red); }
     .task-group-header.completed-header td { background-color: #f0fdf4; color: var(--green); }
+    .group-header-content { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+    .group-header-main { display: flex; align-items: center; gap: 8px; font-size: 11px; letter-spacing: 0.6px; }
+    .group-toggle { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: var(--card); box-shadow: var(--shadow-sm); font-size: 11px; transition: transform .2s ease; color: var(--ink); }
+    .task-group-header.collapsed .group-toggle { transform: rotate(-90deg); }
+    .group-summary { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-left: auto; }
+    .group-count-pill { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; background: var(--card); border: 1px solid var(--line); font-size: 10px; font-weight: 600; color: var(--muted); }
+    .group-count-pill .dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
+    .group-count-total { background: var(--accent-weak); border-color: var(--accent); color: var(--accent); }
+    .group-count-total .dot { background: var(--accent); }
+    .group-count-work { background: var(--cat-work-bg); border-color: var(--cat-work-border); color: var(--cat-work-text); }
+    .group-count-work .dot { background: var(--cat-work-border); }
+    .group-count-private { background: var(--cat-private-bg); border-color: var(--cat-private-border); color: var(--cat-private-text); }
+    .group-count-private .dot { background: var(--cat-private-border); }
+    .group-collapsed-note { font-size: 10px; font-weight: 600; color: var(--muted); }
     .task-actions .btn { padding: 6px; }
 
     /* Tags & Pills */
@@ -93,9 +108,21 @@
     .modal-actions { margin-top: 20px; display: flex; justify-content: center; gap: 8px; }
 
     /* Stats */
-    .stats-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
-    @media(max-width: 768px) { .stats-grid { grid-template-columns: 1fr; } }
-    .chart-container { position: relative; }
+    .stats-controls { display: flex; flex-wrap: wrap; gap: 16px; margin: 16px 0; }
+    .stats-control { display: flex; flex-direction: column; gap: 8px; min-width: 200px; }
+    .stats-control .control-label { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--muted); letter-spacing: 0.6px; }
+    .stats-summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 16px; margin-bottom: 24px; }
+    .summary-card { background: var(--surface); border: 1px solid var(--line); border-radius: 12px; padding: 16px; box-shadow: var(--shadow-sm); display: flex; flex-direction: column; gap: 6px; }
+    .summary-label { font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--muted); letter-spacing: 0.5px; }
+    .summary-value { font-size: 24px; font-weight: 700; color: var(--ink); }
+    .summary-trend { font-size: 11px; color: var(--muted); display: flex; align-items: center; gap: 4px; }
+    .trend-up { color: var(--green); font-weight: 600; }
+    .trend-down { color: var(--red); font-weight: 600; }
+    .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 24px; }
+    .chart-card { background: var(--surface); border: 1px solid var(--line); border-radius: 16px; padding: 16px; box-shadow: var(--shadow-sm); display: flex; flex-direction: column; gap: 12px; }
+    .chart-card h4 { margin: 0; font-size: 13px; }
+    .chart-card p { margin: 0; font-size: 11px; color: var(--muted); }
+    .chart-container { position: relative; min-height: 240px; }
 
     /* Calendar */
     .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); border: 1px solid var(--line); border-radius: 12px; overflow: hidden;}
@@ -105,13 +132,19 @@
     .calendar-day:nth-child(7n) { border-right: none; }
     .day-number { font-weight: 600; margin-bottom: 4px; }
     .calendar-tasks { display: flex; flex-direction: column; gap: 4px; }
-    .calendar-task-pill { padding: 2px 8px; border-radius: 6px; font-size: 10px; white-space: normal; word-break: break-word; cursor: pointer; border-left: 3px solid transparent; }
+    .calendar-task-pill { display: flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 8px; font-size: 10px; white-space: normal; word-break: break-word; cursor: pointer; border-left: 4px solid transparent; transition: transform .2s ease, box-shadow .2s ease, opacity .2s ease; }
+    .calendar-task-pill span { flex: 1; }
     .calendar-task-pill.work { border-left-color: var(--cat-work-border); }
     .calendar-task-pill.private { border-left-color: var(--cat-private-border); }
     .calendar-task-pill.prio-high { background-color: var(--prio-high-bg); color: var(--prio-high-text); }
     .calendar-task-pill.prio-medium { background-color: var(--prio-medium-bg); color: var(--prio-medium-text); }
     .calendar-task-pill.prio-low { background-color: var(--prio-low-bg); color: var(--prio-low-text); }
-    .calendar-task-pill.task-done { text-decoration: line-through; opacity: 0.7; }
+    .calendar-task-pill.task-todo { font-weight: 600; box-shadow: var(--shadow-sm); }
+    .calendar-task-pill.task-todo:hover { transform: translateY(-1px); box-shadow: var(--shadow); }
+    .calendar-task-pill.task-done { background: rgba(148, 163, 184, 0.18); color: var(--muted); border-left-color: var(--green); text-decoration: none; box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2); }
+    .calendar-task-pill.task-done::before { content: '✓'; font-weight: 700; color: var(--green); font-size: 12px; }
+    .calendar-task-pill.task-done span { text-decoration: line-through; }
+    .calendar-task-pill.task-done:hover { opacity: 0.85; }
     
     /* Segmented Control */
     .segmented-control { display: flex; background: var(--surface); border-radius: 10px; padding: 4px; }
@@ -207,11 +240,52 @@
         <div id="calendar-container" style="margin-top: 16px;"></div>
     </div>
     <div id="tab-content-stats" class="card" style="display:none;">
-        <h3 class="title">Statystyki Produktywności</h3>
+        <div class="row" style="justify-content: space-between; align-items: flex-start; gap: 16px;">
+            <div>
+                <h3 class="title" style="margin-bottom: 4px;">Centrum analityczne</h3>
+                <p class="muted" style="font-size: 11px; margin: 0;">Monitoruj dynamikę zadań, tempo pracy i obciążenie kategorii.</p>
+            </div>
+        </div>
+        <div class="stats-controls">
+            <div class="stats-control">
+                <span class="control-label">Zakres analizy</span>
+                <div id="stats-range-control" class="segmented-control">
+                    <div class="segment active" data-range="7">7 dni</div>
+                    <div class="segment" data-range="30">30 dni</div>
+                    <div class="segment" data-range="90">90 dni</div>
+                </div>
+            </div>
+            <div class="stats-control">
+                <span class="control-label">Filtr kategorii</span>
+                <div id="stats-category-control" class="segmented-control">
+                    <div class="segment active" data-category="all">Wszystkie</div>
+                    <div class="segment" data-category="work">Praca</div>
+                    <div class="segment" data-category="private">Prywatne</div>
+                </div>
+            </div>
+        </div>
+        <div id="stats-summary" class="stats-summary-grid"></div>
         <div id="stats-grid" class="stats-grid">
-            <div class="chart-container"><canvas id="completed-tasks-chart"></canvas></div>
-            <div class="chart-container"><canvas id="tasks-by-prio-chart"></canvas></div>
-            <div class="chart-container"><canvas id="tasks-by-tag-chart"></canvas></div>
+            <div class="chart-card">
+                <h4>Realizacja planu</h4>
+                <p>Planowane vs ukończone zadania w analizowanym okresie.</p>
+                <div class="chart-container"><canvas id="productivity-trend-chart"></canvas></div>
+            </div>
+            <div class="chart-card">
+                <h4>Balans kategorii</h4>
+                <p>Porównanie obciążenia między kategoriami.</p>
+                <div class="chart-container"><canvas id="category-distribution-chart"></canvas></div>
+            </div>
+            <div class="chart-card">
+                <h4>Profil priorytetów</h4>
+                <p>Rozkład priorytetów dla zadań aktywnych i ukończonych.</p>
+                <div class="chart-container"><canvas id="priority-balance-chart"></canvas></div>
+            </div>
+            <div class="chart-card">
+                <h4>Postęp realizacji</h4>
+                <p>Status pracy na najbliższe tygodnie.</p>
+                <div class="chart-container"><canvas id="completion-progress-chart"></canvas></div>
+            </div>
         </div>
     </div>
   </div>
@@ -228,6 +302,8 @@ let charts = {};
 let tempSubtasks = [];
 let currentCalendarDate = new Date();
 let expandedTasks = new Set(); // Przechowuje ID rozwiniętych zadań
+let collapsedGroups = new Set();
+const statsState = { range: 7, category: 'all' };
 
 // --- STAN APLIKACJI ---
 function loadState() {
@@ -249,9 +325,20 @@ const hideCompletedFilter = getEl('hide-completed-filter'), tagFilterInput = get
 const priorityFilter = getEl('task-priority-filter'), categoryFilter = getEl('category-filter'), dateFilter = getEl('date-filter');
 const sortBySelect = getEl('sort-by'), sortDirectionBtn = getEl('sort-direction');
 const modalOverlay = getEl('modal-overlay'), modalText = getEl('modal-text'), modalActions = getEl('modal-actions');
+const statsSummaryEl = getEl('stats-summary');
+const statsRangeControl = getEl('stats-range-control');
+const statsCategoryControl = getEl('stats-category-control');
+
+const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 
 // --- GŁÓWNE FUNKCJE ---
-function render() { renderTaskList(); }
+function render() {
+    renderTaskList();
+    const activeTabEl = document.querySelector('.tab.active');
+    const activeTab = activeTabEl ? activeTabEl.dataset.tab : 'list';
+    if (activeTab === 'calendar') renderCalendar();
+    if (activeTab === 'stats') renderStats();
+}
 
 function parseDate(dateString) {
     if (!dateString) return null;
@@ -277,32 +364,30 @@ function renderTaskList() {
 
     let filteredTasks = state.tasks;
 
-    // Apply text/select filters first
     if (catFilterVal !== 'all') filteredTasks = filteredTasks.filter(t => t.category === catFilterVal);
     if (prioFilterVal !== 'all') filteredTasks = filteredTasks.filter(t => t.priority === prioFilterVal);
     if (tagFilterVal) filteredTasks = filteredTasks.filter(t => t.tags.some(tag => tag.toLowerCase().includes(tagFilterVal)));
 
-    // Apply date range filter (only for active tasks view)
     if (dateFilterVal !== 'all') {
         const now = new Date();
-        const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+        const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
         let startDate, endDate;
         if (dateFilterVal === 'this_week') {
             const dayOfWeek = now.getUTCDay() === 0 ? 6 : now.getUTCDay() - 1;
-            startDate = new Date(today);
+            startDate = new Date(todayUtc);
             startDate.setUTCDate(startDate.getUTCDate() - dayOfWeek);
             endDate = new Date(startDate);
             endDate.setUTCDate(endDate.getUTCDate() + 6);
         } else if (dateFilterVal === 'next_week') {
             const dayOfWeek = now.getUTCDay() === 0 ? 6 : now.getUTCDay() - 1;
-            startDate = new Date(today);
+            startDate = new Date(todayUtc);
             startDate.setUTCDate(startDate.getUTCDate() - dayOfWeek + 7);
             endDate = new Date(startDate);
             endDate.setUTCDate(endDate.getUTCDate() + 6);
         }
         if (startDate && endDate) {
             filteredTasks = filteredTasks.filter(t => {
-                if (t.status === 'done') return true; // Keep all completed tasks regardless of date filter
+                if (t.status === 'done') return true;
                 if (!t.dueDate) return false;
                 const dueDate = parseDate(t.dueDate);
                 return dueDate >= startDate && dueDate <= endDate;
@@ -310,12 +395,9 @@ function renderTaskList() {
         }
     }
 
-    taskTableBody.innerHTML = '';
-    
-    const today = new Date(); 
+    const today = new Date();
     today.setUTCHours(0, 0, 0, 0);
 
-    // Create groups
     const overdue = [];
     const todayTasks = [];
     const upcoming = [];
@@ -326,19 +408,15 @@ function renderTaskList() {
         const isOverdue = dueDate && dueDate < today;
 
         if (task.status === 'done') {
-            if (hideCompleted) {
-                continue; // Skip if we hide completed
-            }
+            if (hideCompleted) continue;
             if (isOverdue) {
                 completedOverdue.push(task);
+            } else if (dueDate && dueDate.getTime() === today.getTime()) {
+                todayTasks.push(task);
             } else {
-                if (dueDate && dueDate.getTime() === today.getTime()) {
-                    todayTasks.push(task);
-                } else { 
-                    upcoming.push(task);
-                }
+                upcoming.push(task);
             }
-        } else { // Task is active
+        } else {
             if (isOverdue) {
                 overdue.push(task);
             } else if (dueDate && dueDate.getTime() === today.getTime()) {
@@ -349,11 +427,10 @@ function renderTaskList() {
         }
     }
 
-    // Sorting function
     const priorityOrder = { 'high': 1, 'medium': 2, 'low': 3 };
     const sortFn = (a, b) => {
         let comparison = 0;
-        switch(sortBy) {
+        switch (sortBy) {
             case 'dueDate':
                 if (a.dueDate && b.dueDate) comparison = parseDate(a.dueDate) - parseDate(b.dueDate);
                 else if (a.dueDate) comparison = -1; else if (b.dueDate) comparison = 1;
@@ -367,38 +444,75 @@ function renderTaskList() {
         }
         return sortAsc ? comparison : -comparison;
     };
-    
-    // Sort each group
+
     overdue.sort(sortFn);
-    todayTasks.sort(sortFn).sort((a,b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
-    upcoming.sort(sortFn).sort((a,b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
+    todayTasks.sort(sortFn).sort((a, b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
+    upcoming.sort(sortFn).sort((a, b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
     completedOverdue.sort((a, b) => (parseDate(b.dueDate) || 0) - (parseDate(a.dueDate) || 0));
 
-    if ([overdue, todayTasks, upcoming, completedOverdue].every(g => g.length === 0)) {
-         taskTableBody.innerHTML = `<tr><td colspan="8" class="muted" style="text-align:center; padding: 40px 0;">Brak zadań pasujących do filtrów.</td></tr>`;
-         return;
+    const groups = [
+        { key: 'overdue', label: 'Zaległe', className: 'overdue-header', tasks: overdue },
+        { key: 'today', label: 'Dzisiaj', className: '', tasks: todayTasks },
+        { key: 'upcoming', label: 'Nadchodzące', className: '', tasks: upcoming },
+        { key: 'completedOverdue', label: 'Ukończone (Zaległe)', className: 'completed-header', tasks: completedOverdue }
+    ];
+
+    if (groups.every(group => group.tasks.length === 0)) {
+        taskTableBody.innerHTML = `<tr><td colspan="8" class="muted" style="text-align:center; padding: 40px 0;">Brak zadań pasujących do filtrów.</td></tr>`;
+        return;
     }
 
-    const createHeaderRow = (title, className = '') => `<tr class="task-group-header ${className}"><td colspan="8">${title}</td></tr>`;
-    
-    if (overdue.length > 0) {
-        taskTableBody.innerHTML += createHeaderRow('Zaległe', 'overdue-header');
-        overdue.forEach(t => appendTaskRow(t));
-    }
-    if (todayTasks.length > 0) {
-         taskTableBody.innerHTML += createHeaderRow('Dzisiaj');
-         todayTasks.forEach(t => appendTaskRow(t));
-    }
-    if (upcoming.length > 0) {
-        taskTableBody.innerHTML += createHeaderRow('Nadchodzące');
-        upcoming.forEach(t => appendTaskRow(t));
-    }
-    if (completedOverdue.length > 0) {
-        taskTableBody.innerHTML += createHeaderRow('Ukończone (Zaległe)', 'completed-header');
-        completedOverdue.forEach(t => appendTaskRow(t));
-    }
-    
+    const fragment = document.createDocumentFragment();
+    groups.forEach(group => {
+        if (group.tasks.length === 0) return;
+        const headerRow = createGroupHeaderRow(group);
+        fragment.appendChild(headerRow);
+        if (!collapsedGroups.has(group.key)) {
+            group.tasks.forEach(task => appendTaskRow(task, fragment));
+        }
+    });
+
+    taskTableBody.innerHTML = '';
+    taskTableBody.appendChild(fragment);
     addEventListenersToRows();
+}
+
+function createGroupHeaderRow(group) {
+    const { key, label, className, tasks } = group;
+    const row = document.createElement('tr');
+    row.className = `task-group-header ${className}`.trim();
+    const collapsed = collapsedGroups.has(key);
+    if (collapsed) row.classList.add('collapsed');
+
+    const workCount = tasks.filter(t => t.category === 'work').length;
+    const privateCount = tasks.filter(t => t.category === 'private').length;
+
+    row.innerHTML = `
+        <td colspan="8">
+            <div class="group-header-content">
+                <div class="group-header-main">
+                    <span class="group-toggle">${collapsed ? '▸' : '▾'}</span>
+                    <span>${label}</span>
+                </div>
+                <div class="group-summary">
+                    <span class="group-count-pill group-count-total"><span class="dot"></span>Łącznie: ${tasks.length}</span>
+                    <span class="group-count-pill group-count-work"><span class="dot"></span>Praca: ${workCount}</span>
+                    <span class="group-count-pill group-count-private"><span class="dot"></span>Prywatne: ${privateCount}</span>
+                    ${collapsed ? '<span class="group-collapsed-note">Sekcja zwinięta</span>' : ''}
+                </div>
+            </div>
+        </td>`;
+
+    row.addEventListener('click', () => {
+        if (collapsedGroups.has(key)) {
+            collapsedGroups.delete(key);
+        } else {
+            collapsedGroups.add(key);
+        }
+        renderTaskList();
+    });
+
+    return row;
 }
 
 
@@ -421,7 +535,7 @@ function addEventListenersToRows() {
     }));
 }
 
-function appendTaskRow(task) {
+function appendTaskRow(task, container) {
     const today = new Date(); today.setUTCHours(0, 0, 0, 0);
     const dueDate = parseDate(task.dueDate);
     const daysDiff = dueDate ? Math.ceil((dueDate - today) / (1000 * 60 * 60 * 24)) : null;
@@ -472,8 +586,8 @@ function appendTaskRow(task) {
                 `).join('')}
             </ul>` : '<span class="muted" style="font-size:11px;">Brak podzadań.</span>'}
     </td>`;
-    taskTableBody.appendChild(row);
-    taskTableBody.appendChild(subtaskRow);
+    container.appendChild(row);
+    container.appendChild(subtaskRow);
 }
 
 // --- ZARZĄDZANIE ZADANIAMI ---
@@ -575,7 +689,10 @@ function renderCalendar() {
         const tasksForDay = state.tasks.filter(t => t.dueDate === dateStr);
         tasksForDay.sort((a,b) => (a.status === 'done' ? 1 : -1) - (b.status === 'done' ? 1 : -1));
         
-        let tasksHtml = tasksForDay.map(t => `<div class="calendar-task-pill ${t.category} prio-${t.priority || 'low'} ${t.status === 'done' ? 'task-done' : ''}" title="${t.title}">${t.title}</div>`).join('');
+        let tasksHtml = tasksForDay.map(t => {
+            const statusClass = t.status === 'done' ? 'task-done' : 'task-todo';
+            return `<div class="calendar-task-pill ${t.category} prio-${t.priority || 'low'} ${statusClass}" title="${t.title}"><span>${t.title}</span></div>`;
+        }).join('');
         
         html += `<div class="calendar-day"><div class="day-number">${day}</div><div class="calendar-tasks">${tasksHtml}</div></div>`;
     }
@@ -584,17 +701,226 @@ function renderCalendar() {
 
 // --- STATYSTYKI ---
 function renderStats() {
-    Object.values(charts).forEach(chart => chart.destroy());
-    const last7Days = Array(7).fill(0).map((_, i) => { const d = new Date(); d.setDate(d.getDate() - i); return toYYYYMMDD(d); }).reverse();
-    const completedCounts = last7Days.map(day => state.tasks.filter(t => t.status === 'done' && t.dueDate === day).length);
-    charts.completed = new Chart(getEl('completed-tasks-chart'), { type: 'bar', data: { labels: last7Days.map(d => d.slice(5)), datasets: [{ label: 'Ukończone zadania', data: completedCounts, backgroundColor: 'var(--accent-weak)', borderColor: 'var(--accent)', borderWidth: 1 }] }, options: { responsive: true, plugins: { legend: { display: false }, title: { display: true, text: 'Aktywność w ostatnim tygodniu' } } } });
-    const activeTasks = state.tasks.filter(t => t.status !== 'done');
-    const prioCounts = { high: 0, medium: 0, low: 0 };
-    activeTasks.forEach(t => prioCounts[t.priority]++);
-    charts.prio = new Chart(getEl('tasks-by-prio-chart'), { type: 'doughnut', data: { labels: ['Wysoki', 'Średni', 'Niski'], datasets: [{ data: Object.values(prioCounts), backgroundColor: ['#b91c1c', '#c2410c', '#475569'] }] }, options: { responsive: true, plugins: { title: { display: true, text: 'Aktywne zadania wg priorytetu' } } } });
-    const tagCounts = {};
-    activeTasks.forEach(t => t.tags.forEach(tag => tagCounts[tag] = (tagCounts[tag] || 0) + 1));
-    charts.tags = new Chart(getEl('tasks-by-tag-chart'), { type: 'pie', data: { labels: Object.keys(tagCounts), datasets: [{ data: Object.values(tagCounts), backgroundColor: ['#3b82f6', '#84cc16', '#f97316', '#a855f7', '#ec4899', '#10b981', '#f59e0b'] }] }, options: { responsive: true, plugins: { title: { display: true, text: 'Aktywne zadania wg tagów' } } } });
+    Object.values(charts).forEach(chart => chart && chart.destroy && chart.destroy());
+    charts = {};
+    if (!statsSummaryEl) return;
+
+    const rangeDays = Number(statsState.range) || 7;
+    const now = new Date();
+    now.setUTCHours(0, 0, 0, 0);
+    const startDate = new Date(now);
+    startDate.setUTCDate(startDate.getUTCDate() - (rangeDays - 1));
+    const previousStart = new Date(startDate);
+    previousStart.setUTCDate(previousStart.getUTCDate() - rangeDays);
+    const previousEnd = new Date(startDate);
+    previousEnd.setUTCDate(previousEnd.getUTCDate() - 1);
+    const upcomingEnd = new Date(now);
+    upcomingEnd.setUTCDate(upcomingEnd.getUTCDate() + rangeDays);
+
+    const filteredByCategory = state.tasks.filter(t => statsState.category === 'all' ? true : t.category === statsState.category);
+    const activeTasks = filteredByCategory.filter(t => t.status !== 'done');
+    const completedInRange = filteredByCategory.filter(t => t.status === 'done' && t.dueDate && parseDate(t.dueDate) >= startDate && parseDate(t.dueDate) <= now);
+    const completedPrevRange = filteredByCategory.filter(t => t.status === 'done' && t.dueDate && parseDate(t.dueDate) >= previousStart && parseDate(t.dueDate) <= previousEnd);
+    const completedDiff = completedInRange.length - completedPrevRange.length;
+
+    const overdueTasks = filteredByCategory.filter(t => {
+        if (!t.dueDate) return false;
+        const due = parseDate(t.dueDate);
+        return due < now && t.status !== 'done';
+    });
+    const oldestOverdueDate = overdueTasks.reduce((earliest, task) => {
+        const due = parseDate(task.dueDate);
+        if (!earliest || due < earliest) return due;
+        return earliest;
+    }, null);
+    const overdueDays = oldestOverdueDate ? Math.max(0, Math.floor((now - oldestOverdueDate) / (1000 * 60 * 60 * 24))) : 0;
+
+    const upcomingTasks = filteredByCategory.filter(t => {
+        if (!t.dueDate) return false;
+        const due = parseDate(t.dueDate);
+        return due > now && due <= upcomingEnd && t.status !== 'done';
+    });
+    const noDueTasks = activeTasks.filter(t => !t.dueDate);
+    const inRangeActive = filteredByCategory.filter(t => t.status !== 'done' && t.dueDate && parseDate(t.dueDate) >= startDate && parseDate(t.dueDate) <= now);
+
+    const activeHigh = activeTasks.filter(t => t.priority === 'high').length;
+    const activeMedium = activeTasks.filter(t => t.priority === 'medium').length;
+    const activeLow = activeTasks.filter(t => t.priority === 'low').length;
+
+    const completedTrendClass = completedDiff > 0 ? 'trend-up' : (completedDiff < 0 ? 'trend-down' : '');
+    const completedTrendLabel = completedDiff === 0 ? 'Bez zmian vs poprzedni okres' : `${completedDiff > 0 ? '↑' : '↓'} ${Math.abs(completedDiff)} vs poprzedni okres`;
+
+    statsSummaryEl.innerHTML = `
+        <div class="summary-card">
+            <span class="summary-label">Aktywne zadania</span>
+            <span class="summary-value">${activeTasks.length}</span>
+            <span class="summary-trend">Wysoki: ${activeHigh} • Średni: ${activeMedium} • Niski: ${activeLow}</span>
+        </div>
+        <div class="summary-card">
+            <span class="summary-label">Ukończone (${rangeDays} dni)</span>
+            <span class="summary-value">${completedInRange.length}</span>
+            <span class="summary-trend ${completedTrendClass}">${completedTrendLabel}</span>
+        </div>
+        <div class="summary-card">
+            <span class="summary-label">Zaległe</span>
+            <span class="summary-value">${overdueTasks.length}</span>
+            <span class="summary-trend">${overdueTasks.length ? `Najstarsze: ${overdueDays} dni` : 'Brak zaległości — brawo!'}</span>
+        </div>
+        <div class="summary-card">
+            <span class="summary-label">Plan (${rangeDays} dni naprzód)</span>
+            <span class="summary-value">${upcomingTasks.length}</span>
+            <span class="summary-trend">Bez terminu: ${noDueTasks.length}</span>
+        </div>`;
+
+    const dateRange = Array.from({ length: rangeDays }, (_, index) => {
+        const d = new Date(startDate);
+        d.setUTCDate(startDate.getUTCDate() + index);
+        return d;
+    });
+    const labels = dateRange.map(date => date.toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit' }));
+    const plannedCounts = dateRange.map(date => filteredByCategory.filter(t => t.dueDate === toYYYYMMDD(date)).length);
+    const completedCounts = dateRange.map(date => filteredByCategory.filter(t => t.status === 'done' && t.dueDate === toYYYYMMDD(date)).length);
+
+    const accent = cssVar('--accent');
+    const accentWeak = cssVar('--accent-weak');
+    const green = cssVar('--green');
+    const blue = cssVar('--blue');
+    const yellow = cssVar('--yellow');
+    const muted = cssVar('--muted');
+
+    charts.productivityTrend = new Chart(getEl('productivity-trend-chart'), {
+        type: 'line',
+        data: {
+            labels,
+            datasets: [
+                {
+                    label: 'Planowane',
+                    data: plannedCounts,
+                    borderColor: accent,
+                    backgroundColor: accentWeak,
+                    tension: 0.35,
+                    fill: false,
+                    borderWidth: 2,
+                    pointRadius: 3
+                },
+                {
+                    label: 'Ukończone',
+                    data: completedCounts,
+                    borderColor: green,
+                    backgroundColor: 'rgba(5, 150, 105, 0.18)',
+                    tension: 0.35,
+                    fill: true,
+                    borderWidth: 2,
+                    pointRadius: 3
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+                legend: { position: 'bottom' },
+                title: { display: true, text: `Realizacja planu (ostatnie ${rangeDays} dni)` }
+            },
+            scales: {
+                y: { beginAtZero: true, ticks: { precision: 0 } }
+            }
+        }
+    });
+
+    const categoryKeys = statsState.category === 'all' ? ['work', 'private'] : [statsState.category];
+    const categoryLabels = categoryKeys.map(key => key === 'work' ? 'Praca' : 'Prywatne');
+    const activeByCategory = categoryKeys.map(key => filteredByCategory.filter(t => t.category === key && t.status !== 'done').length);
+    const doneByCategory = categoryKeys.map(key => filteredByCategory.filter(t => t.category === key && t.status === 'done' && t.dueDate && parseDate(t.dueDate) >= startDate && parseDate(t.dueDate) <= now).length);
+
+    charts.categoryDistribution = new Chart(getEl('category-distribution-chart'), {
+        type: 'bar',
+        data: {
+            labels: categoryLabels,
+            datasets: [
+                { label: 'Aktywne', data: activeByCategory, backgroundColor: accent },
+                { label: 'Ukończone (okres)', data: doneByCategory, backgroundColor: green }
+            ]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'bottom' },
+                title: { display: true, text: 'Aktywne vs ukończone zadania' }
+            },
+            scales: {
+                y: { beginAtZero: true, ticks: { precision: 0 } }
+            }
+        }
+    });
+
+    const priorityLevels = ['high', 'medium', 'low'];
+    const priorityLabels = ['Wysoki', 'Średni', 'Niski'];
+    const activePriority = priorityLevels.map(level => filteredByCategory.filter(t => t.priority === level && t.status !== 'done').length);
+    const donePriority = priorityLevels.map(level => filteredByCategory.filter(t => t.priority === level && t.status === 'done' && t.dueDate && parseDate(t.dueDate) >= startDate && parseDate(t.dueDate) <= now).length);
+
+    charts.priorityBalance = new Chart(getEl('priority-balance-chart'), {
+        type: 'radar',
+        data: {
+            labels: priorityLabels,
+            datasets: [
+                {
+                    label: 'Aktywne',
+                    data: activePriority,
+                    backgroundColor: 'rgba(37, 99, 235, 0.18)',
+                    borderColor: blue,
+                    pointBackgroundColor: blue,
+                    borderWidth: 2
+                },
+                {
+                    label: 'Ukończone',
+                    data: donePriority,
+                    backgroundColor: 'rgba(5, 150, 105, 0.2)',
+                    borderColor: green,
+                    pointBackgroundColor: green,
+                    borderWidth: 2
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'bottom' },
+                title: { display: true, text: 'Profil priorytetów' }
+            },
+            scales: {
+                r: {
+                    beginAtZero: true,
+                    ticks: { stepSize: 1, display: false },
+                    grid: { circular: true }
+                }
+            }
+        }
+    });
+
+    charts.completionProgress = new Chart(getEl('completion-progress-chart'), {
+        type: 'doughnut',
+        data: {
+            labels: [
+                `Ukończone (ostatnie ${rangeDays} dni)`,
+                'W trakcie (z terminem)',
+                `Plan na kolejne ${rangeDays} dni`,
+                'Bez terminu'
+            ],
+            datasets: [{
+                data: [completedInRange.length, inRangeActive.length, upcomingTasks.length, noDueTasks.length],
+                backgroundColor: [green, accent, yellow, muted],
+                borderWidth: 1
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'bottom' },
+                title: { display: true, text: 'Postęp realizacji' }
+            }
+        }
+    });
 }
 
 // --- MODALE ---
@@ -638,6 +964,26 @@ function init() {
     subtaskInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); addTempSubtask(); }});
     cancelEditBtn.addEventListener('click', resetForm);
     clearAllBtn.addEventListener('click', () => showConfirm('Na pewno usunąć WSZYSTKIE zadania?', () => { state.tasks = []; saveState(); render(); showAlert('Wszystkie zadania zostały usunięte.'); }));
+    if (statsRangeControl) {
+        statsRangeControl.addEventListener('click', (e) => {
+            const segment = e.target.closest('.segment');
+            if (!segment) return;
+            statsRangeControl.querySelectorAll('.segment').forEach(s => s.classList.remove('active'));
+            segment.classList.add('active');
+            statsState.range = Number(segment.dataset.range);
+            renderStats();
+        });
+    }
+    if (statsCategoryControl) {
+        statsCategoryControl.addEventListener('click', (e) => {
+            const segment = e.target.closest('.segment');
+            if (!segment) return;
+            statsCategoryControl.querySelectorAll('.segment').forEach(s => s.classList.remove('active'));
+            segment.classList.add('active');
+            statsState.category = segment.dataset.category;
+            renderStats();
+        });
+    }
     document.querySelectorAll('.tab').forEach(tab => tab.addEventListener('click', (e) => {
         document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
         e.target.classList.add('active');


### PR DESCRIPTION
## Summary
- add collapsible task group headers with per-category counts and preserve expanded subtasks
- refresh calendar styling so completed tasks have a distinct badge and active items stand out
- rebuild the statistics tab with range/category filters, summary cards, and multiple interactive Chart.js visualizations

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d29b92dc9c8331be7db083064652d6